### PR TITLE
Draft: add graph fusion optimizer and qualify wider PDF stages

### DIFF
--- a/nemo_retriever/src/nemo_retriever/chart/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/chart/cpu_actor.py
@@ -10,11 +10,12 @@ import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
 from nemo_retriever.graph.cpu_operator import CPUOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.chart.shared import graphic_elements_ocr_page_elements
 
 
-class GraphicElementsCPUActor(AbstractOperator, CPUOperator):
+class GraphicElementsCPUActor(ProcessOnlyFusionSafe, AbstractOperator, CPUOperator):
     """CPU-only variant of :class:`GraphicElementsActor`.
 
     Defaults to build.nvidia.com endpoints for ``nemotron-graphic-elements-v1``
@@ -23,6 +24,9 @@ class GraphicElementsCPUActor(AbstractOperator, CPUOperator):
 
     DEFAULT_GRAPHIC_ELEMENTS_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-graphic-elements-v1"
     DEFAULT_OCR_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1"
+    fusion_stage_id = "graphic_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = False
 
     def __init__(
         self,

--- a/nemo_retriever/src/nemo_retriever/chart/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/chart/gpu_actor.py
@@ -9,16 +9,21 @@ from typing import Any, Optional
 import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.chart.shared import graphic_elements_ocr_page_elements
 
 
-class GraphicElementsActor(AbstractOperator, GPUOperator):
+class GraphicElementsActor(ProcessOnlyFusionSafe, AbstractOperator, GPUOperator):
     """
     Ray-friendly callable that initializes both graphic-elements and OCR
     models once per actor and runs the combined stage.
     """
+
+    fusion_stage_id = "graphic_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = False
 
     def __init__(
         self,

--- a/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
+++ b/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
@@ -158,6 +158,25 @@ def _write_runtime_summary(
     target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _maybe_attach_fusion_metadata(
+    payload: dict[str, object],
+    *,
+    enable_fusion: bool,
+    fusion_summary: dict[str, object] | None,
+    ray_object_store_memory_bytes: int | None = None,
+) -> dict[str, object]:
+    if not enable_fusion and ray_object_store_memory_bytes is None:
+        return payload
+    enriched = dict(payload)
+    if enable_fusion:
+        enriched["enable_fusion"] = True
+    if enable_fusion and fusion_summary is not None:
+        enriched["fusion_summary"] = fusion_summary
+    if ray_object_store_memory_bytes is not None:
+        enriched["ray_object_store_memory_bytes"] = int(ray_object_store_memory_bytes)
+    return enriched
+
+
 def _count_input_units(result_df) -> int:
     if "source_id" in result_df.columns:
         return int(result_df["source_id"].nunique())
@@ -202,6 +221,11 @@ def main(
         "batch",
         "--run-mode",
         help="Execution mode: 'batch' (Ray Data) or 'inprocess' (pandas, no Ray).",
+    ),
+    enable_fusion: bool = typer.Option(
+        False,
+        "--enable-fusion/--no-enable-fusion",
+        help="Experimentally compile eligible extraction stages into fused segments.",
     ),
     debug: bool = typer.Option(False, "--debug/--no-debug", help="Enable debug-level logging."),
     dpi: int = typer.Option(300, "--dpi", min=72, help="Render DPI for PDF page images."),
@@ -257,6 +281,12 @@ def main(
     # "not set → use heuristic" from "explicitly 0 → no GPU".  Other tuning
     # defaults use 0/0.0 because those values are never valid explicit choices.
     ray_address: Optional[str] = typer.Option(None, "--ray-address"),
+    ray_object_store_memory_bytes: Optional[int] = typer.Option(
+        None,
+        "--ray-object-store-memory-bytes",
+        min=1,
+        help="Explicit Ray object store memory in bytes for local Ray startup.",
+    ),
     ray_log_to_driver: bool = typer.Option(True, "--ray-log-to-driver/--no-ray-log-to-driver"),
     ocr_actors: Optional[int] = typer.Option(0, "--ocr-actors"),
     ocr_batch_size: Optional[int] = typer.Option(0, "--ocr-batch-size"),
@@ -472,7 +502,13 @@ def main(
         if caption_gpus_per_actor is not None:
             node_overrides["CaptionActor"] = {"num_gpus": caption_gpus_per_actor}
 
-        ingestor = GraphIngestor(run_mode=run_mode, ray_address=ray_address, node_overrides=node_overrides or None)
+        ingestor = GraphIngestor(
+            run_mode=run_mode,
+            ray_address=ray_address,
+            node_overrides=node_overrides or None,
+            ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+            enable_fusion=enable_fusion,
+        )
         ingestor = ingestor.files(file_patterns)
 
         # Extraction stage
@@ -539,6 +575,7 @@ def main(
         #   batch mode     -> materialized ray.data.Dataset
         #   inprocess mode -> pandas.DataFrame
         result = ingestor.ingest()
+        fusion_summary = getattr(ingestor, "last_fusion_summary", None)
 
         ingestion_only_total_time = time.perf_counter() - ingest_start
 
@@ -602,23 +639,28 @@ def main(
             _write_runtime_summary(
                 runtime_metrics_dir,
                 runtime_metrics_prefix,
-                {
-                    "run_mode": run_mode,
-                    "input_path": str(Path(input_path).resolve()),
-                    "input_pages": int(num_rows),
-                    "num_pages": int(num_rows),
-                    "num_rows": int(len(result_df.index)),
-                    "ingestion_only_secs": float(ingestion_only_total_time),
-                    "ray_download_secs": float(ray_download_time),
-                    "lancedb_write_secs": float(lancedb_write_time),
-                    "evaluation_secs": 0.0,
-                    "total_secs": float(time.perf_counter() - ingest_start),
-                    "evaluation_mode": evaluation_mode,
-                    "evaluation_metrics": {},
-                    "recall_details": bool(recall_details),
-                    "lancedb_uri": str(lancedb_uri),
-                    "lancedb_table": str(LANCEDB_TABLE),
-                },
+                _maybe_attach_fusion_metadata(
+                    {
+                        "run_mode": run_mode,
+                        "input_path": str(Path(input_path).resolve()),
+                        "input_pages": int(num_rows),
+                        "num_pages": int(num_rows),
+                        "num_rows": int(len(result_df.index)),
+                        "ingestion_only_secs": float(ingestion_only_total_time),
+                        "ray_download_secs": float(ray_download_time),
+                        "lancedb_write_secs": float(lancedb_write_time),
+                        "evaluation_secs": 0.0,
+                        "total_secs": float(time.perf_counter() - ingest_start),
+                        "evaluation_mode": evaluation_mode,
+                        "evaluation_metrics": {},
+                        "recall_details": bool(recall_details),
+                        "lancedb_uri": str(lancedb_uri),
+                        "lancedb_table": str(LANCEDB_TABLE),
+                    },
+                    enable_fusion=enable_fusion,
+                    fusion_summary=fusion_summary,
+                    ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+                ),
             )
             if run_mode == "batch":
                 ray.shutdown()
@@ -669,24 +711,29 @@ def main(
                 _write_runtime_summary(
                     runtime_metrics_dir,
                     runtime_metrics_prefix,
+                    _maybe_attach_fusion_metadata(
                     {
                         "run_mode": run_mode,
-                        "input_path": str(Path(input_path).resolve()),
-                        "input_pages": int(num_rows),
-                        "num_pages": int(num_rows),
-                        "num_rows": int(len(result_df.index)),
-                        "ingestion_only_secs": float(ingestion_only_total_time),
-                        "ray_download_secs": float(ray_download_time),
-                        "lancedb_write_secs": float(lancedb_write_time),
-                        "evaluation_secs": 0.0,
-                        "total_secs": float(time.perf_counter() - ingest_start),
-                        "evaluation_mode": evaluation_mode,
-                        "evaluation_metrics": {},
-                        "recall_details": bool(recall_details),
+                            "input_path": str(Path(input_path).resolve()),
+                            "input_pages": int(num_rows),
+                            "num_pages": int(num_rows),
+                            "num_rows": int(len(result_df.index)),
+                            "ingestion_only_secs": float(ingestion_only_total_time),
+                            "ray_download_secs": float(ray_download_time),
+                            "lancedb_write_secs": float(lancedb_write_time),
+                            "evaluation_secs": 0.0,
+                            "total_secs": float(time.perf_counter() - ingest_start),
+                            "evaluation_mode": evaluation_mode,
+                            "evaluation_metrics": {},
+                            "recall_details": bool(recall_details),
                         "lancedb_uri": str(lancedb_uri),
                         "lancedb_table": str(LANCEDB_TABLE),
                     },
-                )
+                    enable_fusion=enable_fusion,
+                    fusion_summary=fusion_summary,
+                    ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+                ),
+            )
                 if run_mode == "batch":
                     ray.shutdown()
                 return
@@ -719,24 +766,29 @@ def main(
         _write_runtime_summary(
             runtime_metrics_dir,
             runtime_metrics_prefix,
-            {
-                "run_mode": run_mode,
-                "input_path": str(Path(input_path).resolve()),
-                "input_pages": int(num_rows),
-                "num_pages": int(num_rows),
-                "num_rows": int(len(result_df.index)),
-                "ingestion_only_secs": float(ingestion_only_total_time),
-                "ray_download_secs": float(ray_download_time),
-                "lancedb_write_secs": float(lancedb_write_time),
-                "evaluation_secs": float(evaluation_total_time),
-                "total_secs": float(total_time),
-                "evaluation_mode": evaluation_mode,
-                "evaluation_metrics": dict(evaluation_metrics),
-                "evaluation_count": evaluation_query_count,
-                "recall_details": bool(recall_details),
-                "lancedb_uri": str(lancedb_uri),
-                "lancedb_table": str(LANCEDB_TABLE),
-            },
+            _maybe_attach_fusion_metadata(
+                {
+                    "run_mode": run_mode,
+                    "input_path": str(Path(input_path).resolve()),
+                    "input_pages": int(num_rows),
+                    "num_pages": int(num_rows),
+                    "num_rows": int(len(result_df.index)),
+                    "ingestion_only_secs": float(ingestion_only_total_time),
+                    "ray_download_secs": float(ray_download_time),
+                    "lancedb_write_secs": float(lancedb_write_time),
+                    "evaluation_secs": float(evaluation_total_time),
+                    "total_secs": float(total_time),
+                    "evaluation_mode": evaluation_mode,
+                    "evaluation_metrics": dict(evaluation_metrics),
+                    "evaluation_count": evaluation_query_count,
+                    "recall_details": bool(recall_details),
+                    "lancedb_uri": str(lancedb_uri),
+                    "lancedb_table": str(LANCEDB_TABLE),
+                },
+                enable_fusion=enable_fusion,
+                fusion_summary=fusion_summary,
+                ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+            ),
         )
 
         if run_mode == "batch":

--- a/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
+++ b/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
@@ -151,6 +151,25 @@ def _write_runtime_summary(
     target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _maybe_attach_fusion_metadata(
+    payload: dict[str, object],
+    *,
+    enable_fusion: bool,
+    fusion_summary: dict[str, object] | None,
+    ray_object_store_memory_bytes: int | None = None,
+) -> dict[str, object]:
+    if not enable_fusion and ray_object_store_memory_bytes is None:
+        return payload
+    enriched = dict(payload)
+    if enable_fusion:
+        enriched["enable_fusion"] = True
+    if enable_fusion and fusion_summary is not None:
+        enriched["fusion_summary"] = fusion_summary
+    if ray_object_store_memory_bytes is not None:
+        enriched["ray_object_store_memory_bytes"] = int(ray_object_store_memory_bytes)
+    return enriched
+
+
 def _count_input_units(result_df) -> int:
     if "source_id" in result_df.columns:
         return int(result_df["source_id"].nunique())
@@ -205,6 +224,11 @@ def main(
         "--run-mode",
         help="Execution mode: 'batch' (Ray Data) or 'inprocess' (pandas, no Ray).",
     ),
+    enable_fusion: bool = typer.Option(
+        False,
+        "--enable-fusion/--no-enable-fusion",
+        help="Experimentally compile eligible extraction stages into fused segments.",
+    ),
     debug: bool = typer.Option(False, "--debug/--no-debug", help="Enable debug-level logging."),
     dpi: int = typer.Option(300, "--dpi", min=72, help="Render DPI for PDF page images."),
     input_type: str = typer.Option(
@@ -252,6 +276,12 @@ def main(
     text_chunk_overlap_tokens: Optional[int] = typer.Option(None, "--text-chunk-overlap-tokens"),
     # Ray / batch tuning
     ray_address: Optional[str] = typer.Option(None, "--ray-address"),
+    ray_object_store_memory_bytes: Optional[int] = typer.Option(
+        None,
+        "--ray-object-store-memory-bytes",
+        min=1,
+        help="Explicit Ray object store memory in bytes for local Ray startup.",
+    ),
     ray_log_to_driver: bool = typer.Option(True, "--ray-log-to-driver/--no-ray-log-to-driver"),
     ocr_actors: Optional[int] = typer.Option(0, "--ocr-actors"),
     ocr_batch_size: Optional[int] = typer.Option(0, "--ocr-batch-size"),
@@ -449,7 +479,12 @@ def main(
         # ------------------------------------------------------------------
         logger.info("Building graph pipeline (run_mode=%s) for %s ...", run_mode, input_path)
 
-        ingestor = GraphIngestor(run_mode=run_mode, ray_address=ray_address)
+        ingestor = GraphIngestor(
+            run_mode=run_mode,
+            ray_address=ray_address,
+            ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+            enable_fusion=enable_fusion,
+        )
         ingestor = ingestor.files(file_patterns)
 
         # Extraction stage
@@ -513,6 +548,7 @@ def main(
         #   batch mode     -> materialized ray.data.Dataset
         #   inprocess mode -> pandas.DataFrame
         result = ingestor.ingest()
+        fusion_summary = getattr(ingestor, "last_fusion_summary", None)
 
         ingestion_only_total_time = time.perf_counter() - ingest_start
 
@@ -569,23 +605,28 @@ def main(
             _write_runtime_summary(
                 runtime_metrics_dir,
                 runtime_metrics_prefix,
-                {
-                    "run_mode": run_mode,
-                    "input_path": str(Path(input_path).resolve()),
-                    "input_pages": int(num_rows),
-                    "num_pages": int(num_rows),
-                    "num_rows": int(len(result_df.index)),
-                    "ingestion_only_secs": float(ingestion_only_total_time),
-                    "ray_download_secs": float(ray_download_time),
-                    "lancedb_write_secs": float(lancedb_write_time),
-                    "evaluation_secs": 0.0,
-                    "total_secs": float(time.perf_counter() - ingest_start),
-                    "evaluation_mode": evaluation_mode,
-                    "evaluation_metrics": {},
-                    "recall_details": bool(recall_details),
-                    "lancedb_uri": str(lancedb_uri),
-                    "lancedb_table": str(LANCEDB_TABLE),
-                },
+                _maybe_attach_fusion_metadata(
+                    {
+                        "run_mode": run_mode,
+                        "input_path": str(Path(input_path).resolve()),
+                        "input_pages": int(num_rows),
+                        "num_pages": int(num_rows),
+                        "num_rows": int(len(result_df.index)),
+                        "ingestion_only_secs": float(ingestion_only_total_time),
+                        "ray_download_secs": float(ray_download_time),
+                        "lancedb_write_secs": float(lancedb_write_time),
+                        "evaluation_secs": 0.0,
+                        "total_secs": float(time.perf_counter() - ingest_start),
+                        "evaluation_mode": evaluation_mode,
+                        "evaluation_metrics": {},
+                        "recall_details": bool(recall_details),
+                        "lancedb_uri": str(lancedb_uri),
+                        "lancedb_table": str(LANCEDB_TABLE),
+                    },
+                    enable_fusion=enable_fusion,
+                    fusion_summary=fusion_summary,
+                    ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+                ),
             )
             if run_mode == "batch":
                 ray.shutdown()
@@ -636,24 +677,29 @@ def main(
                 _write_runtime_summary(
                     runtime_metrics_dir,
                     runtime_metrics_prefix,
+                    _maybe_attach_fusion_metadata(
                     {
                         "run_mode": run_mode,
-                        "input_path": str(Path(input_path).resolve()),
-                        "input_pages": int(num_rows),
-                        "num_pages": int(num_rows),
-                        "num_rows": int(len(result_df.index)),
-                        "ingestion_only_secs": float(ingestion_only_total_time),
-                        "ray_download_secs": float(ray_download_time),
-                        "lancedb_write_secs": float(lancedb_write_time),
-                        "evaluation_secs": 0.0,
-                        "total_secs": float(time.perf_counter() - ingest_start),
-                        "evaluation_mode": evaluation_mode,
-                        "evaluation_metrics": {},
-                        "recall_details": bool(recall_details),
+                            "input_path": str(Path(input_path).resolve()),
+                            "input_pages": int(num_rows),
+                            "num_pages": int(num_rows),
+                            "num_rows": int(len(result_df.index)),
+                            "ingestion_only_secs": float(ingestion_only_total_time),
+                            "ray_download_secs": float(ray_download_time),
+                            "lancedb_write_secs": float(lancedb_write_time),
+                            "evaluation_secs": 0.0,
+                            "total_secs": float(time.perf_counter() - ingest_start),
+                            "evaluation_mode": evaluation_mode,
+                            "evaluation_metrics": {},
+                            "recall_details": bool(recall_details),
                         "lancedb_uri": str(lancedb_uri),
                         "lancedb_table": str(LANCEDB_TABLE),
                     },
-                )
+                    enable_fusion=enable_fusion,
+                    fusion_summary=fusion_summary,
+                    ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+                ),
+            )
                 if run_mode == "batch":
                     ray.shutdown()
                 return
@@ -685,24 +731,29 @@ def main(
         _write_runtime_summary(
             runtime_metrics_dir,
             runtime_metrics_prefix,
-            {
-                "run_mode": run_mode,
-                "input_path": str(Path(input_path).resolve()),
-                "input_pages": int(num_rows),
-                "num_pages": int(num_rows),
-                "num_rows": int(len(result_df.index)),
-                "ingestion_only_secs": float(ingestion_only_total_time),
-                "ray_download_secs": float(ray_download_time),
-                "lancedb_write_secs": float(lancedb_write_time),
-                "evaluation_secs": float(evaluation_total_time),
-                "total_secs": float(total_time),
-                "evaluation_mode": evaluation_mode,
-                "evaluation_metrics": dict(evaluation_metrics),
-                "evaluation_count": evaluation_query_count,
-                "recall_details": bool(recall_details),
-                "lancedb_uri": str(lancedb_uri),
-                "lancedb_table": str(LANCEDB_TABLE),
-            },
+            _maybe_attach_fusion_metadata(
+                {
+                    "run_mode": run_mode,
+                    "input_path": str(Path(input_path).resolve()),
+                    "input_pages": int(num_rows),
+                    "num_pages": int(num_rows),
+                    "num_rows": int(len(result_df.index)),
+                    "ingestion_only_secs": float(ingestion_only_total_time),
+                    "ray_download_secs": float(ray_download_time),
+                    "lancedb_write_secs": float(lancedb_write_time),
+                    "evaluation_secs": float(evaluation_total_time),
+                    "total_secs": float(total_time),
+                    "evaluation_mode": evaluation_mode,
+                    "evaluation_metrics": dict(evaluation_metrics),
+                    "evaluation_count": evaluation_query_count,
+                    "recall_details": bool(recall_details),
+                    "lancedb_uri": str(lancedb_uri),
+                    "lancedb_table": str(LANCEDB_TABLE),
+                },
+                enable_fusion=enable_fusion,
+                fusion_summary=fusion_summary,
+                ray_object_store_memory_bytes=ray_object_store_memory_bytes,
+            ),
         )
 
         if run_mode == "batch":

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 import pandas as pd
 
+from nemo_retriever.graph.fusion import compile_graph_for_fusion
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.graph.pipeline_graph import Graph, Node
 from nemo_retriever.graph.operator_resolution import resolve_graph
@@ -39,10 +40,12 @@ class AbstractExecutor(ABC):
     :meth:`ingest` method that feeds data through the graph.
     """
 
-    def __init__(self, graph: Graph) -> None:
+    def __init__(self, graph: Graph, *, enable_fusion: bool = False) -> None:
         if not isinstance(graph, Graph):
             raise TypeError(f"graph must be a Graph, got {type(graph).__name__}")
         self.graph = graph
+        self._enable_fusion = enable_fusion
+        self.last_fusion_summary: dict[str, Any] | None = None
 
     @abstractmethod
     def ingest(self, data: Any, **kwargs: Any) -> Any:
@@ -60,8 +63,8 @@ class InprocessExecutor(AbstractExecutor):
     Only linear (single-root, no fan-out) graphs are currently supported.
     """
 
-    def __init__(self, graph: Graph, *, show_progress: bool = True) -> None:
-        super().__init__(graph)
+    def __init__(self, graph: Graph, *, show_progress: bool = True, enable_fusion: bool = False) -> None:
+        super().__init__(graph, enable_fusion=enable_fusion)
         self._show_progress = show_progress
 
     @staticmethod
@@ -120,7 +123,11 @@ class InprocessExecutor(AbstractExecutor):
             )
 
         resolved_graph = resolve_graph(self.graph, gather_local_resources())
-        nodes = self._linearize(resolved_graph)
+        compilation = compile_graph_for_fusion(resolved_graph, enable_fusion=self._enable_fusion)
+        self.last_fusion_summary = compilation.fusion_summary
+        if self._enable_fusion:
+            _log_fusion_summary("InprocessExecutor", compilation.fusion_summary)
+        nodes = self._linearize(compilation.graph)
         operators = []
         for node in nodes:
             op = node.operator_class(**node.operator_kwargs)
@@ -179,14 +186,17 @@ class RayDataExecutor(AbstractExecutor):
         graph: Graph,
         *,
         ray_address: Optional[str] = None,
+        ray_object_store_memory_bytes: Optional[int] = None,
         batch_size: int = 1,
         batch_format: str = "pandas",
         num_cpus: float = 1,
         num_gpus: float = 0,
         node_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
+        enable_fusion: bool = False,
     ) -> None:
-        super().__init__(graph)
+        super().__init__(graph, enable_fusion=enable_fusion)
         self._ray_address = ray_address
+        self._ray_object_store_memory_bytes = ray_object_store_memory_bytes
         self._default_batch_size = batch_size
         self._default_batch_format = batch_format
         self._default_num_cpus = num_cpus
@@ -211,6 +221,28 @@ class RayDataExecutor(AbstractExecutor):
                 )
             node = node.children[0] if node.children else None
         return ordered
+
+    def _build_ray_init_kwargs(self) -> Dict[str, Any]:
+        init_kwargs: Dict[str, Any] = {
+            "ignore_reinit_error": True,
+            "runtime_env": {
+                "env_vars": {
+                    "VIRTUAL_ENV": os.path.dirname(os.path.dirname(sys.executable)),
+                },
+            },
+        }
+        if self._ray_address:
+            init_kwargs["address"] = self._ray_address
+        if self._ray_object_store_memory_bytes is not None:
+            if self._ray_address:
+                logger.warning(
+                    "Ignoring ray_object_store_memory_bytes=%s because ray_address=%r connects to an existing Ray cluster.",
+                    self._ray_object_store_memory_bytes,
+                    self._ray_address,
+                )
+            else:
+                init_kwargs["object_store_memory"] = int(self._ray_object_store_memory_bytes)
+        return init_kwargs
 
     def ingest(self, data: Any, **kwargs: Any) -> Any:
         """Build and execute a Ray Data pipeline from the graph.
@@ -237,16 +269,7 @@ class RayDataExecutor(AbstractExecutor):
             )
 
         if self._ray_address or not ray.is_initialized():
-            runtime_env = {
-                "env_vars": {
-                    "VIRTUAL_ENV": os.path.dirname(os.path.dirname(sys.executable)),
-                },
-            }
-            ray.init(
-                address=self._ray_address,
-                ignore_reinit_error=True,
-                runtime_env=runtime_env,
-            )
+            ray.init(**self._build_ray_init_kwargs())
 
         ctx = rd.DataContext.get_current()
         ctx.enable_rich_progress_bars = True
@@ -255,6 +278,15 @@ class RayDataExecutor(AbstractExecutor):
         cluster = gather_cluster_resources(ray)
         available_gpus = cluster.available_gpu_count()
         resolved_graph = resolve_graph(self.graph, cluster)
+        compilation = compile_graph_for_fusion(
+            resolved_graph,
+            enable_fusion=self._enable_fusion,
+            node_overrides=self._node_overrides,
+        )
+        self.last_fusion_summary = compilation.fusion_summary
+        if self._enable_fusion:
+            _log_fusion_summary("RayDataExecutor", compilation.fusion_summary)
+        effective_overrides = compilation.node_overrides
 
         if isinstance(data, rd.Dataset):
             ds = data
@@ -265,9 +297,9 @@ class RayDataExecutor(AbstractExecutor):
                 matches = _glob.glob(pattern, recursive=True)
                 expanded.extend(sorted(matches) if matches else [pattern])
             ds = rd.read_binary_files(expanded, include_paths=True)
-        nodes = self._linearize(resolved_graph)
+        nodes = self._linearize(compilation.graph)
         for node in nodes:
-            overrides = dict(self._node_overrides.get(node.name, {}))
+            overrides = dict(effective_overrides.get(node.name, {}))
             target_num_rows_per_block = overrides.pop("target_num_rows_per_block", None)
             batch_size = overrides.pop("batch_size", self._default_batch_size)
             batch_format = overrides.pop("batch_format", self._default_batch_format)
@@ -354,3 +386,16 @@ class RayDataExecutor(AbstractExecutor):
             )
 
         return ds.materialize()
+
+
+def _log_fusion_summary(executor_name: str, summary: dict[str, Any]) -> None:
+    logger.info(
+        "%s fusion compile: enabled=%s applied=%s original=%s compiled=%s segments=%s reason=%s",
+        executor_name,
+        summary.get("enabled"),
+        summary.get("applied"),
+        summary.get("original_stage_count"),
+        summary.get("compiled_stage_count"),
+        len(summary.get("fused_segments", [])),
+        summary.get("reason"),
+    )

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 import pandas as pd
 
+from nemo_retriever.graph.fusion import compile_graph_for_fusion
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.graph.pipeline_graph import Graph, Node
 from nemo_retriever.graph.operator_resolution import resolve_graph
@@ -37,10 +38,12 @@ class AbstractExecutor(ABC):
     :meth:`ingest` method that feeds data through the graph.
     """
 
-    def __init__(self, graph: Graph) -> None:
+    def __init__(self, graph: Graph, *, enable_fusion: bool = False) -> None:
         if not isinstance(graph, Graph):
             raise TypeError(f"graph must be a Graph, got {type(graph).__name__}")
         self.graph = graph
+        self._enable_fusion = enable_fusion
+        self.last_fusion_summary: dict[str, Any] | None = None
 
     @abstractmethod
     def ingest(self, data: Any, **kwargs: Any) -> Any:
@@ -58,8 +61,8 @@ class InprocessExecutor(AbstractExecutor):
     Only linear (single-root, no fan-out) graphs are currently supported.
     """
 
-    def __init__(self, graph: Graph, *, show_progress: bool = True) -> None:
-        super().__init__(graph)
+    def __init__(self, graph: Graph, *, show_progress: bool = True, enable_fusion: bool = False) -> None:
+        super().__init__(graph, enable_fusion=enable_fusion)
         self._show_progress = show_progress
 
     @staticmethod
@@ -118,7 +121,11 @@ class InprocessExecutor(AbstractExecutor):
             )
 
         resolved_graph = resolve_graph(self.graph, gather_local_resources())
-        nodes = self._linearize(resolved_graph)
+        compilation = compile_graph_for_fusion(resolved_graph, enable_fusion=self._enable_fusion)
+        self.last_fusion_summary = compilation.fusion_summary
+        if self._enable_fusion:
+            _log_fusion_summary("InprocessExecutor", compilation.fusion_summary)
+        nodes = self._linearize(compilation.graph)
         operators = []
         for node in nodes:
             op = node.operator_class(**node.operator_kwargs)
@@ -177,14 +184,17 @@ class RayDataExecutor(AbstractExecutor):
         graph: Graph,
         *,
         ray_address: Optional[str] = None,
+        ray_object_store_memory_bytes: Optional[int] = None,
         batch_size: int = 1,
         batch_format: str = "pandas",
         num_cpus: float = 1,
         num_gpus: float = 0,
         node_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
+        enable_fusion: bool = False,
     ) -> None:
-        super().__init__(graph)
+        super().__init__(graph, enable_fusion=enable_fusion)
         self._ray_address = ray_address
+        self._ray_object_store_memory_bytes = ray_object_store_memory_bytes
         self._default_batch_size = batch_size
         self._default_batch_format = batch_format
         self._default_num_cpus = num_cpus
@@ -209,6 +219,21 @@ class RayDataExecutor(AbstractExecutor):
                 )
             node = node.children[0] if node.children else None
         return ordered
+
+    def _build_ray_init_kwargs(self) -> Dict[str, Any]:
+        init_kwargs: Dict[str, Any] = {"ignore_reinit_error": True}
+        if self._ray_address:
+            init_kwargs["address"] = self._ray_address
+        if self._ray_object_store_memory_bytes is not None:
+            if self._ray_address:
+                logger.warning(
+                    "Ignoring ray_object_store_memory_bytes=%s because ray_address=%r connects to an existing Ray cluster.",
+                    self._ray_object_store_memory_bytes,
+                    self._ray_address,
+                )
+            else:
+                init_kwargs["object_store_memory"] = int(self._ray_object_store_memory_bytes)
+        return init_kwargs
 
     def ingest(self, data: Any, **kwargs: Any) -> Any:
         """Build and execute a Ray Data pipeline from the graph.
@@ -235,7 +260,7 @@ class RayDataExecutor(AbstractExecutor):
             )
 
         if self._ray_address or not ray.is_initialized():
-            ray.init(address=self._ray_address, ignore_reinit_error=True)
+            ray.init(**self._build_ray_init_kwargs())
 
         ctx = rd.DataContext.get_current()
         ctx.enable_rich_progress_bars = True
@@ -244,6 +269,15 @@ class RayDataExecutor(AbstractExecutor):
         cluster = gather_cluster_resources(ray)
         available_gpus = cluster.available_gpu_count()
         resolved_graph = resolve_graph(self.graph, cluster)
+        compilation = compile_graph_for_fusion(
+            resolved_graph,
+            enable_fusion=self._enable_fusion,
+            node_overrides=self._node_overrides,
+        )
+        self.last_fusion_summary = compilation.fusion_summary
+        if self._enable_fusion:
+            _log_fusion_summary("RayDataExecutor", compilation.fusion_summary)
+        effective_overrides = compilation.node_overrides
 
         if isinstance(data, rd.Dataset):
             ds = data
@@ -254,9 +288,9 @@ class RayDataExecutor(AbstractExecutor):
                 matches = _glob.glob(pattern)
                 expanded.extend(sorted(matches) if matches else [pattern])
             ds = rd.read_binary_files(expanded, include_paths=True)
-        nodes = self._linearize(resolved_graph)
+        nodes = self._linearize(compilation.graph)
         for node in nodes:
-            overrides = dict(self._node_overrides.get(node.name, {}))
+            overrides = dict(effective_overrides.get(node.name, {}))
             target_num_rows_per_block = overrides.pop("target_num_rows_per_block", None)
             batch_size = overrides.pop("batch_size", self._default_batch_size)
             batch_format = overrides.pop("batch_format", self._default_batch_format)
@@ -337,3 +371,16 @@ class RayDataExecutor(AbstractExecutor):
             )
 
         return ds.materialize()
+
+
+def _log_fusion_summary(executor_name: str, summary: dict[str, Any]) -> None:
+    logger.info(
+        "%s fusion compile: enabled=%s applied=%s original=%s compiled=%s segments=%s reason=%s",
+        executor_name,
+        summary.get("enabled"),
+        summary.get("applied"),
+        summary.get("original_stage_count"),
+        summary.get("compiled_stage_count"),
+        len(summary.get("fused_segments", [])),
+        summary.get("reason"),
+    )

--- a/nemo_retriever/src/nemo_retriever/graph/fusion.py
+++ b/nemo_retriever/src/nemo_retriever/graph/fusion.py
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for compiling eligible linear graph segments into fused operators."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.gpu_operator import GPUOperator
+from nemo_retriever.graph.pipeline_graph import Graph, Node
+from nemo_retriever.utils.ray_resource_hueristics import OCR_GPUS_PER_ACTOR
+
+
+class ProcessOnlyFusionSafe:
+    """Explicit opt-in contract for stages safe to fuse at ``process()`` level."""
+
+    fusion_stage_id: ClassVar[str]
+    fusion_next_stage_ids: ClassVar[tuple[str, ...]] = ()
+    fusion_can_start_segment: ClassVar[bool] = False
+
+
+@dataclass(frozen=True)
+class GraphCompilationResult:
+    graph: Graph
+    node_overrides: dict[str, dict[str, Any]]
+    fusion_summary: dict[str, Any]
+
+
+class FusedOperator(AbstractOperator):
+    """Composite operator that runs a known-safe stage chain via ``process()`` only."""
+
+    def __init__(
+        self,
+        *,
+        stage_specs: list[dict[str, Any]],
+        fused_node_names: list[str],
+        segment_name: str,
+    ) -> None:
+        super().__init__(
+            stage_specs=deepcopy(stage_specs),
+            fused_node_names=list(fused_node_names),
+            segment_name=segment_name,
+        )
+        self.stage_specs = deepcopy(stage_specs)
+        self.fused_node_names = tuple(fused_node_names)
+        self.segment_name = segment_name
+        self._operators: list[AbstractOperator] | None = None
+
+    def preprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+    def process(self, data: Any, **kwargs: Any) -> Any:
+        current = data
+        for operator in self._ensure_operators():
+            current = operator.process(current, **kwargs)
+        return current
+
+    def postprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+    def _ensure_operators(self) -> list[AbstractOperator]:
+        if self._operators is None:
+            self._operators = []
+            for stage in self.stage_specs:
+                operator_class = stage["operator_class"]
+                operator_kwargs = deepcopy(stage.get("operator_kwargs", {}))
+                self._operators.append(operator_class(**operator_kwargs))
+        return self._operators
+
+
+def compile_graph_for_fusion(
+    graph: Graph,
+    *,
+    enable_fusion: bool = False,
+    node_overrides: dict[str, dict[str, Any]] | None = None,
+) -> GraphCompilationResult:
+    """Compile eligible linear graph segments into fused operators."""
+
+    original_node_names = _node_names(graph)
+    original_overrides = deepcopy(node_overrides or {})
+
+    if not enable_fusion:
+        return GraphCompilationResult(
+            graph=graph,
+            node_overrides=original_overrides,
+            fusion_summary=_fusion_summary(
+                enabled=False,
+                applied=False,
+                reason="disabled",
+                original_nodes=original_node_names,
+                compiled_nodes=original_node_names,
+                fused_segments=[],
+            ),
+        )
+
+    linear_nodes = _linearize_if_possible(graph)
+    if linear_nodes is None:
+        return GraphCompilationResult(
+            graph=graph,
+            node_overrides=original_overrides,
+            fusion_summary=_fusion_summary(
+                enabled=True,
+                applied=False,
+                reason="graph_not_linear",
+                original_nodes=original_node_names,
+                compiled_nodes=original_node_names,
+                fused_segments=[],
+            ),
+        )
+
+    compiled_nodes: list[Node] = []
+    compiled_overrides: dict[str, dict[str, Any]] = {}
+    fused_segments: list[dict[str, Any]] = []
+    idx = 0
+    while idx < len(linear_nodes):
+        segment_nodes = _consume_fusable_segment(linear_nodes, idx)
+        if len(segment_nodes) > 1:
+            fused_node = _make_fused_node(segment_nodes)
+            compiled_nodes.append(fused_node)
+            aggregated = _aggregate_node_overrides(segment_nodes, original_overrides)
+            if aggregated:
+                compiled_overrides[fused_node.name] = aggregated
+            fused_segments.append(
+                {
+                    "name": fused_node.name,
+                    "stage_names": [node.name for node in segment_nodes],
+                    "operator_classes": [node.operator_class.__name__ for node in segment_nodes],
+                    "stage_count": len(segment_nodes),
+                    "aggregated_overrides": aggregated,
+                }
+            )
+            idx += len(segment_nodes)
+            continue
+
+        node = linear_nodes[idx]
+        compiled_nodes.append(_clone_node(node))
+        if node.name in original_overrides:
+            compiled_overrides[node.name] = deepcopy(original_overrides[node.name])
+        idx += 1
+
+    if not fused_segments:
+        return GraphCompilationResult(
+            graph=graph,
+            node_overrides=original_overrides,
+            fusion_summary=_fusion_summary(
+                enabled=True,
+                applied=False,
+                reason="no_eligible_segments",
+                original_nodes=original_node_names,
+                compiled_nodes=original_node_names,
+                fused_segments=[],
+            ),
+        )
+
+    compiled_graph = Graph()
+    compiled_graph.add_chain(*compiled_nodes)
+    compiled_node_names = [node.name for node in compiled_nodes]
+    return GraphCompilationResult(
+        graph=compiled_graph,
+        node_overrides=compiled_overrides,
+        fusion_summary=_fusion_summary(
+            enabled=True,
+            applied=True,
+            reason="compiled",
+            original_nodes=original_node_names,
+            compiled_nodes=compiled_node_names,
+            fused_segments=fused_segments,
+        ),
+    )
+
+
+def _fusion_summary(
+    *,
+    enabled: bool,
+    applied: bool,
+    reason: str,
+    original_nodes: list[str],
+    compiled_nodes: list[str],
+    fused_segments: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "enabled": enabled,
+        "applied": applied,
+        "reason": reason,
+        "original_stage_count": len(original_nodes),
+        "compiled_stage_count": len(compiled_nodes),
+        "original_nodes": list(original_nodes),
+        "compiled_nodes": list(compiled_nodes),
+        "fused_segments": fused_segments,
+    }
+
+
+def _linearize_if_possible(graph: Graph) -> list[Node] | None:
+    if not graph.roots:
+        return []
+    if len(graph.roots) > 1:
+        return None
+
+    ordered: list[Node] = []
+    node = graph.roots[0]
+    while node is not None:
+        ordered.append(node)
+        if len(node.children) > 1:
+            return None
+        node = node.children[0] if node.children else None
+    return ordered
+
+
+def _node_names(graph: Graph) -> list[str]:
+    linear_nodes = _linearize_if_possible(graph)
+    if linear_nodes is not None:
+        return [node.name for node in linear_nodes]
+
+    names: list[str] = []
+    seen: set[int] = set()
+
+    def _visit(node: Node) -> None:
+        node_id = id(node)
+        if node_id in seen:
+            return
+        seen.add(node_id)
+        names.append(node.name)
+        for child in node.children:
+            _visit(child)
+
+    for root in graph.roots:
+        _visit(root)
+    return names
+
+
+def _consume_fusable_segment(nodes: list[Node], start_idx: int) -> list[Node]:
+    start = nodes[start_idx]
+    start_class = start.operator_class
+    if not _can_start_fused_segment(start_class):
+        return [start]
+
+    segment = [start]
+    current_class = start_class
+    idx = start_idx + 1
+    while idx < len(nodes):
+        next_node = nodes[idx]
+        next_class = next_node.operator_class
+        if not _is_process_only_fusion_safe(next_class):
+            break
+        if _stage_id(next_class) not in _next_stage_ids(current_class):
+            break
+        segment.append(next_node)
+        current_class = next_class
+        idx += 1
+    return segment if len(segment) > 1 else [start]
+
+
+def _make_fused_node(segment_nodes: list[Node]) -> Node:
+    stage_names = [node.name for node in segment_nodes]
+    fused_name = f"Fused[{'+'.join(stage_names)}]"
+    stage_specs = [
+        {
+            "name": node.name,
+            "operator_class": node.operator_class,
+            "operator_kwargs": deepcopy(node.operator_kwargs),
+        }
+        for node in segment_nodes
+    ]
+    operator_kwargs = {
+        "stage_specs": stage_specs,
+        "fused_node_names": stage_names,
+        "segment_name": fused_name,
+    }
+    operator = FusedOperator(**operator_kwargs)
+    return Node(
+        operator,
+        name=fused_name,
+        operator_class=FusedOperator,
+        operator_kwargs=operator_kwargs,
+    )
+
+
+def _clone_node(node: Node) -> Node:
+    return Node(
+        node.operator,
+        name=node.name,
+        operator_class=node.operator_class,
+        operator_kwargs=deepcopy(node.operator_kwargs),
+    )
+
+
+def _aggregate_node_overrides(
+    segment_nodes: list[Node],
+    original_overrides: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    per_stage_overrides = [deepcopy(original_overrides.get(node.name, {})) for node in segment_nodes]
+    aggregated: dict[str, Any] = {}
+
+    for key in ("batch_size", "target_num_rows_per_block", "concurrency"):
+        value = _min_positive_override(per_stage_overrides, key)
+        if value is not None:
+            aggregated[key] = value
+
+    num_cpus = _max_positive_override(per_stage_overrides, "num_cpus")
+    if num_cpus is not None:
+        aggregated["num_cpus"] = num_cpus
+
+    num_gpus = _sum_num_gpus(segment_nodes, per_stage_overrides)
+    if num_gpus is not None:
+        aggregated["num_gpus"] = num_gpus
+
+    batch_format = _first_override(per_stage_overrides, "batch_format")
+    if batch_format is not None:
+        aggregated["batch_format"] = batch_format
+
+    reserved_keys = {
+        "batch_size",
+        "target_num_rows_per_block",
+        "concurrency",
+        "num_cpus",
+        "num_gpus",
+        "batch_format",
+    }
+    passthrough_keys = {
+        key for override in per_stage_overrides for key in override if key not in reserved_keys and key not in aggregated
+    }
+    for key in sorted(passthrough_keys):
+        value = _first_override(per_stage_overrides, key)
+        if value is not None:
+            aggregated[key] = value
+
+    return aggregated
+
+
+def _first_override(per_stage_overrides: list[dict[str, Any]], key: str) -> Any:
+    for override in per_stage_overrides:
+        if key in override:
+            return override[key]
+    return None
+
+
+def _min_positive_override(per_stage_overrides: list[dict[str, Any]], key: str) -> int | float | None:
+    values = [override.get(key) for override in per_stage_overrides if _is_positive_number(override.get(key))]
+    if not values:
+        return None
+    return min(values)
+
+
+def _max_positive_override(per_stage_overrides: list[dict[str, Any]], key: str) -> float | None:
+    values = [float(override.get(key)) for override in per_stage_overrides if _is_positive_number(override.get(key))]
+    if not values:
+        return None
+    return max(values)
+
+
+def _sum_num_gpus(segment_nodes: list[Node], per_stage_overrides: list[dict[str, Any]]) -> float | None:
+    total = 0.0
+    saw_any = False
+    for node, override in zip(segment_nodes, per_stage_overrides):
+        if "num_gpus" in override:
+            saw_any = True
+            total += max(float(override.get("num_gpus") or 0.0), 0.0)
+            continue
+        if issubclass(node.operator_class, GPUOperator):
+            saw_any = True
+            total += float(OCR_GPUS_PER_ACTOR)
+    if not saw_any:
+        return None
+    return total
+
+
+def _is_positive_number(value: Any) -> bool:
+    try:
+        return float(value) > 0.0
+    except (TypeError, ValueError):
+        return False
+
+
+def _is_process_only_fusion_safe(operator_class: type) -> bool:
+    return issubclass(operator_class, ProcessOnlyFusionSafe) and bool(getattr(operator_class, "fusion_stage_id", ""))
+
+
+def _can_start_fused_segment(operator_class: type) -> bool:
+    return _is_process_only_fusion_safe(operator_class) and bool(
+        getattr(operator_class, "fusion_can_start_segment", False)
+    )
+
+
+def _stage_id(operator_class: type) -> str:
+    return str(getattr(operator_class, "fusion_stage_id", ""))
+
+
+def _next_stage_ids(operator_class: type) -> tuple[str, ...]:
+    return tuple(getattr(operator_class, "fusion_next_stage_ids", ()))

--- a/nemo_retriever/src/nemo_retriever/graph/fusion.py
+++ b/nemo_retriever/src/nemo_retriever/graph/fusion.py
@@ -32,7 +32,7 @@ class GraphCompilationResult:
 
 
 class FusedOperator(AbstractOperator):
-    """Composite operator that runs a known-safe stage chain via ``process()`` only."""
+    """Composite operator that runs a known-safe stage chain."""
 
     def __init__(
         self,
@@ -62,6 +62,13 @@ class FusedOperator(AbstractOperator):
 
     def postprocess(self, data: Any, **kwargs: Any) -> Any:
         return data
+
+    def __call__(self, data: Any, **kwargs: Any) -> Any:
+        """Preserve unfused Ray batch semantics by invoking each stage callable."""
+        current = self.preprocess(data, **kwargs)
+        for operator in self._ensure_operators():
+            current = operator(current, **kwargs)
+        return self.postprocess(current, **kwargs)
 
     def _ensure_operators(self) -> list[AbstractOperator]:
         if self._operators is None:

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -27,6 +27,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -47,6 +48,8 @@ from nemo_retriever.params import (
     TextChunkParams,
 )
 from nemo_retriever.utils.remote_auth import resolve_remote_api_key
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_api_key(params: Any) -> Any:
@@ -102,6 +105,9 @@ class GraphIngestor(ingestor):
         ``RayDataExecutor.__init__`` (``num_gpus``, ``batch_size``, etc.).
     show_progress
         Show a tqdm progress bar when running in inprocess mode.
+    enable_fusion
+        Experimentally compile eligible extraction stages into fused segments
+        before executor dispatch.
     """
 
     RUN_MODE = "graph"
@@ -112,6 +118,7 @@ class GraphIngestor(ingestor):
         run_mode: str = "batch",
         documents: Optional[List[str]] = None,
         ray_address: Optional[str] = None,
+        ray_object_store_memory_bytes: Optional[int] = None,
         ray_log_to_driver: bool = True,
         debug: bool = False,
         allow_no_gpu: bool = False,
@@ -120,12 +127,14 @@ class GraphIngestor(ingestor):
         num_gpus: float = 0,
         node_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         show_progress: bool = True,
+        enable_fusion: bool = False,
     ) -> None:
         super().__init__(documents=documents)
         if run_mode not in {"batch", "inprocess"}:
             raise ValueError(f"run_mode must be 'batch' or 'inprocess', got {run_mode!r}")
         self._run_mode = run_mode
         self._ray_address = ray_address
+        self._ray_object_store_memory_bytes = ray_object_store_memory_bytes
         self._ray_log_to_driver = ray_log_to_driver
         self._debug = debug
         self._allow_no_gpu = allow_no_gpu
@@ -134,7 +143,9 @@ class GraphIngestor(ingestor):
         self._num_gpus = num_gpus
         self._node_overrides: Dict[str, Dict[str, Any]] = node_overrides or {}
         self._show_progress = show_progress
+        self._enable_fusion = enable_fusion
         self._rd_dataset: Any = None
+        self._last_fusion_summary: dict[str, Any] | None = None
 
         # Pipeline configuration accumulated by fluent methods
         self._extraction_mode: str = "pdf"
@@ -274,16 +285,26 @@ class GraphIngestor(ingestor):
             import ray
 
             if self._ray_address or not ray.is_initialized():
-                runtime_env = {
-                    "env_vars": {
-                        "VIRTUAL_ENV": os.path.dirname(os.path.dirname(sys.executable)),
+                init_kwargs: Dict[str, Any] = {
+                    "ignore_reinit_error": True,
+                    "runtime_env": {
+                        "env_vars": {
+                            "VIRTUAL_ENV": os.path.dirname(os.path.dirname(sys.executable)),
+                        },
                     },
                 }
-                ray.init(
-                    address=self._ray_address,
-                    ignore_reinit_error=True,
-                    runtime_env=runtime_env,
-                )
+                if self._ray_address:
+                    init_kwargs["address"] = self._ray_address
+                if self._ray_object_store_memory_bytes is not None:
+                    if self._ray_address:
+                        logger.warning(
+                            "Ignoring ray_object_store_memory_bytes=%s because ray_address=%r connects to an existing Ray cluster.",
+                            self._ray_object_store_memory_bytes,
+                            self._ray_address,
+                        )
+                    else:
+                        init_kwargs["object_store_memory"] = int(self._ray_object_store_memory_bytes)
+                ray.init(**init_kwargs)
             cluster_resources = gather_cluster_resources(ray)
 
             graph = build_graph(
@@ -320,12 +341,15 @@ class GraphIngestor(ingestor):
             executor = RayDataExecutor(
                 graph,
                 ray_address=self._ray_address,
+                ray_object_store_memory_bytes=self._ray_object_store_memory_bytes,
                 batch_size=self._batch_size,
                 num_cpus=self._num_cpus,
                 num_gpus=self._num_gpus,
                 node_overrides=merged_overrides,
+                enable_fusion=self._enable_fusion,
             )
             result = executor.ingest(self._documents)
+            self._last_fusion_summary = executor.last_fusion_summary
             self._rd_dataset = result
             return result
         else:
@@ -343,9 +367,12 @@ class GraphIngestor(ingestor):
                 store_params=self._store_params,
                 stage_order=post_extract_order,
             )
-            executor = InprocessExecutor(graph, show_progress=self._show_progress)
+            executor = InprocessExecutor(graph, show_progress=self._show_progress, enable_fusion=self._enable_fusion)
+            self._last_fusion_summary = None
             self._rd_dataset = None
-            return executor.ingest(self._documents)
+            result = executor.ingest(self._documents)
+            self._last_fusion_summary = executor.last_fusion_summary
+            return result
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -385,6 +412,12 @@ class GraphIngestor(ingestor):
             low = s.lower()
             return any(tok in low for tok in ("error", "exception", "traceback", "failed"))
         return False
+
+    @property
+    def last_fusion_summary(self) -> dict[str, Any] | None:
+        if self._last_fusion_summary is None:
+            return None
+        return dict(self._last_fusion_summary)
 
     @staticmethod
     def extract_error_rows(batch: Any) -> Any:

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -100,6 +100,9 @@ class GraphIngestor(ingestor):
         ``RayDataExecutor.__init__`` (``num_gpus``, ``batch_size``, etc.).
     show_progress
         Show a tqdm progress bar when running in inprocess mode.
+    enable_fusion
+        Experimentally compile eligible extraction stages into fused segments
+        before executor dispatch.
     """
 
     RUN_MODE = "graph"
@@ -110,6 +113,7 @@ class GraphIngestor(ingestor):
         run_mode: str = "batch",
         documents: Optional[List[str]] = None,
         ray_address: Optional[str] = None,
+        ray_object_store_memory_bytes: Optional[int] = None,
         ray_log_to_driver: bool = True,
         debug: bool = False,
         allow_no_gpu: bool = False,
@@ -118,12 +122,14 @@ class GraphIngestor(ingestor):
         num_gpus: float = 0,
         node_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         show_progress: bool = True,
+        enable_fusion: bool = False,
     ) -> None:
         super().__init__(documents=documents)
         if run_mode not in {"batch", "inprocess"}:
             raise ValueError(f"run_mode must be 'batch' or 'inprocess', got {run_mode!r}")
         self._run_mode = run_mode
         self._ray_address = ray_address
+        self._ray_object_store_memory_bytes = ray_object_store_memory_bytes
         self._ray_log_to_driver = ray_log_to_driver
         self._debug = debug
         self._allow_no_gpu = allow_no_gpu
@@ -132,7 +138,9 @@ class GraphIngestor(ingestor):
         self._num_gpus = num_gpus
         self._node_overrides: Dict[str, Dict[str, Any]] = node_overrides or {}
         self._show_progress = show_progress
+        self._enable_fusion = enable_fusion
         self._rd_dataset: Any = None
+        self._last_fusion_summary: dict[str, Any] | None = None
 
         # Pipeline configuration accumulated by fluent methods
         self._extraction_mode: str = "pdf"
@@ -272,7 +280,19 @@ class GraphIngestor(ingestor):
             import ray
 
             if self._ray_address or not ray.is_initialized():
-                ray.init(address=self._ray_address, ignore_reinit_error=True)
+                init_kwargs: Dict[str, Any] = {"ignore_reinit_error": True}
+                if self._ray_address:
+                    init_kwargs["address"] = self._ray_address
+                if self._ray_object_store_memory_bytes is not None:
+                    if self._ray_address:
+                        logger.warning(
+                            "Ignoring ray_object_store_memory_bytes=%s because ray_address=%r connects to an existing Ray cluster.",
+                            self._ray_object_store_memory_bytes,
+                            self._ray_address,
+                        )
+                    else:
+                        init_kwargs["object_store_memory"] = int(self._ray_object_store_memory_bytes)
+                ray.init(**init_kwargs)
             cluster_resources = gather_cluster_resources(ray)
 
             graph = build_graph(
@@ -308,12 +328,15 @@ class GraphIngestor(ingestor):
             executor = RayDataExecutor(
                 graph,
                 ray_address=self._ray_address,
+                ray_object_store_memory_bytes=self._ray_object_store_memory_bytes,
                 batch_size=self._batch_size,
                 num_cpus=self._num_cpus,
                 num_gpus=self._num_gpus,
                 node_overrides=merged_overrides,
+                enable_fusion=self._enable_fusion,
             )
             result = executor.ingest(self._documents)
+            self._last_fusion_summary = executor.last_fusion_summary
             self._rd_dataset = result
             return result
         else:
@@ -331,9 +354,12 @@ class GraphIngestor(ingestor):
                 store_params=self._store_params,
                 stage_order=post_extract_order,
             )
-            executor = InprocessExecutor(graph, show_progress=self._show_progress)
+            executor = InprocessExecutor(graph, show_progress=self._show_progress, enable_fusion=self._enable_fusion)
+            self._last_fusion_summary = None
             self._rd_dataset = None
-            return executor.ingest(self._documents)
+            result = executor.ingest(self._documents)
+            self._last_fusion_summary = executor.last_fusion_summary
+            return result
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -373,6 +399,12 @@ class GraphIngestor(ingestor):
             low = s.lower()
             return any(tok in low for tok in ("error", "exception", "traceback", "failed"))
         return False
+
+    @property
+    def last_fusion_summary(self) -> dict[str, Any] | None:
+        if self._last_fusion_summary is None:
+            return None
+        return dict(self._last_fusion_summary)
 
     @staticmethod
     def extract_error_rows(batch: Any) -> Any:

--- a/nemo_retriever/src/nemo_retriever/harness/config.py
+++ b/nemo_retriever/src/nemo_retriever/harness/config.py
@@ -56,6 +56,7 @@ class HarnessConfig:
     dataset_label: str
     preset: str
     run_mode: str = "batch"
+    enable_fusion: bool = False
 
     query_csv: str | None = None
     input_type: str = "pdf"
@@ -76,6 +77,7 @@ class HarnessConfig:
 
     artifacts_dir: str | None = None
     ray_address: str | None = None
+    ray_object_store_memory_bytes: int | None = None
     lancedb_uri: str = "lancedb"
     hybrid: bool = False
     embed_model_name: str = "nvidia/llama-nemotron-embed-1b-v2"
@@ -118,6 +120,8 @@ class HarnessConfig:
 
         if self.run_mode not in VALID_RUN_MODES:
             errors.append(f"run_mode must be one of {sorted(VALID_RUN_MODES)}")
+        if self.ray_object_store_memory_bytes is not None and int(self.ray_object_store_memory_bytes) < 1:
+            errors.append("ray_object_store_memory_bytes must be >= 1")
 
         if self.evaluation_mode not in VALID_EVALUATION_MODES:
             errors.append(f"evaluation_mode must be one of {sorted(VALID_EVALUATION_MODES)}")
@@ -241,6 +245,10 @@ def _resolve_dataset_dir_path(value: str) -> str:
     if alternate.exists():
         return str(alternate)
 
+    home_datasets = (Path.home() / "datasets" / "nv-ingest" / relative).resolve()
+    if home_datasets.exists():
+        return str(home_datasets)
+
     return str(resolved)
 
 
@@ -269,6 +277,7 @@ def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
         "HARNESS_DATASET_DIR": ("dataset_dir", str),
         "HARNESS_PRESET": ("preset", str),
         "HARNESS_RUN_MODE": ("run_mode", str),
+        "HARNESS_ENABLE_FUSION": ("enable_fusion", _parse_bool),
         "HARNESS_QUERY_CSV": ("query_csv", str),
         "HARNESS_INPUT_TYPE": ("input_type", str),
         "HARNESS_RECALL_REQUIRED": ("recall_required", _parse_bool),
@@ -286,6 +295,7 @@ def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
         "HARNESS_BEIR_DOC_ID_FIELD": ("beir_doc_id_field", str),
         "HARNESS_ARTIFACTS_DIR": ("artifacts_dir", str),
         "HARNESS_RAY_ADDRESS": ("ray_address", str),
+        "HARNESS_RAY_OBJECT_STORE_MEMORY_BYTES": ("ray_object_store_memory_bytes", _parse_number),
         "HARNESS_LANCEDB_URI": ("lancedb_uri", str),
         "HARNESS_HYBRID": ("hybrid", _parse_bool),
         "HARNESS_EMBED_MODEL_NAME": ("embed_model_name", str),

--- a/nemo_retriever/src/nemo_retriever/harness/config.py
+++ b/nemo_retriever/src/nemo_retriever/harness/config.py
@@ -83,8 +83,14 @@ class HarnessConfig:
     embed_model_name: str = "nvidia/llama-nemotron-embed-1b-v2"
     embed_modality: str = "text"
     embed_granularity: str = "element"
+    extract_text: bool = True
+    extract_tables: bool = True
+    extract_charts: bool = True
     extract_page_as_image: bool = True
     extract_infographics: bool = False
+    use_graphic_elements: bool = False
+    use_table_structure: bool = False
+    table_output_format: str | None = None
     write_detection_file: bool = False
     use_heuristics: bool = False
     store_images_uri: str | None = None
@@ -301,8 +307,14 @@ def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
         "HARNESS_EMBED_MODEL_NAME": ("embed_model_name", str),
         "HARNESS_EMBED_MODALITY": ("embed_modality", str),
         "HARNESS_EMBED_GRANULARITY": ("embed_granularity", str),
+        "HARNESS_EXTRACT_TEXT": ("extract_text", _parse_bool),
+        "HARNESS_EXTRACT_TABLES": ("extract_tables", _parse_bool),
+        "HARNESS_EXTRACT_CHARTS": ("extract_charts", _parse_bool),
         "HARNESS_EXTRACT_PAGE_AS_IMAGE": ("extract_page_as_image", _parse_bool),
         "HARNESS_EXTRACT_INFOGRAPHICS": ("extract_infographics", _parse_bool),
+        "HARNESS_USE_GRAPHIC_ELEMENTS": ("use_graphic_elements", _parse_bool),
+        "HARNESS_USE_TABLE_STRUCTURE": ("use_table_structure", _parse_bool),
+        "HARNESS_TABLE_OUTPUT_FORMAT": ("table_output_format", str),
         "HARNESS_WRITE_DETECTION_FILE": ("write_detection_file", _parse_bool),
         "HARNESS_USE_HEURISTICS": ("use_heuristics", _parse_bool),
         "HARNESS_STORE_IMAGES_URI": ("store_images_uri", str),

--- a/nemo_retriever/src/nemo_retriever/harness/config.py
+++ b/nemo_retriever/src/nemo_retriever/harness/config.py
@@ -83,8 +83,14 @@ class HarnessConfig:
     embed_model_name: str = "nvidia/llama-nemotron-embed-1b-v2"
     embed_modality: str = "text"
     embed_granularity: str = "element"
+    extract_text: bool = True
+    extract_tables: bool = True
+    extract_charts: bool = True
     extract_page_as_image: bool = True
     extract_infographics: bool = False
+    use_graphic_elements: bool = False
+    use_table_structure: bool = False
+    table_output_format: str | None = None
     write_detection_file: bool = False
     use_heuristics: bool = False
     store_images_uri: str | None = None
@@ -310,8 +316,14 @@ def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
         "HARNESS_EMBED_MODEL_NAME": ("embed_model_name", str),
         "HARNESS_EMBED_MODALITY": ("embed_modality", str),
         "HARNESS_EMBED_GRANULARITY": ("embed_granularity", str),
+        "HARNESS_EXTRACT_TEXT": ("extract_text", _parse_bool),
+        "HARNESS_EXTRACT_TABLES": ("extract_tables", _parse_bool),
+        "HARNESS_EXTRACT_CHARTS": ("extract_charts", _parse_bool),
         "HARNESS_EXTRACT_PAGE_AS_IMAGE": ("extract_page_as_image", _parse_bool),
         "HARNESS_EXTRACT_INFOGRAPHICS": ("extract_infographics", _parse_bool),
+        "HARNESS_USE_GRAPHIC_ELEMENTS": ("use_graphic_elements", _parse_bool),
+        "HARNESS_USE_TABLE_STRUCTURE": ("use_table_structure", _parse_bool),
+        "HARNESS_TABLE_OUTPUT_FORMAT": ("table_output_format", str),
         "HARNESS_WRITE_DETECTION_FILE": ("write_detection_file", _parse_bool),
         "HARNESS_USE_HEURISTICS": ("use_heuristics", _parse_bool),
         "HARNESS_STORE_IMAGES_URI": ("store_images_uri", str),

--- a/nemo_retriever/src/nemo_retriever/harness/config.py
+++ b/nemo_retriever/src/nemo_retriever/harness/config.py
@@ -56,6 +56,7 @@ class HarnessConfig:
     dataset_label: str
     preset: str
     run_mode: str = "batch"
+    enable_fusion: bool = False
 
     query_csv: str | None = None
     input_type: str = "pdf"
@@ -76,6 +77,7 @@ class HarnessConfig:
 
     artifacts_dir: str | None = None
     ray_address: str | None = None
+    ray_object_store_memory_bytes: int | None = None
     lancedb_uri: str = "lancedb"
     hybrid: bool = False
     embed_model_name: str = "nvidia/llama-nemotron-embed-1b-v2"
@@ -125,6 +127,8 @@ class HarnessConfig:
 
         if self.run_mode not in VALID_RUN_MODES:
             errors.append(f"run_mode must be one of {sorted(VALID_RUN_MODES)}")
+        if self.ray_object_store_memory_bytes is not None and int(self.ray_object_store_memory_bytes) < 1:
+            errors.append("ray_object_store_memory_bytes must be >= 1")
 
         if self.evaluation_mode not in VALID_EVALUATION_MODES:
             errors.append(f"evaluation_mode must be one of {sorted(VALID_EVALUATION_MODES)}")
@@ -248,6 +252,10 @@ def _resolve_dataset_dir_path(value: str) -> str:
     if alternate.exists():
         return str(alternate)
 
+    home_datasets = (Path.home() / "datasets" / "nv-ingest" / relative).resolve()
+    if home_datasets.exists():
+        return str(home_datasets)
+
     return str(resolved)
 
 
@@ -278,6 +286,7 @@ def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
         "HARNESS_DATASET_DIR": ("dataset_dir", str),
         "HARNESS_PRESET": ("preset", str),
         "HARNESS_RUN_MODE": ("run_mode", str),
+        "HARNESS_ENABLE_FUSION": ("enable_fusion", _parse_bool),
         "HARNESS_QUERY_CSV": ("query_csv", str),
         "HARNESS_INPUT_TYPE": ("input_type", str),
         "HARNESS_RECALL_REQUIRED": ("recall_required", _parse_bool),
@@ -295,6 +304,7 @@ def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
         "HARNESS_BEIR_DOC_ID_FIELD": ("beir_doc_id_field", str),
         "HARNESS_ARTIFACTS_DIR": ("artifacts_dir", str),
         "HARNESS_RAY_ADDRESS": ("ray_address", str),
+        "HARNESS_RAY_OBJECT_STORE_MEMORY_BYTES": ("ray_object_store_memory_bytes", _parse_number),
         "HARNESS_LANCEDB_URI": ("lancedb_uri", str),
         "HARNESS_HYBRID": ("hybrid", _parse_bool),
         "HARNESS_EMBED_MODEL_NAME": ("embed_model_name", str),

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -303,6 +303,9 @@ def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple
         cfg.evaluation_mode,
     ]
 
+    if cfg.enable_fusion:
+        cmd.append("--enable-fusion")
+
     if not cfg.use_heuristics:
         cmd += [
             "--pdf-extract-tasks",
@@ -398,6 +401,8 @@ def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple
         cmd += ["--structured-elements-modality", cfg.embed_modality]
     if cfg.ray_address:
         cmd += ["--ray-address", cfg.ray_address]
+    if cfg.ray_object_store_memory_bytes is not None:
+        cmd += ["--ray-object-store-memory-bytes", str(int(cfg.ray_object_store_memory_bytes))]
     if cfg.hybrid:
         cmd += ["--hybrid"]
 
@@ -514,49 +519,55 @@ def _run_single(cfg: HarnessConfig, artifact_dir: Path, run_id: str, tags: list[
     summary_metrics = _resolve_summary_metrics(cfg, metrics_payload, runtime_summary)
     configured_tuning = {field: getattr(cfg, field) for field in sorted(TUNING_FIELDS)}
 
+    test_config = {
+        "dataset_label": cfg.dataset_label,
+        "dataset_dir": cfg.dataset_dir,
+        "preset": cfg.preset,
+        "run_mode": cfg.run_mode,
+        "query_csv": cfg.query_csv,
+        "effective_query_csv": str(effective_query_csv) if effective_query_csv is not None else None,
+        "input_type": cfg.input_type,
+        "recall_required": cfg.recall_required,
+        "recall_match_mode": cfg.recall_match_mode,
+        "recall_adapter": cfg.recall_adapter,
+        "audio_match_tolerance_secs": cfg.audio_match_tolerance_secs,
+        "segment_audio": cfg.segment_audio,
+        "audio_split_type": cfg.audio_split_type,
+        "audio_split_interval": cfg.audio_split_interval,
+        "evaluation_mode": cfg.evaluation_mode,
+        "beir_loader": cfg.beir_loader,
+        "beir_dataset_name": cfg.beir_dataset_name,
+        "beir_split": cfg.beir_split,
+        "beir_query_language": cfg.beir_query_language,
+        "beir_doc_id_field": cfg.beir_doc_id_field,
+        "beir_ks": list(cfg.beir_ks),
+        "ray_address": cfg.ray_address,
+        "hybrid": cfg.hybrid,
+        "embed_model_name": cfg.embed_model_name,
+        "embed_modality": cfg.embed_modality,
+        "embed_granularity": cfg.embed_granularity,
+        "extract_page_as_image": cfg.extract_page_as_image,
+        "extract_infographics": cfg.extract_infographics,
+        "write_detection_file": cfg.write_detection_file,
+        "use_heuristics": cfg.use_heuristics,
+        "store_images_uri": _resolve_store_uri(cfg, artifact_dir),
+        "store_text": cfg.store_text,
+        "strip_base64": cfg.strip_base64,
+        "lancedb_uri": _resolve_lancedb_uri(cfg, artifact_dir),
+        "tuning": configured_tuning,
+    }
+    if cfg.enable_fusion:
+        test_config["enable_fusion"] = True
+    if cfg.ray_object_store_memory_bytes is not None:
+        test_config["ray_object_store_memory_bytes"] = int(cfg.ray_object_store_memory_bytes)
+
     result_payload: dict[str, Any] = {
         "timestamp": now_timestr(),
         "latest_commit": last_commit(),
         "success": success,
         "return_code": effective_rc,
         "failure_reason": failure_reason or None,
-        "test_config": {
-            "dataset_label": cfg.dataset_label,
-            "dataset_dir": cfg.dataset_dir,
-            "preset": cfg.preset,
-            "run_mode": cfg.run_mode,
-            "query_csv": cfg.query_csv,
-            "effective_query_csv": str(effective_query_csv) if effective_query_csv is not None else None,
-            "input_type": cfg.input_type,
-            "recall_required": cfg.recall_required,
-            "recall_match_mode": cfg.recall_match_mode,
-            "recall_adapter": cfg.recall_adapter,
-            "audio_match_tolerance_secs": cfg.audio_match_tolerance_secs,
-            "segment_audio": cfg.segment_audio,
-            "audio_split_type": cfg.audio_split_type,
-            "audio_split_interval": cfg.audio_split_interval,
-            "evaluation_mode": cfg.evaluation_mode,
-            "beir_loader": cfg.beir_loader,
-            "beir_dataset_name": cfg.beir_dataset_name,
-            "beir_split": cfg.beir_split,
-            "beir_query_language": cfg.beir_query_language,
-            "beir_doc_id_field": cfg.beir_doc_id_field,
-            "beir_ks": list(cfg.beir_ks),
-            "ray_address": cfg.ray_address,
-            "hybrid": cfg.hybrid,
-            "embed_model_name": cfg.embed_model_name,
-            "embed_modality": cfg.embed_modality,
-            "embed_granularity": cfg.embed_granularity,
-            "extract_page_as_image": cfg.extract_page_as_image,
-            "extract_infographics": cfg.extract_infographics,
-            "write_detection_file": cfg.write_detection_file,
-            "use_heuristics": cfg.use_heuristics,
-            "store_images_uri": _resolve_store_uri(cfg, artifact_dir),
-            "store_text": cfg.store_text,
-            "strip_base64": cfg.strip_base64,
-            "lancedb_uri": _resolve_lancedb_uri(cfg, artifact_dir),
-            "tuning": configured_tuning,
-        },
+        "test_config": test_config,
         "metrics": {
             **metrics_payload,
         },

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -390,6 +390,9 @@ def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple
             "--no-recall-details",
         ]
 
+    cmd += ["--extract-text" if cfg.extract_text else "--no-extract-text"]
+    cmd += ["--extract-tables" if cfg.extract_tables else "--no-extract-tables"]
+    cmd += ["--extract-charts" if cfg.extract_charts else "--no-extract-charts"]
     cmd += ["--extract-page-as-image" if cfg.extract_page_as_image else "--no-extract-page-as-image"]
     if cfg.input_type == "audio":
         cmd += ["--segment-audio" if cfg.segment_audio else "--no-segment-audio"]
@@ -397,6 +400,12 @@ def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple
         cmd += ["--audio-split-interval", str(cfg.audio_split_interval)]
     if cfg.extract_infographics:
         cmd += ["--extract-infographics"]
+    if cfg.use_graphic_elements:
+        cmd += ["--use-graphic-elements"]
+    if cfg.use_table_structure:
+        cmd += ["--use-table-structure"]
+    if cfg.table_output_format:
+        cmd += ["--table-output-format", cfg.table_output_format]
     if cfg.embed_modality:
         cmd += ["--structured-elements-modality", cfg.embed_modality]
     if cfg.ray_address:

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -398,6 +398,9 @@ def _build_command(
         cfg.evaluation_mode,
     ]
 
+    if cfg.enable_fusion:
+        cmd.append("--enable-fusion")
+
     if not cfg.use_heuristics:
         cmd += [
             "--pdf-extract-tasks",
@@ -511,6 +514,8 @@ def _build_command(
         env_extra["NVIDIA_API_KEY"] = cfg.api_key
     if cfg.ray_address:
         cmd += ["--ray-address", cfg.ray_address]
+    if cfg.ray_object_store_memory_bytes is not None:
+        cmd += ["--ray-object-store-memory-bytes", str(int(cfg.ray_object_store_memory_bytes))]
     if cfg.hybrid:
         cmd += ["--hybrid"]
 
@@ -746,49 +751,55 @@ def _run_single(
     summary_metrics = _resolve_summary_metrics(cfg, metrics_payload, runtime_summary)
     configured_tuning = {field: getattr(cfg, field) for field in sorted(TUNING_FIELDS)}
 
+    test_config = {
+        "dataset_label": cfg.dataset_label,
+        "dataset_dir": cfg.dataset_dir,
+        "preset": cfg.preset,
+        "run_mode": cfg.run_mode,
+        "query_csv": cfg.query_csv,
+        "effective_query_csv": str(effective_query_csv) if effective_query_csv is not None else None,
+        "input_type": cfg.input_type,
+        "recall_required": cfg.recall_required,
+        "recall_match_mode": cfg.recall_match_mode,
+        "recall_adapter": cfg.recall_adapter,
+        "audio_match_tolerance_secs": cfg.audio_match_tolerance_secs,
+        "segment_audio": cfg.segment_audio,
+        "audio_split_type": cfg.audio_split_type,
+        "audio_split_interval": cfg.audio_split_interval,
+        "evaluation_mode": cfg.evaluation_mode,
+        "beir_loader": cfg.beir_loader,
+        "beir_dataset_name": cfg.beir_dataset_name,
+        "beir_split": cfg.beir_split,
+        "beir_query_language": cfg.beir_query_language,
+        "beir_doc_id_field": cfg.beir_doc_id_field,
+        "beir_ks": list(cfg.beir_ks),
+        "ray_address": cfg.ray_address,
+        "hybrid": cfg.hybrid,
+        "embed_model_name": cfg.embed_model_name,
+        "embed_modality": cfg.embed_modality,
+        "embed_granularity": cfg.embed_granularity,
+        "extract_page_as_image": cfg.extract_page_as_image,
+        "extract_infographics": cfg.extract_infographics,
+        "write_detection_file": cfg.write_detection_file,
+        "use_heuristics": cfg.use_heuristics,
+        "store_images_uri": _resolve_store_uri(cfg, artifact_dir),
+        "store_text": cfg.store_text,
+        "strip_base64": cfg.strip_base64,
+        "lancedb_uri": _resolve_lancedb_uri(cfg, artifact_dir),
+        "tuning": configured_tuning,
+    }
+    if cfg.enable_fusion:
+        test_config["enable_fusion"] = True
+    if cfg.ray_object_store_memory_bytes is not None:
+        test_config["ray_object_store_memory_bytes"] = int(cfg.ray_object_store_memory_bytes)
+
     result_payload: dict[str, Any] = {
         "timestamp": now_timestr(),
         "latest_commit": last_commit(),
         "success": success,
         "return_code": effective_rc,
         "failure_reason": failure_reason or None,
-        "test_config": {
-            "dataset_label": cfg.dataset_label,
-            "dataset_dir": cfg.dataset_dir,
-            "preset": cfg.preset,
-            "run_mode": cfg.run_mode,
-            "query_csv": cfg.query_csv,
-            "effective_query_csv": str(effective_query_csv) if effective_query_csv is not None else None,
-            "input_type": cfg.input_type,
-            "recall_required": cfg.recall_required,
-            "recall_match_mode": cfg.recall_match_mode,
-            "recall_adapter": cfg.recall_adapter,
-            "audio_match_tolerance_secs": cfg.audio_match_tolerance_secs,
-            "segment_audio": cfg.segment_audio,
-            "audio_split_type": cfg.audio_split_type,
-            "audio_split_interval": cfg.audio_split_interval,
-            "evaluation_mode": cfg.evaluation_mode,
-            "beir_loader": cfg.beir_loader,
-            "beir_dataset_name": cfg.beir_dataset_name,
-            "beir_split": cfg.beir_split,
-            "beir_query_language": cfg.beir_query_language,
-            "beir_doc_id_field": cfg.beir_doc_id_field,
-            "beir_ks": list(cfg.beir_ks),
-            "ray_address": cfg.ray_address,
-            "hybrid": cfg.hybrid,
-            "embed_model_name": cfg.embed_model_name,
-            "embed_modality": cfg.embed_modality,
-            "embed_granularity": cfg.embed_granularity,
-            "extract_page_as_image": cfg.extract_page_as_image,
-            "extract_infographics": cfg.extract_infographics,
-            "write_detection_file": cfg.write_detection_file,
-            "use_heuristics": cfg.use_heuristics,
-            "store_images_uri": _resolve_store_uri(cfg, artifact_dir),
-            "store_text": cfg.store_text,
-            "strip_base64": cfg.strip_base64,
-            "lancedb_uri": _resolve_lancedb_uri(cfg, artifact_dir),
-            "tuning": configured_tuning,
-        },
+        "test_config": test_config,
         "metrics": {
             **metrics_payload,
         },

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -490,6 +490,9 @@ def _build_command(
             "--no-recall-details",
         ]
 
+    cmd += ["--extract-text" if cfg.extract_text else "--no-extract-text"]
+    cmd += ["--extract-tables" if cfg.extract_tables else "--no-extract-tables"]
+    cmd += ["--extract-charts" if cfg.extract_charts else "--no-extract-charts"]
     cmd += ["--extract-page-as-image" if cfg.extract_page_as_image else "--no-extract-page-as-image"]
     if cfg.input_type == "audio":
         cmd += ["--segment-audio" if cfg.segment_audio else "--no-segment-audio"]
@@ -497,6 +500,12 @@ def _build_command(
         cmd += ["--audio-split-interval", str(cfg.audio_split_interval)]
     if cfg.extract_infographics:
         cmd += ["--extract-infographics"]
+    if cfg.use_graphic_elements:
+        cmd += ["--use-graphic-elements"]
+    if cfg.use_table_structure:
+        cmd += ["--use-table-structure"]
+    if cfg.table_output_format:
+        cmd += ["--table-output-format", cfg.table_output_format]
     if cfg.embed_modality:
         cmd += ["--structured-elements-modality", cfg.embed_modality]
     if cfg.page_elements_invoke_url:

--- a/nemo_retriever/src/nemo_retriever/ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor.py
@@ -10,7 +10,6 @@ Concrete implementations are provided by runmodes:
 
 - inprocess: local Python process, no framework assumptions
 - batch: large-scale batch execution
-- fused: low-latency single-actor GPU model fusion
 - online: low-latency, multi-request serving
 """
 

--- a/nemo_retriever/src/nemo_retriever/ocr/cpu_ocr.py
+++ b/nemo_retriever/src/nemo_retriever/ocr/cpu_ocr.py
@@ -10,15 +10,19 @@ import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
 from nemo_retriever.graph.cpu_operator import CPUOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.ocr.shared import _error_payload
 from nemo_retriever.ocr.shared import ocr_page_elements
 
 
-class OCRCPUActor(AbstractOperator, CPUOperator):
+class OCRCPUActor(ProcessOnlyFusionSafe, AbstractOperator, CPUOperator):
     """CPU-only variant of :class:`OCRActor`."""
 
     DEFAULT_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1"
+    fusion_stage_id = "ocr"
+    fusion_next_stage_ids = ()
+    fusion_can_start_segment = False
 
     def __init__(self, **ocr_kwargs: Any) -> None:
         super().__init__(**ocr_kwargs)

--- a/nemo_retriever/src/nemo_retriever/ocr/gpu_ocr.py
+++ b/nemo_retriever/src/nemo_retriever/ocr/gpu_ocr.py
@@ -9,13 +9,18 @@ from typing import Any
 import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.ocr.shared import Image, _error_payload, ocr_page_elements
 
 
-class OCRActor(AbstractOperator, GPUOperator):
+class OCRActor(ProcessOnlyFusionSafe, AbstractOperator, GPUOperator):
     """Ray-friendly callable that initializes Nemotron OCR v1 once per actor."""
+
+    fusion_stage_id = "ocr"
+    fusion_next_stage_ids = ()
+    fusion_can_start_segment = False
 
     def __init__(self, **ocr_kwargs: Any) -> None:
         super().__init__(**ocr_kwargs)

--- a/nemo_retriever/src/nemo_retriever/page_elements/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/page_elements/cpu_actor.py
@@ -23,7 +23,7 @@ class PageElementDetectionCPUActor(ProcessOnlyFusionSafe, AbstractOperator, CPUO
 
     DEFAULT_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3"
     fusion_stage_id = "page_elements"
-    fusion_next_stage_ids = ("ocr",)
+    fusion_next_stage_ids = ("table_structure", "graphic_elements", "ocr")
     fusion_can_start_segment = True
 
     def __init__(self, **detect_kwargs: Any) -> None:

--- a/nemo_retriever/src/nemo_retriever/page_elements/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/page_elements/cpu_actor.py
@@ -10,10 +10,11 @@ import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
 from nemo_retriever.graph.cpu_operator import CPUOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.page_elements.shared import _error_payload, detect_page_elements_v3
 
 
-class PageElementDetectionCPUActor(AbstractOperator, CPUOperator):
+class PageElementDetectionCPUActor(ProcessOnlyFusionSafe, AbstractOperator, CPUOperator):
     """CPU-only variant of :class:`PageElementDetectionActor`.
 
     Defaults to the build.nvidia.com endpoint for ``nemotron-page-elements-v3``.
@@ -21,6 +22,9 @@ class PageElementDetectionCPUActor(AbstractOperator, CPUOperator):
     """
 
     DEFAULT_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3"
+    fusion_stage_id = "page_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = True
 
     def __init__(self, **detect_kwargs: Any) -> None:
         super().__init__(**detect_kwargs)

--- a/nemo_retriever/src/nemo_retriever/page_elements/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/page_elements/gpu_actor.py
@@ -9,17 +9,22 @@ from typing import Any
 import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.page_elements.shared import _error_payload, detect_page_elements_v3
 
 
-class PageElementDetectionActor(AbstractOperator, GPUOperator):
+class PageElementDetectionActor(ProcessOnlyFusionSafe, AbstractOperator, GPUOperator):
     """
     Ray-friendly callable that initializes Nemotron Page Elements v3 once.
 
     Use with Ray Data:
       ds = ds.map_batches(PageElementDetectionActor, fn_constructor_kwargs={...}, batch_format="pandas")
     """
+
+    fusion_stage_id = "page_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = True
 
     def __init__(self, **detect_kwargs: Any) -> None:
         super().__init__(**detect_kwargs)

--- a/nemo_retriever/src/nemo_retriever/page_elements/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/page_elements/gpu_actor.py
@@ -23,7 +23,7 @@ class PageElementDetectionActor(ProcessOnlyFusionSafe, AbstractOperator, GPUOper
     """
 
     fusion_stage_id = "page_elements"
-    fusion_next_stage_ids = ("ocr",)
+    fusion_next_stage_ids = ("table_structure", "graphic_elements", "ocr")
     fusion_can_start_segment = True
 
     def __init__(self, **detect_kwargs: Any) -> None:

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from nemo_retriever.utils.remote_auth import resolve_remote_api_key
 
-RunMode = Literal["inprocess", "batch", "fused", "online"]
+RunMode = Literal["inprocess", "batch", "online"]
 
 # Pass as an api_key value to suppress auto-resolution from environment variables.
 # Example: EmbedParams(api_key=NO_API_KEY)

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -15,7 +15,7 @@ from upath import UPath
 from nemo_retriever.tabular_data.sql_database import SQLDatabase
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-RunMode = Literal["inprocess", "batch", "fused", "online"]
+RunMode = Literal["inprocess", "batch", "online"]
 
 
 class _ParamsModel(BaseModel):

--- a/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
@@ -10,11 +10,12 @@ import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
 from nemo_retriever.graph.cpu_operator import CPUOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.table.shared import table_structure_ocr_page_elements
 
 
-class TableStructureCPUActor(AbstractOperator, CPUOperator):
+class TableStructureCPUActor(ProcessOnlyFusionSafe, AbstractOperator, CPUOperator):
     """CPU-only variant of :class:`TableStructureActor`.
 
     Defaults to the build.nvidia.com endpoint for
@@ -22,6 +23,10 @@ class TableStructureCPUActor(AbstractOperator, CPUOperator):
     """
 
     DEFAULT_TABLE_STRUCTURE_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1"
+    DEFAULT_OCR_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1"
+    fusion_stage_id = "table_structure"
+    fusion_next_stage_ids = ("graphic_elements", "ocr")
+    fusion_can_start_segment = False
 
     def __init__(
         self,

--- a/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
@@ -10,11 +10,12 @@ import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
 from nemo_retriever.graph.cpu_operator import CPUOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.table.shared import table_structure_ocr_page_elements
 
 
-class TableStructureCPUActor(AbstractOperator, CPUOperator):
+class TableStructureCPUActor(ProcessOnlyFusionSafe, AbstractOperator, CPUOperator):
     """CPU-only variant of :class:`TableStructureActor`.
 
     Defaults to build.nvidia.com endpoints for ``nemotron-table-structure-v1``
@@ -23,6 +24,9 @@ class TableStructureCPUActor(AbstractOperator, CPUOperator):
 
     DEFAULT_TABLE_STRUCTURE_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1"
     DEFAULT_OCR_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1"
+    fusion_stage_id = "table_structure"
+    fusion_next_stage_ids = ("graphic_elements", "ocr")
+    fusion_can_start_segment = False
 
     def __init__(
         self,

--- a/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
@@ -9,16 +9,21 @@ from typing import Any, Optional
 import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.table.shared import table_structure_ocr_page_elements
 
 
-class TableStructureActor(AbstractOperator, GPUOperator):
+class TableStructureActor(ProcessOnlyFusionSafe, AbstractOperator, GPUOperator):
     """
     Ray-friendly callable that initializes the table-structure model once
     per actor and runs the structure stage.
     """
+
+    fusion_stage_id = "table_structure"
+    fusion_next_stage_ids = ("graphic_elements", "ocr")
+    fusion_can_start_segment = False
 
     def __init__(
         self,

--- a/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
@@ -9,16 +9,21 @@ from typing import Any, Optional
 import pandas as pd
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.fusion import ProcessOnlyFusionSafe
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.table.shared import table_structure_ocr_page_elements
 
 
-class TableStructureActor(AbstractOperator, GPUOperator):
+class TableStructureActor(ProcessOnlyFusionSafe, AbstractOperator, GPUOperator):
     """
     Ray-friendly callable that initializes both table-structure and OCR
     models once per actor and runs the combined stage.
     """
+
+    fusion_stage_id = "table_structure"
+    fusion_next_stage_ids = ("graphic_elements", "ocr")
+    fusion_can_start_segment = False
 
     def __init__(
         self,

--- a/nemo_retriever/src/nemo_retriever/text_embed/main_text_embed.py
+++ b/nemo_retriever/src/nemo_retriever/text_embed/main_text_embed.py
@@ -49,7 +49,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 from urllib.parse import urlparse  # noqa: F401
 
 import pandas as pd
-from nv_ingest_api.util.string_processing import ensure_openai_embeddings_http_url
+from nv_ingest_api.util.string_processing import generate_url
 
 from nemo_retriever.params.models import IMAGE_MODALITIES
 
@@ -257,9 +257,16 @@ def _multimodal_callable_runner(
 
 def _normalize_embeddings_endpoint(endpoint_url: str) -> str:
     """
-    Normalize endpoint to a concrete embeddings URL (delegates to shared nv-ingest helper).
+    Normalize endpoint to a concrete OpenAI-compatible embeddings URL.
     """
-    return ensure_openai_embeddings_http_url(endpoint_url)
+    url = generate_url(endpoint_url).rstrip("/")
+    if url.endswith("/v1/embeddings"):
+        return url
+    if url.endswith("/v1"):
+        return f"{url}/embeddings"
+    if url.endswith("/embeddings"):
+        return url
+    return f"{url}/v1/embeddings"
 
 
 def _http_embed_openai_compat(

--- a/nemo_retriever/tests/test_harness_config.py
+++ b/nemo_retriever/tests/test_harness_config.py
@@ -83,6 +83,42 @@ def test_load_harness_config_supports_run_mode_override(tmp_path: Path, monkeypa
     assert cfg.run_mode == "inprocess"
 
 
+def test_load_harness_config_supports_enable_fusion_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("query,source,page\nq,a,1\n", encoding="utf-8")
+    cfg_path = tmp_path / "test_configs.yaml"
+    _write_harness_config(cfg_path, dataset_dir, query_csv)
+
+    monkeypatch.setenv("HARNESS_ENABLE_FUSION", "true")
+
+    cfg = load_harness_config(
+        config_file=str(cfg_path),
+        dataset="tiny",
+        preset="base",
+    )
+    assert cfg.enable_fusion is True
+
+
+def test_load_harness_config_supports_object_store_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("query,source,page\nq,a,1\n", encoding="utf-8")
+    cfg_path = tmp_path / "test_configs.yaml"
+    _write_harness_config(cfg_path, dataset_dir, query_csv)
+
+    monkeypatch.setenv("HARNESS_RAY_OBJECT_STORE_MEMORY_BYTES", "900000000000")
+
+    cfg = load_harness_config(
+        config_file=str(cfg_path),
+        dataset="tiny",
+        preset="base",
+    )
+    assert cfg.ray_object_store_memory_bytes == 900000000000
+
+
 def test_load_harness_config_rejects_invalid_run_mode(tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_harness_config.py
+++ b/nemo_retriever/tests/test_harness_config.py
@@ -119,6 +119,37 @@ def test_load_harness_config_supports_object_store_override(tmp_path: Path, monk
     assert cfg.ray_object_store_memory_bytes == 900000000000
 
 
+def test_load_harness_config_supports_extraction_shape_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("query,source,page\nq,a,1\n", encoding="utf-8")
+    cfg_path = tmp_path / "test_configs.yaml"
+    _write_harness_config(cfg_path, dataset_dir, query_csv)
+
+    monkeypatch.setenv("HARNESS_EXTRACT_TEXT", "false")
+    monkeypatch.setenv("HARNESS_EXTRACT_TABLES", "false")
+    monkeypatch.setenv("HARNESS_EXTRACT_CHARTS", "false")
+    monkeypatch.setenv("HARNESS_USE_GRAPHIC_ELEMENTS", "true")
+    monkeypatch.setenv("HARNESS_USE_TABLE_STRUCTURE", "true")
+    monkeypatch.setenv("HARNESS_TABLE_OUTPUT_FORMAT", "markdown")
+
+    cfg = load_harness_config(
+        config_file=str(cfg_path),
+        dataset="tiny",
+        preset="base",
+    )
+
+    assert cfg.extract_text is False
+    assert cfg.extract_tables is False
+    assert cfg.extract_charts is False
+    assert cfg.use_graphic_elements is True
+    assert cfg.use_table_structure is True
+    assert cfg.table_output_format == "markdown"
+
+
 def test_load_harness_config_rejects_invalid_run_mode(tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -167,6 +167,43 @@ def test_build_command_supports_inprocess_run_mode(tmp_path: Path) -> None:
     assert cmd[cmd.index("--run-mode") + 1] == "inprocess"
 
 
+def test_build_command_includes_enable_fusion_flag(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        enable_fusion=True,
+    )
+    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+
+    assert "--enable-fusion" in cmd
+
+
+def test_build_command_includes_object_store_memory_flag(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        ray_object_store_memory_bytes=900000000000,
+    )
+    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+
+    assert "--ray-object-store-memory-bytes" in cmd
+    assert cmd[cmd.index("--ray-object-store-memory-bytes") + 1] == "900000000000"
+
+
 def test_build_command_supports_beir_evaluation_mode(tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -204,6 +204,35 @@ def test_build_command_includes_object_store_memory_flag(tmp_path: Path) -> None
     assert cmd[cmd.index("--ray-object-store-memory-bytes") + 1] == "900000000000"
 
 
+def test_build_command_includes_extraction_shape_flags(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        extract_text=False,
+        extract_tables=False,
+        extract_charts=False,
+        use_graphic_elements=True,
+        use_table_structure=True,
+        table_output_format="markdown",
+    )
+    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+
+    assert "--no-extract-text" in cmd
+    assert "--no-extract-tables" in cmd
+    assert "--no-extract-charts" in cmd
+    assert "--use-graphic-elements" in cmd
+    assert "--use-table-structure" in cmd
+    assert "--table-output-format" in cmd
+    assert cmd[cmd.index("--table-output-format") + 1] == "markdown"
+
+
 def test_build_command_supports_beir_evaluation_mode(tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -184,7 +184,9 @@ def test_build_command_includes_enable_fusion_flag(tmp_path: Path) -> None:
         query_csv=str(query_csv),
         enable_fusion=True,
     )
-    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, _runtime_dir, _detection_file, _effective_query_csv, _metrics_file, _env_extra = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
 
     assert "--enable-fusion" in cmd
 
@@ -202,7 +204,9 @@ def test_build_command_includes_object_store_memory_flag(tmp_path: Path) -> None
         query_csv=str(query_csv),
         ray_object_store_memory_bytes=900000000000,
     )
-    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, _runtime_dir, _detection_file, _effective_query_csv, _metrics_file, _env_extra = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
 
     assert "--ray-object-store-memory-bytes" in cmd
     assert cmd[cmd.index("--ray-object-store-memory-bytes") + 1] == "900000000000"
@@ -226,7 +230,9 @@ def test_build_command_includes_extraction_shape_flags(tmp_path: Path) -> None:
         use_table_structure=True,
         table_output_format="markdown",
     )
-    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, _runtime_dir, _detection_file, _effective_query_csv, _metrics_file, _env_extra = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
 
     assert "--no-extract-text" in cmd
     assert "--no-extract-tables" in cmd
@@ -339,7 +345,9 @@ def test_build_command_supports_earnings_beir_pdf_page_doc_id_field(tmp_path: Pa
         recall_required=False,
     )
 
-    cmd, _runtime_dir, _detection_file, effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, _runtime_dir, _detection_file, effective_query_csv, _metrics_file, _env_extra = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
 
     assert cmd[cmd.index("--beir-loader") + 1] == "earnings_csv"
     assert cmd[cmd.index("--beir-dataset-name") + 1] == str(annotations_csv.resolve())
@@ -365,7 +373,9 @@ def test_build_command_supports_financebench_beir_pdf_basename_doc_id_field(tmp_
         recall_required=False,
     )
 
-    cmd, _runtime_dir, _detection_file, effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, _runtime_dir, _detection_file, effective_query_csv, _metrics_file, _env_extra = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
 
     assert cmd[cmd.index("--beir-loader") + 1] == "financebench_json"
     assert cmd[cmd.index("--beir-dataset-name") + 1] == str(annotations_json.resolve())

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -208,6 +208,35 @@ def test_build_command_includes_object_store_memory_flag(tmp_path: Path) -> None
     assert cmd[cmd.index("--ray-object-store-memory-bytes") + 1] == "900000000000"
 
 
+def test_build_command_includes_extraction_shape_flags(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        extract_text=False,
+        extract_tables=False,
+        extract_charts=False,
+        use_graphic_elements=True,
+        use_table_structure=True,
+        table_output_format="markdown",
+    )
+    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+
+    assert "--no-extract-text" in cmd
+    assert "--no-extract-tables" in cmd
+    assert "--no-extract-charts" in cmd
+    assert "--use-graphic-elements" in cmd
+    assert "--use-table-structure" in cmd
+    assert "--table-output-format" in cmd
+    assert cmd[cmd.index("--table-output-format") + 1] == "markdown"
+
+
 def test_build_command_supports_beir_evaluation_mode(tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -171,6 +171,43 @@ def test_build_command_supports_inprocess_run_mode(tmp_path: Path) -> None:
     assert cmd[cmd.index("--run-mode") + 1] == "inprocess"
 
 
+def test_build_command_includes_enable_fusion_flag(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        enable_fusion=True,
+    )
+    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+
+    assert "--enable-fusion" in cmd
+
+
+def test_build_command_includes_object_store_memory_flag(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        ray_object_store_memory_bytes=900000000000,
+    )
+    cmd, _runtime_dir, _detection_file, _effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+
+    assert "--ray-object-store-memory-bytes" in cmd
+    assert cmd[cmd.index("--ray-object-store-memory-bytes") + 1] == "900000000000"
+
+
 def test_build_command_supports_beir_evaluation_mode(tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from nemo_retriever.audio.media_interface import is_media_available
@@ -242,6 +244,7 @@ def test_graph_ingestor_autodetects_no_gpu_for_batch_overrides(monkeypatch) -> N
     class _FakeExecutor:
         def __init__(self, graph, **kwargs):
             self.graph = graph
+            self.last_fusion_summary = None
 
         def ingest(self, data):
             return {"data": data, "graph": self.graph}
@@ -275,6 +278,51 @@ def test_graph_ingestor_autodetects_no_gpu_for_batch_overrides(monkeypatch) -> N
     assert captured["allow_no_gpu"] is True
     assert captured["cluster_resources"] == cluster
     assert result["data"] == ["/tmp/input.pdf"]
+
+
+def test_graph_ingestor_warns_when_object_store_memory_is_ignored_for_existing_cluster(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeExecutor:
+        def __init__(self, graph, **kwargs):
+            self.graph = graph
+            self.last_fusion_summary = None
+
+        def ingest(self, data):
+            captured["data"] = data
+            return {"data": data, "graph": self.graph}
+
+    cluster = ClusterResources(
+        total_resources=Resources(cpu_count=16, gpu_count=1),
+        available_resources=Resources(cpu_count=16, gpu_count=1),
+    )
+
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.build_graph", lambda **kwargs: Graph())
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.batch_tuning_to_node_overrides", lambda *args, **kwargs: {})
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.gather_cluster_resources", lambda ray: cluster)
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.RayDataExecutor", _FakeExecutor)
+
+    init_kwargs: dict[str, object] = {}
+    monkeypatch.setattr("ray.is_initialized", lambda: False)
+    monkeypatch.setattr("ray.init", lambda **kwargs: init_kwargs.update(kwargs))
+
+    ingestor = GraphIngestor(
+        run_mode="batch",
+        documents=["/tmp/input.pdf"],
+        ray_address="ray://cluster",
+        ray_object_store_memory_bytes=123,
+    )
+    ingestor.extract(ExtractParams(method="ocr"))
+
+    with caplog.at_level(logging.WARNING):
+        result = ingestor.ingest()
+
+    assert init_kwargs == {"ignore_reinit_error": True, "address": "ray://cluster"}
+    assert "Ignoring ray_object_store_memory_bytes=123 because ray_address='ray://cluster'" in caplog.text
+    assert captured["data"] == ["/tmp/input.pdf"]
+    assert result["graph"] is not None
 
 
 @pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="CUDA not available")

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.fusion import FusedOperator, ProcessOnlyFusionSafe, compile_graph_for_fusion
 from nemo_retriever.graph.operator_archetype import ArchetypeOperator
 from nemo_retriever.graph import FileListLoaderOperator, MultiTypeExtractOperator, UDFOperator
 from nemo_retriever.graph.cpu_operator import CPUOperator
@@ -72,6 +73,42 @@ class AppendOperator(AbstractOperator):
 
     def postprocess(self, data: Any, **kwargs: Any) -> Any:
         return data
+
+
+class DataFrameMarkerOperator(AbstractOperator):
+    """Adds a label to a DataFrame trace column and increments ``value``."""
+
+    def __init__(self, label: str, increment: int = 1) -> None:
+        super().__init__()
+        self.label = label
+        self.increment = increment
+
+    def preprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+    def process(self, data: Any, **kwargs: Any) -> Any:
+        out = data.copy()
+        out["value"] = out["value"] + self.increment
+        if "trace" not in out.columns:
+            out["trace"] = [self.label for _ in range(len(out.index))]
+        else:
+            out["trace"] = out["trace"].astype(str) + f">{self.label}"
+        return out
+
+    def postprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+
+class FusionPageElementsOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "page_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = True
+
+
+class FusionOCROperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "ocr"
+    fusion_next_stage_ids = ()
+    fusion_can_start_segment = False
 
 
 class ParamsHolderOperator(AbstractOperator):
@@ -1070,3 +1107,86 @@ class TestInprocessExecutor:
 
         assert isinstance(result, pd.DataFrame)
         assert result["val"].iloc[0] == 13
+
+
+def _build_fusable_dataframe_graph() -> Graph:
+    graph = Graph()
+    graph.add_chain(
+        Node(
+            DataFrameMarkerOperator("extract", increment=1),
+            name="PDFExtractionActor",
+            operator_class=DataFrameMarkerOperator,
+            operator_kwargs={"label": "extract", "increment": 1},
+        ),
+        Node(
+            FusionPageElementsOperator("page", increment=2),
+            name="PageElementDetectionActor",
+            operator_class=FusionPageElementsOperator,
+            operator_kwargs={"label": "page", "increment": 2},
+        ),
+        Node(
+            FusionOCROperator("ocr", increment=4),
+            name="OCRActor",
+            operator_class=FusionOCROperator,
+            operator_kwargs={"label": "ocr", "increment": 4},
+        ),
+    )
+    return graph
+
+
+class TestFusionCompiler:
+    def test_compile_graph_for_fusion_collapses_eligible_segment(self):
+        graph = _build_fusable_dataframe_graph()
+        overrides = {
+            "PageElementDetectionActor": {
+                "batch_size": 8,
+                "target_num_rows_per_block": 8,
+                "concurrency": 3,
+                "num_cpus": 1.0,
+                "num_gpus": 0.1,
+            },
+            "OCRActor": {
+                "batch_size": 4,
+                "target_num_rows_per_block": 4,
+                "concurrency": 2,
+                "num_cpus": 2.0,
+                "num_gpus": 0.2,
+            },
+        }
+
+        compiled = compile_graph_for_fusion(graph, enable_fusion=True, node_overrides=overrides)
+        nodes = InprocessExecutor._linearize(compiled.graph)
+
+        assert [node.name for node in nodes] == [
+            "PDFExtractionActor",
+            "Fused[PageElementDetectionActor+OCRActor]",
+        ]
+        assert nodes[1].operator_class is FusedOperator
+        assert compiled.fusion_summary["applied"] is True
+        assert compiled.fusion_summary["compiled_stage_count"] == 2
+        assert compiled.fusion_summary["fused_segments"] == [
+            {
+                "name": "Fused[PageElementDetectionActor+OCRActor]",
+                "stage_names": ["PageElementDetectionActor", "OCRActor"],
+                "operator_classes": ["FusionPageElementsOperator", "FusionOCROperator"],
+                "stage_count": 2,
+                "aggregated_overrides": {
+                    "batch_size": 4,
+                    "target_num_rows_per_block": 4,
+                    "concurrency": 2,
+                    "num_cpus": 2.0,
+                    "num_gpus": pytest.approx(0.3),
+                },
+            }
+        ]
+
+    def test_inprocess_executor_preserves_dataframe_results_with_fusion(self):
+        data = pd.DataFrame({"value": [10]})
+        graph = _build_fusable_dataframe_graph()
+
+        baseline = InprocessExecutor(graph, enable_fusion=False, show_progress=False).ingest(data.copy())
+        fused = InprocessExecutor(graph, enable_fusion=True, show_progress=False).ingest(data.copy())
+
+        assert baseline.to_dict("records") == fused.to_dict("records")
+        assert fused["value"].iloc[0] == 17
+        assert fused["trace"].iloc[0] == "extract>page>ocr"

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -101,8 +101,20 @@ class DataFrameMarkerOperator(AbstractOperator):
 
 class FusionPageElementsOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
     fusion_stage_id = "page_elements"
-    fusion_next_stage_ids = ("ocr",)
+    fusion_next_stage_ids = ("table_structure", "graphic_elements", "ocr")
     fusion_can_start_segment = True
+
+
+class FusionTableStructureOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "table_structure"
+    fusion_next_stage_ids = ("graphic_elements", "ocr")
+    fusion_can_start_segment = False
+
+
+class FusionGraphicElementsOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "graphic_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = False
 
 
 class FusionOCROperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
@@ -1134,6 +1146,43 @@ def _build_fusable_dataframe_graph() -> Graph:
     return graph
 
 
+def _build_extended_fusable_dataframe_graph() -> Graph:
+    graph = Graph()
+    graph.add_chain(
+        Node(
+            DataFrameMarkerOperator("extract", increment=1),
+            name="PDFExtractionActor",
+            operator_class=DataFrameMarkerOperator,
+            operator_kwargs={"label": "extract", "increment": 1},
+        ),
+        Node(
+            FusionPageElementsOperator("page", increment=2),
+            name="PageElementDetectionActor",
+            operator_class=FusionPageElementsOperator,
+            operator_kwargs={"label": "page", "increment": 2},
+        ),
+        Node(
+            FusionTableStructureOperator("table", increment=8),
+            name="TableStructureActor",
+            operator_class=FusionTableStructureOperator,
+            operator_kwargs={"label": "table", "increment": 8},
+        ),
+        Node(
+            FusionGraphicElementsOperator("graphic", increment=16),
+            name="GraphicElementsActor",
+            operator_class=FusionGraphicElementsOperator,
+            operator_kwargs={"label": "graphic", "increment": 16},
+        ),
+        Node(
+            FusionOCROperator("ocr", increment=4),
+            name="OCRActor",
+            operator_class=FusionOCROperator,
+            operator_kwargs={"label": "ocr", "increment": 4},
+        ),
+    )
+    return graph
+
+
 class TestFusionCompiler:
     def test_compile_graph_for_fusion_collapses_eligible_segment(self):
         graph = _build_fusable_dataframe_graph()
@@ -1179,6 +1228,84 @@ class TestFusionCompiler:
                 },
             }
         ]
+
+    def test_compile_graph_for_fusion_collapses_extended_linear_segment(self):
+        graph = _build_extended_fusable_dataframe_graph()
+        overrides = {
+            "PageElementDetectionActor": {
+                "batch_size": 16,
+                "target_num_rows_per_block": 16,
+                "concurrency": 4,
+                "num_cpus": 1.0,
+                "num_gpus": 0.1,
+            },
+            "TableStructureActor": {
+                "batch_size": 8,
+                "target_num_rows_per_block": 8,
+                "concurrency": 3,
+                "num_cpus": 1.5,
+                "num_gpus": 0.1,
+            },
+            "GraphicElementsActor": {
+                "batch_size": 6,
+                "target_num_rows_per_block": 6,
+                "concurrency": 2,
+                "num_cpus": 1.25,
+                "num_gpus": 0.1,
+            },
+            "OCRActor": {
+                "batch_size": 4,
+                "target_num_rows_per_block": 4,
+                "concurrency": 2,
+                "num_cpus": 2.0,
+                "num_gpus": 0.2,
+            },
+        }
+
+        compiled = compile_graph_for_fusion(graph, enable_fusion=True, node_overrides=overrides)
+        nodes = InprocessExecutor._linearize(compiled.graph)
+
+        assert [node.name for node in nodes] == [
+            "PDFExtractionActor",
+            "Fused[PageElementDetectionActor+TableStructureActor+GraphicElementsActor+OCRActor]",
+        ]
+        assert nodes[1].operator_class is FusedOperator
+        assert compiled.fusion_summary["applied"] is True
+        assert compiled.fusion_summary["compiled_stage_count"] == 2
+        assert compiled.fusion_summary["fused_segments"] == [
+            {
+                "name": "Fused[PageElementDetectionActor+TableStructureActor+GraphicElementsActor+OCRActor]",
+                "stage_names": [
+                    "PageElementDetectionActor",
+                    "TableStructureActor",
+                    "GraphicElementsActor",
+                    "OCRActor",
+                ],
+                "operator_classes": [
+                    "FusionPageElementsOperator",
+                    "FusionTableStructureOperator",
+                    "FusionGraphicElementsOperator",
+                    "FusionOCROperator",
+                ],
+                "stage_count": 4,
+                "aggregated_overrides": {
+                    "batch_size": 4,
+                    "target_num_rows_per_block": 4,
+                    "concurrency": 2,
+                    "num_cpus": 2.0,
+                    "num_gpus": pytest.approx(0.5),
+                },
+            }
+        ]
+
+    def test_inprocess_executor_preserves_dataframe_results_with_extended_fusion(self):
+        data = pd.DataFrame({"value": [10]})
+        graph = _build_extended_fusable_dataframe_graph()
+
+        baseline = InprocessExecutor(graph, enable_fusion=False).ingest(data.copy())
+        fused = InprocessExecutor(graph, enable_fusion=True).ingest(data.copy())
+
+        pd.testing.assert_frame_equal(fused, baseline)
 
     def test_inprocess_executor_preserves_dataframe_results_with_fusion(self):
         data = pd.DataFrame({"value": [10]})

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -4,6 +4,8 @@
 
 """Unit tests for Node, Graph, >> chaining (including auto-wrap), and Executors."""
 
+import sys
+from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import pandas as pd
@@ -121,6 +123,46 @@ class FusionOCROperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
     fusion_stage_id = "ocr"
     fusion_next_stage_ids = ()
     fusion_can_start_segment = False
+
+
+class FusionWrappedFailureOperator(ProcessOnlyFusionSafe, AbstractOperator):
+    fusion_stage_id = "page_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = True
+
+    def preprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+    def process(self, data: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("wrapped boom")
+
+    def postprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+    def __call__(self, data: Any, **kwargs: Any) -> Any:
+        try:
+            return self.run(data, **kwargs)
+        except RuntimeError as exc:
+            out = data.copy()
+            out["wrapped_error"] = [str(exc) for _ in range(len(out.index))]
+            return out
+
+
+class FusionWrapperObserverOperator(ProcessOnlyFusionSafe, AbstractOperator):
+    fusion_stage_id = "ocr"
+    fusion_next_stage_ids = ()
+    fusion_can_start_segment = False
+
+    def preprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+    def process(self, data: Any, **kwargs: Any) -> Any:
+        out = data.copy()
+        out["wrapper_seen"] = out["wrapped_error"].fillna("missing")
+        return out
+
+    def postprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
 
 
 class ParamsHolderOperator(AbstractOperator):
@@ -936,6 +978,7 @@ class TestRayDataExecutor:
 
         monkeypatch.setitem(sys.modules, "ray", fake_ray)
         monkeypatch.setitem(sys.modules, "ray.data", fake_ray_data)
+
         monkeypatch.setattr(
             "nemo_retriever.graph.executor.gather_cluster_resources",
             lambda ray: SimpleNamespace(available_gpu_count=lambda: 0),
@@ -948,6 +991,68 @@ class TestRayDataExecutor:
         assert isinstance(result, _FakeDataset)
         assert captured["paths"] == [str(pdf_path)]
         assert captured["include_paths"] is True
+
+    def test_ingest_fused_operator_preserves_stage_call_wrappers(self, monkeypatch):
+        graph = Graph()
+        graph.add_chain(
+            Node(
+                FusionWrappedFailureOperator(),
+                name="PageElementDetectionActor",
+                operator_class=FusionWrappedFailureOperator,
+                operator_kwargs={},
+            ),
+            Node(
+                FusionWrapperObserverOperator(),
+                name="OCRActor",
+                operator_class=FusionWrapperObserverOperator,
+                operator_kwargs={},
+            ),
+        )
+
+        class _FakeRayDataset:
+            def __init__(self, df: pd.DataFrame) -> None:
+                self.df = df
+                self.map_calls: list[type[AbstractOperator]] = []
+
+            def map_batches(self, operator_class, *, fn_constructor_kwargs=None, **kwargs):
+                del kwargs
+                self.map_calls.append(operator_class)
+                operator = operator_class(**(fn_constructor_kwargs or {}))
+                self.df = operator(self.df)
+                return self
+
+            def materialize(self):
+                return self
+
+        fake_context = SimpleNamespace(enable_rich_progress_bars=None, use_ray_tqdm=None)
+        fake_ray_module = ModuleType("ray")
+        fake_ray_data_module = ModuleType("ray.data")
+
+        class _FakeDataContext:
+            @staticmethod
+            def get_current():
+                return fake_context
+
+        fake_ray_data_module.Dataset = _FakeRayDataset
+        fake_ray_data_module.DataContext = _FakeDataContext
+        fake_ray_module.data = fake_ray_data_module
+        fake_ray_module.is_initialized = lambda: True
+        fake_ray_module.init = lambda **kwargs: None
+
+        monkeypatch.setitem(sys.modules, "ray", fake_ray_module)
+        monkeypatch.setitem(sys.modules, "ray.data", fake_ray_data_module)
+        monkeypatch.setattr(
+            "nemo_retriever.graph.executor.gather_cluster_resources",
+            lambda ray: SimpleNamespace(available_gpu_count=lambda: 0),
+        )
+        monkeypatch.setattr("nemo_retriever.graph.executor.resolve_graph", lambda graph, cluster: graph)
+
+        dataset = _FakeRayDataset(pd.DataFrame({"value": [1]}))
+        result = RayDataExecutor(graph, enable_fusion=True).ingest(dataset)
+
+        assert result.map_calls == [FusedOperator]
+        assert result.df["wrapped_error"].tolist() == ["wrapped boom"]
+        assert result.df["wrapper_seen"].tolist() == ["wrapped boom"]
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from nemo_retriever.graph.abstract_operator import AbstractOperator
+from nemo_retriever.graph.fusion import FusedOperator, ProcessOnlyFusionSafe, compile_graph_for_fusion
 from nemo_retriever.graph.operator_archetype import ArchetypeOperator
 from nemo_retriever.graph import FileListLoaderOperator, MultiTypeExtractOperator, UDFOperator
 from nemo_retriever.graph.cpu_operator import CPUOperator
@@ -72,6 +73,42 @@ class AppendOperator(AbstractOperator):
 
     def postprocess(self, data: Any, **kwargs: Any) -> Any:
         return data
+
+
+class DataFrameMarkerOperator(AbstractOperator):
+    """Adds a label to a DataFrame trace column and increments ``value``."""
+
+    def __init__(self, label: str, increment: int = 1) -> None:
+        super().__init__()
+        self.label = label
+        self.increment = increment
+
+    def preprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+    def process(self, data: Any, **kwargs: Any) -> Any:
+        out = data.copy()
+        out["value"] = out["value"] + self.increment
+        if "trace" not in out.columns:
+            out["trace"] = [self.label for _ in range(len(out.index))]
+        else:
+            out["trace"] = out["trace"].astype(str) + f">{self.label}"
+        return out
+
+    def postprocess(self, data: Any, **kwargs: Any) -> Any:
+        return data
+
+
+class FusionPageElementsOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "page_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = True
+
+
+class FusionOCROperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "ocr"
+    fusion_next_stage_ids = ()
+    fusion_can_start_segment = False
 
 
 class ParamsHolderOperator(AbstractOperator):
@@ -1153,3 +1190,86 @@ class TestInprocessExecutor:
 
         assert isinstance(result, pd.DataFrame)
         assert result["val"].iloc[0] == 13
+
+
+def _build_fusable_dataframe_graph() -> Graph:
+    graph = Graph()
+    graph.add_chain(
+        Node(
+            DataFrameMarkerOperator("extract", increment=1),
+            name="PDFExtractionActor",
+            operator_class=DataFrameMarkerOperator,
+            operator_kwargs={"label": "extract", "increment": 1},
+        ),
+        Node(
+            FusionPageElementsOperator("page", increment=2),
+            name="PageElementDetectionActor",
+            operator_class=FusionPageElementsOperator,
+            operator_kwargs={"label": "page", "increment": 2},
+        ),
+        Node(
+            FusionOCROperator("ocr", increment=4),
+            name="OCRActor",
+            operator_class=FusionOCROperator,
+            operator_kwargs={"label": "ocr", "increment": 4},
+        ),
+    )
+    return graph
+
+
+class TestFusionCompiler:
+    def test_compile_graph_for_fusion_collapses_eligible_segment(self):
+        graph = _build_fusable_dataframe_graph()
+        overrides = {
+            "PageElementDetectionActor": {
+                "batch_size": 8,
+                "target_num_rows_per_block": 8,
+                "concurrency": 3,
+                "num_cpus": 1.0,
+                "num_gpus": 0.1,
+            },
+            "OCRActor": {
+                "batch_size": 4,
+                "target_num_rows_per_block": 4,
+                "concurrency": 2,
+                "num_cpus": 2.0,
+                "num_gpus": 0.2,
+            },
+        }
+
+        compiled = compile_graph_for_fusion(graph, enable_fusion=True, node_overrides=overrides)
+        nodes = InprocessExecutor._linearize(compiled.graph)
+
+        assert [node.name for node in nodes] == [
+            "PDFExtractionActor",
+            "Fused[PageElementDetectionActor+OCRActor]",
+        ]
+        assert nodes[1].operator_class is FusedOperator
+        assert compiled.fusion_summary["applied"] is True
+        assert compiled.fusion_summary["compiled_stage_count"] == 2
+        assert compiled.fusion_summary["fused_segments"] == [
+            {
+                "name": "Fused[PageElementDetectionActor+OCRActor]",
+                "stage_names": ["PageElementDetectionActor", "OCRActor"],
+                "operator_classes": ["FusionPageElementsOperator", "FusionOCROperator"],
+                "stage_count": 2,
+                "aggregated_overrides": {
+                    "batch_size": 4,
+                    "target_num_rows_per_block": 4,
+                    "concurrency": 2,
+                    "num_cpus": 2.0,
+                    "num_gpus": pytest.approx(0.3),
+                },
+            }
+        ]
+
+    def test_inprocess_executor_preserves_dataframe_results_with_fusion(self):
+        data = pd.DataFrame({"value": [10]})
+        graph = _build_fusable_dataframe_graph()
+
+        baseline = InprocessExecutor(graph, enable_fusion=False, show_progress=False).ingest(data.copy())
+        fused = InprocessExecutor(graph, enable_fusion=True, show_progress=False).ingest(data.copy())
+
+        assert baseline.to_dict("records") == fused.to_dict("records")
+        assert fused["value"].iloc[0] == 17
+        assert fused["trace"].iloc[0] == "extract>page>ocr"

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -101,8 +101,20 @@ class DataFrameMarkerOperator(AbstractOperator):
 
 class FusionPageElementsOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
     fusion_stage_id = "page_elements"
-    fusion_next_stage_ids = ("ocr",)
+    fusion_next_stage_ids = ("table_structure", "graphic_elements", "ocr")
     fusion_can_start_segment = True
+
+
+class FusionTableStructureOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "table_structure"
+    fusion_next_stage_ids = ("graphic_elements", "ocr")
+    fusion_can_start_segment = False
+
+
+class FusionGraphicElementsOperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
+    fusion_stage_id = "graphic_elements"
+    fusion_next_stage_ids = ("ocr",)
+    fusion_can_start_segment = False
 
 
 class FusionOCROperator(ProcessOnlyFusionSafe, DataFrameMarkerOperator):
@@ -1217,6 +1229,43 @@ def _build_fusable_dataframe_graph() -> Graph:
     return graph
 
 
+def _build_extended_fusable_dataframe_graph() -> Graph:
+    graph = Graph()
+    graph.add_chain(
+        Node(
+            DataFrameMarkerOperator("extract", increment=1),
+            name="PDFExtractionActor",
+            operator_class=DataFrameMarkerOperator,
+            operator_kwargs={"label": "extract", "increment": 1},
+        ),
+        Node(
+            FusionPageElementsOperator("page", increment=2),
+            name="PageElementDetectionActor",
+            operator_class=FusionPageElementsOperator,
+            operator_kwargs={"label": "page", "increment": 2},
+        ),
+        Node(
+            FusionTableStructureOperator("table", increment=8),
+            name="TableStructureActor",
+            operator_class=FusionTableStructureOperator,
+            operator_kwargs={"label": "table", "increment": 8},
+        ),
+        Node(
+            FusionGraphicElementsOperator("graphic", increment=16),
+            name="GraphicElementsActor",
+            operator_class=FusionGraphicElementsOperator,
+            operator_kwargs={"label": "graphic", "increment": 16},
+        ),
+        Node(
+            FusionOCROperator("ocr", increment=4),
+            name="OCRActor",
+            operator_class=FusionOCROperator,
+            operator_kwargs={"label": "ocr", "increment": 4},
+        ),
+    )
+    return graph
+
+
 class TestFusionCompiler:
     def test_compile_graph_for_fusion_collapses_eligible_segment(self):
         graph = _build_fusable_dataframe_graph()
@@ -1262,6 +1311,84 @@ class TestFusionCompiler:
                 },
             }
         ]
+
+    def test_compile_graph_for_fusion_collapses_extended_linear_segment(self):
+        graph = _build_extended_fusable_dataframe_graph()
+        overrides = {
+            "PageElementDetectionActor": {
+                "batch_size": 16,
+                "target_num_rows_per_block": 16,
+                "concurrency": 4,
+                "num_cpus": 1.0,
+                "num_gpus": 0.1,
+            },
+            "TableStructureActor": {
+                "batch_size": 8,
+                "target_num_rows_per_block": 8,
+                "concurrency": 3,
+                "num_cpus": 1.5,
+                "num_gpus": 0.1,
+            },
+            "GraphicElementsActor": {
+                "batch_size": 6,
+                "target_num_rows_per_block": 6,
+                "concurrency": 2,
+                "num_cpus": 1.25,
+                "num_gpus": 0.1,
+            },
+            "OCRActor": {
+                "batch_size": 4,
+                "target_num_rows_per_block": 4,
+                "concurrency": 2,
+                "num_cpus": 2.0,
+                "num_gpus": 0.2,
+            },
+        }
+
+        compiled = compile_graph_for_fusion(graph, enable_fusion=True, node_overrides=overrides)
+        nodes = InprocessExecutor._linearize(compiled.graph)
+
+        assert [node.name for node in nodes] == [
+            "PDFExtractionActor",
+            "Fused[PageElementDetectionActor+TableStructureActor+GraphicElementsActor+OCRActor]",
+        ]
+        assert nodes[1].operator_class is FusedOperator
+        assert compiled.fusion_summary["applied"] is True
+        assert compiled.fusion_summary["compiled_stage_count"] == 2
+        assert compiled.fusion_summary["fused_segments"] == [
+            {
+                "name": "Fused[PageElementDetectionActor+TableStructureActor+GraphicElementsActor+OCRActor]",
+                "stage_names": [
+                    "PageElementDetectionActor",
+                    "TableStructureActor",
+                    "GraphicElementsActor",
+                    "OCRActor",
+                ],
+                "operator_classes": [
+                    "FusionPageElementsOperator",
+                    "FusionTableStructureOperator",
+                    "FusionGraphicElementsOperator",
+                    "FusionOCROperator",
+                ],
+                "stage_count": 4,
+                "aggregated_overrides": {
+                    "batch_size": 4,
+                    "target_num_rows_per_block": 4,
+                    "concurrency": 2,
+                    "num_cpus": 2.0,
+                    "num_gpus": pytest.approx(0.5),
+                },
+            }
+        ]
+
+    def test_inprocess_executor_preserves_dataframe_results_with_extended_fusion(self):
+        data = pd.DataFrame({"value": [10]})
+        graph = _build_extended_fusable_dataframe_graph()
+
+        baseline = InprocessExecutor(graph, enable_fusion=False).ingest(data.copy())
+        fused = InprocessExecutor(graph, enable_fusion=True).ingest(data.copy())
+
+        pd.testing.assert_frame_equal(fused, baseline)
 
     def test_inprocess_executor_preserves_dataframe_results_with_fusion(self):
         data = pd.DataFrame({"value": [10]})


### PR DESCRIPTION
## Summary

This draft introduces graph fusion as an internal compile-time optimizer for the graph pipeline. Fusion remains behind `enable_fusion`; public execution modes stay `batch` and `inprocess`.

The current draft:

- adds `FusedOperator` and compile-time graph rewriting for eligible linear chains
- adds the `ProcessOnlyFusionSafe` contract for process-level fusion legality
- wires `enable_fusion` through the graph executor, graph ingestor, example CLI, and harness
- removes stale public `run_mode="fused"` surface so the API matches the actual execution model
- adds explicit `ray_object_store_memory_bytes` plumbing for large-run Ray comparisons
- qualifies page-elements, table-structure, graphic-elements, and OCR actors for wider linear fusion when present
- fixes harness forwarding for table/graphic extraction flags so widened-chain experiments actually exercise the intended graph shape
- adds focused compiler/executor/harness tests and widened-chain structural tests

## Why This Shape

Fusion is implemented as an optimizer, not a new runtime backend.

- `batch` and `inprocess` remain the execution backends
- `enable_fusion` compiles the graph into a more efficient plan when legal
- eligible chains are replaced with an internal synthetic node such as `Fused[PageElementDetectionActor+OCRActor]`
- legality is explicit and capability-driven rather than inferred from stage names

This follows the standard pattern used by dataflow systems and compilers:

- Flink operator chaining
- Beam fusion
- TensorRT build-time optimization
- XLA / OpenXLA fusion
- TVM fusion passes

## Validation

Focused test coverage:

- `tests/test_pipeline_graph.py`
- `tests/test_harness_config.py`
- `tests/test_harness_run.py`

Validated results:

- `bo20`, `dgx_8gpu`, `embed_batch_size=32`
- median ingest improved from `52.45s` to `37.79s` with PE->OCR fusion
- semantics matched on pages, rows, and detection summary

- `bo767`, `dgx_8gpu`, `embed_batch_size=32`, `ray_object_store_memory_bytes=1000000000000`
- baseline ingest: `371.90s`
- fused ingest: `319.88s`
- pages and rows matched

## Still In Draft

This PR stays draft because:

- the widened table/graphic-qualified chain has structural coverage but still needs its real baseline/fused harness validation pair
- the long quiet post-ingest recall/writeout tail is a separate dev-experience issue and is not resolved here

## Follow-Up

Next validation steps:

- run `bo20` baseline/fused with `use_table_structure=true` and `use_graphic_elements=true`
- if stable, repeat on `bo767`
- compare `fusion_summary`, ingest time, rows, pages, and detection/recall behavior
