### PR TITLE
Expose agentic retrieval via MCP and HTTP service endpoints

### DIFF
--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -70,6 +70,14 @@ curl -X POST http://localhost:7670/v1/agentic/query \
   -d '{"query": "find documents about parser behavior", "top_k": 5}'
 ```
 
+Agentic queries run on a small dedicated worker pool in the VectorDB process, so
+they cannot exhaust the capacity used by plain `/v1/query`. A ReAct run cannot be
+interrupted once started, so a worker stays occupied until it finishes even if
+the caller times out or disconnects. When every worker is busy the endpoint sheds
+load with `503` and a `Retry-After` header instead of queueing behind a
+multi-minute run. Queries are capped at 4096 characters to bound prompt size and
+cost across the multi-step loop.
+
 For local stdio-based agents, run the MCP server as a shim that points at an existing retriever service:
 
 ```bash

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -36,11 +36,15 @@ pipeline introspection, document ingestion, job status, VectorDB query, agentic
 retrieval, and answer generation. If service auth is enabled, the MCP endpoint
 uses the same bearer-token middleware as the REST API.
 
-Plain and agentic retrieval are separate tools:
+Plain and agentic retrieval share `POST /v1/query` and the same hits response
+envelope. They are separate MCP tools so agents can choose explicitly:
 
-- `query` calls `POST /v1/query` for one-pass dense or hybrid retrieval.
-- `agentic_query` calls `POST /v1/agentic/query` and runs the existing ReAct
+- `query` calls `POST /v1/query` with `agentic=false` for one-pass dense or hybrid retrieval.
+- `agentic_query` calls `POST /v1/query` with `agentic=true` and runs the ReAct
   retrieval workflow. It is added to MCP when `agentic.enabled` is true.
+  Agentic results are document-level: `source` is the selected `doc_id`,
+  `metadata` carries `result_source` and `rank`, and chunk-level fields
+  (`text`, `page_number`, scores, …) are unset.
 
 Enable agentic retrieval in `retriever-service.yaml`:
 
@@ -62,21 +66,22 @@ from the service process environment. Service mode requires remote
 OpenAI-compatible LLM and embedding endpoints; local in-process models remain
 available through the one-shot CLI and harness paths.
 
-REST clients can call the same boundary directly:
+REST clients set the flag on `/v1/query`:
 
 ```bash
-curl -X POST http://localhost:7670/v1/agentic/query \
+curl -X POST http://localhost:7670/v1/query \
   -H 'Content-Type: application/json' \
-  -d '{"query": "find documents about parser behavior", "top_k": 5}'
+  -d '{"query": "find documents about parser behavior", "top_k": 5, "agentic": true}'
 ```
 
-Agentic queries run on a small dedicated worker pool in the VectorDB process, so
-they cannot exhaust the capacity used by plain `/v1/query`. A ReAct run cannot be
-interrupted once started, so a worker stays occupied until it finishes even if
-the caller times out or disconnects. When every worker is busy the endpoint sheds
-load with `503` and a `Retry-After` header instead of queueing behind a
-multi-minute run. Queries are capped at 4096 characters to bound prompt size and
-cost across the multi-step loop.
+Requests with `agentic: true` return HTTP `400` when agentic retrieval is not
+configured on the service. Agentic runs use a small dedicated worker pool in the
+VectorDB process so they cannot exhaust the capacity used by plain queries. A
+ReAct run cannot be interrupted once started, so a worker stays occupied until
+it finishes even if the caller times out or disconnects. When every worker is
+busy the endpoint sheds load with `503` and a `Retry-After` header instead of
+queueing behind a multi-minute run. Agentic queries are capped at 4096
+characters to bound prompt size and cost across the multi-step loop.
 
 For local stdio-based agents, run the MCP server as a shim that points at an existing retriever service:
 

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -30,13 +30,52 @@ retriever query "find documents about parser behavior" \
 
 ## MCP access for agents
 
-`retriever service start` mounts a FastMCP HTTP endpoint at `/mcp` by default. Agents can use that endpoint to call the running service for health checks, pipeline introspection, document ingestion, job status, VectorDB query, and answer generation. If service auth is enabled, the MCP endpoint uses the same bearer-token middleware as the REST API.
+`retriever service start` mounts a FastMCP HTTP endpoint at `/mcp` by default.
+Agents can use that endpoint to call the running service for health checks,
+pipeline introspection, document ingestion, job status, VectorDB query, agentic
+retrieval, and answer generation. If service auth is enabled, the MCP endpoint
+uses the same bearer-token middleware as the REST API.
+
+Plain and agentic retrieval are separate tools:
+
+- `query` calls `POST /v1/query` for one-pass dense or hybrid retrieval.
+- `agentic_query` calls `POST /v1/agentic/query` and runs the existing ReAct
+  retrieval workflow. It is added to MCP when `agentic.enabled` is true.
+
+Enable agentic retrieval in `retriever-service.yaml`:
+
+```yaml
+agentic:
+  enabled: true
+  llm_model: your-openai-compatible-model
+  invoke_url: https://your-llm.example/v1/chat/completions
+  reasoning_effort: high
+  backend_top_k: 20
+  react_max_steps: 50
+  request_timeout_s: 1800
+```
+
+The VectorDB process owns the LanceDB volume and executes the agentic workflow.
+Start it with matching `--agentic`, `--agentic-llm-model`, and
+`--agentic-invoke-url` options. The LLM and embedding credentials are resolved
+from the service process environment. Service mode requires remote
+OpenAI-compatible LLM and embedding endpoints; local in-process models remain
+available through the one-shot CLI and harness paths.
+
+REST clients can call the same boundary directly:
+
+```bash
+curl -X POST http://localhost:7670/v1/agentic/query \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "find documents about parser behavior", "top_k": 5}'
+```
 
 For local stdio-based agents, run the MCP server as a shim that points at an existing retriever service:
 
 ```bash
 retriever service mcp-stdio \
   --service-url http://localhost:7670 \
+  --agentic-query \
   --api-token "$NEMO_RETRIEVER_API_TOKEN"
 ```
 

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -331,6 +331,10 @@ The retriever service picks up the in-cluster ASR endpoint when `nimOperator.aud
 | `serviceConfig.llm.model`                           | `""` | Optional explicit LiteLLM model id. Leave empty to inherit `nimOperator.answer_llm.model` when using the operator-managed answer LLM; set it for external endpoints. |
 | `serviceConfig.llm.ragSystemPromptPrefix`           | `""` | Optional explicit RAG prompt prefix. Leave empty unless an endpoint needs model-specific prompt directives. |
 | `serviceConfig.llm.reasoningEnabled`               | `true` | Request-level reasoning toggle for `/v1/answer`. Defaults to true for external OpenAI-compatible providers; set false for Nemotron endpoints that should receive portable no-reasoning controls. |
+| `serviceConfig.agentic.enabled`                    | `false` | Enables `POST /v1/agentic/query` and the additive `agentic_query` MCP tool. |
+| `serviceConfig.agentic.llmModel`                   | `""` | Chat model used by the inner agentic retrieval loop. Required when `invokeUrl` is set. |
+| `serviceConfig.agentic.invokeUrl`                  | `""` | OpenAI-compatible chat completions endpoint used by agentic retrieval. |
+| `serviceConfig.agentic.requestTimeoutS`            | `1800` | Gateway and MCP timeout for the multi-step agentic retrieval call. |
 | `serviceConfig.vectordb.enabled`                  | `true`  | Deploy the LanceDB vectordb Pod. When `true` the chart **requires** a resolvable embed endpoint (refer to [VectorDB and the embed endpoint](#vectordb-and-the-embed-endpoint)); `helm install` / `helm upgrade` fails fast otherwise. |
 | `serviceConfig.vectordb.lancedbUri`               | `/data/vectordb` | LanceDB on the vectordb Pod's PVC. |
 | `serviceConfig.vectordb.embedModel`               | `nvidia/llama-nemotron-embed-vl-1b-v2` | Passed to vectordb + worker `embed_model_name`. |

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -331,7 +331,7 @@ The retriever service picks up the in-cluster ASR endpoint when `nimOperator.aud
 | `serviceConfig.llm.model`                           | `""` | Optional explicit LiteLLM model id. Leave empty to inherit `nimOperator.answer_llm.model` when using the operator-managed answer LLM; set it for external endpoints. |
 | `serviceConfig.llm.ragSystemPromptPrefix`           | `""` | Optional explicit RAG prompt prefix. Leave empty unless an endpoint needs model-specific prompt directives. |
 | `serviceConfig.llm.reasoningEnabled`               | `true` | Request-level reasoning toggle for `/v1/answer`. Defaults to true for external OpenAI-compatible providers; set false for Nemotron endpoints that should receive portable no-reasoning controls. |
-| `serviceConfig.agentic.enabled`                    | `false` | Enables `POST /v1/agentic/query` and the additive `agentic_query` MCP tool. |
+| `serviceConfig.agentic.enabled`                    | `false` | Enables `POST /v1/query` with `agentic=true` and the additive `agentic_query` MCP tool. |
 | `serviceConfig.agentic.llmModel`                   | `""` | Chat model used by the inner agentic retrieval loop. Required when `invokeUrl` is set. |
 | `serviceConfig.agentic.invokeUrl`                  | `""` | OpenAI-compatible chat completions endpoint used by agentic retrieval. |
 | `serviceConfig.agentic.requestTimeoutS`            | `1800` | Gateway and MCP timeout for the multi-step agentic retrieval call. |

--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -135,6 +135,17 @@ llm:
   rag_system_prompt_prefix: {{ if .llmRagSystemPromptPrefix }}{{ .llmRagSystemPromptPrefix | quote }}{{ else }}null{{ end }}
   reasoning_enabled: {{ .Values.serviceConfig.llm.reasoningEnabled }}
 
+agentic:
+  enabled: {{ .Values.serviceConfig.agentic.enabled }}
+  llm_model: {{ if .Values.serviceConfig.agentic.llmModel }}{{ .Values.serviceConfig.agentic.llmModel | quote }}{{ else }}null{{ end }}
+  invoke_url: {{ if .Values.serviceConfig.agentic.invokeUrl }}{{ .Values.serviceConfig.agentic.invokeUrl | quote }}{{ else }}null{{ end }}
+  reasoning_effort: {{ if .Values.serviceConfig.agentic.reasoningEffort }}{{ .Values.serviceConfig.agentic.reasoningEffort | quote }}{{ else }}null{{ end }}
+  backend_top_k: {{ .Values.serviceConfig.agentic.backendTopK }}
+  react_max_steps: {{ .Values.serviceConfig.agentic.reactMaxSteps }}
+  text_truncation: {{ .Values.serviceConfig.agentic.textTruncation }}
+  temperature: {{ .Values.serviceConfig.agentic.temperature }}
+  request_timeout_s: {{ .Values.serviceConfig.agentic.requestTimeoutS }}
+
 pipeline:
   realtime_workers: {{ .Values.serviceConfig.pipeline.realtimeWorkers }}
   realtime_queue_size: {{ .Values.serviceConfig.pipeline.realtimeQueueSize }}

--- a/nemo_retriever/helm/templates/deployment-vectordb.yaml
+++ b/nemo_retriever/helm/templates/deployment-vectordb.yaml
@@ -6,6 +6,7 @@
 {{- $embedURL := include "nemo-retriever.nim.endpointURL" (dict "context" . "key" "vlm_embed" "serviceName" .Values.nimOperator.vlm_embed.nimServiceName "configKey" "embedInvokeUrl" "invokePath" "/v1/embeddings") -}}
 {{- $localEmbed := include "nemo-retriever.localEmbed.enabled" . | eq "true" -}}
 {{- $localModels := .Values.serviceConfig.localModels -}}
+{{- $agentic := .Values.serviceConfig.agentic -}}
 {{- /*
   Fail-fast guard: rendering a vectordb Deployment without any query-time
   embedding backend produces a "healthy" Pod whose first /v1/query request
@@ -99,6 +100,31 @@ spec:
             - --embed-model-provider-prefix
             - {{ .Values.serviceConfig.vectordb.embedModelProviderPrefix | quote }}
             {{- end }}
+            {{- if $agentic.enabled }}
+            - --agentic
+            {{- if $agentic.llmModel }}
+            - --agentic-llm-model
+            - {{ $agentic.llmModel | quote }}
+            {{- end }}
+            {{- if $agentic.invokeUrl }}
+            - --agentic-invoke-url
+            - {{ $agentic.invokeUrl | quote }}
+            {{- end }}
+            {{- if $agentic.reasoningEffort }}
+            - --agentic-reasoning-effort
+            - {{ $agentic.reasoningEffort | quote }}
+            {{- end }}
+            - --agentic-backend-top-k
+            - {{ $agentic.backendTopK | quote }}
+            - --agentic-react-max-steps
+            - {{ $agentic.reactMaxSteps | quote }}
+            - --agentic-text-truncation
+            - {{ $agentic.textTruncation | quote }}
+            - --agentic-temperature
+            - {{ $agentic.temperature | quote }}
+            - --agentic-request-timeout
+            - {{ $agentic.requestTimeoutS | quote }}
+            {{- end }}
             - --port
             - {{ $vdb.port | quote }}
             {{- if $embedURL }}
@@ -110,7 +136,7 @@ spec:
               containerPort: {{ $vdb.port }}
               protocol: TCP
           env:
-            {{- if $embedURL }}
+            {{- if or $embedURL (and $agentic.enabled $agentic.invokeUrl) }}
             - name: NVIDIA_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -641,6 +641,20 @@ serviceConfig:
     # portable no-reasoning controls.
     reasoningEnabled: true
 
+  # Agentic (ReAct) retrieval exposed as POST /v1/agentic/query and the
+  # agentic_query MCP tool. The LLM runs inside the vectordb pod because that
+  # pod owns the LanceDB volume.
+  agentic:
+    enabled: false
+    llmModel: ""
+    invokeUrl: ""
+    reasoningEffort: high
+    backendTopK: 20
+    reactMaxSteps: 50
+    textTruncation: 0
+    temperature: 0.0
+    requestTimeoutS: 1800.0
+
   # Pipeline worker pools.  Workers are abstract dispatchers — sizing
   # depends on whether they do local GPU work or fan out to remote NIMs.
   # For CPU-only NIM-forwarding nodes, higher worker counts are fine.

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -641,7 +641,7 @@ serviceConfig:
     # portable no-reasoning controls.
     reasoningEnabled: true
 
-  # Agentic (ReAct) retrieval exposed as POST /v1/agentic/query and the
+  # Agentic (ReAct) retrieval exposed as POST /v1/query with agentic=true and the
   # agentic_query MCP tool. The LLM runs inside the vectordb pod because that
   # pod owns the LanceDB volume.
   agentic:

--- a/nemo_retriever/src/nemo_retriever/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/query/options.py
@@ -26,6 +26,7 @@ class QueryEmbedOptions:
     embed_invoke_url: str | None = None
     embed_model_name: str | None = None
     embed_model_provider_prefix: str | None = None
+    embed_api_key: str | None = None
 
 
 @dataclass(frozen=True)

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -163,7 +163,7 @@ def build_agentic_config(request: QueryRequest, *, top_k: int | None = None) -> 
     """
     from nemo_retriever.query.agentic import AgenticRetrievalConfig
 
-    api_key = resolve_remote_api_key()
+    api_key = resolve_remote_api_key(request.embed.embed_api_key)
     vdb_kwargs: dict[str, Any] = {"uri": request.storage.lancedb_uri, "table_name": request.storage.table_name}
     if request.retrieval.retrieval_mode != "auto":
         vdb_kwargs["retrieval_mode"] = request.retrieval.retrieval_mode

--- a/nemo_retriever/src/nemo_retriever/service/agentic_query.py
+++ b/nemo_retriever/src/nemo_retriever/service/agentic_query.py
@@ -2,25 +2,57 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Service boundary for the existing in-process agentic retrieval workflow."""
+"""Service boundary for in-process agentic retrieval over the VectorDB query API."""
 
 from __future__ import annotations
+
+from typing import Any
 
 from nemo_retriever.query.options import (
     QueryAgenticOptions,
     QueryEmbedOptions,
-    QueryRequest,
+    QueryRequest as WorkflowQueryRequest,
     QueryRetrievalOptions,
     QueryStorageOptions,
 )
 from nemo_retriever.query.workflow import agentic_query_documents
 from nemo_retriever.service.config import AgenticConfig
-from nemo_retriever.service.query_schema import AgenticQueryRequest, AgenticQueryResponse
+from nemo_retriever.service.query_schema import QueryResponse, QueryResult
+
+
+def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Map agentic document ranks onto the ``/v1/query`` hits envelope.
+
+    Agentic retrieval selects documents (``doc_id``), not chunks. Each hit places
+    ``doc_id`` in ``source``, records ``result_source`` / ``rank`` under
+    ``metadata``, and leaves chunk-level fields (``text``, ``page_number``,
+    scores, …) unset.
+    """
+    hits: list[dict[str, Any]] = []
+    for item in ranked:
+        doc_id = str(item.get("doc_id") or "") or None
+        hits.append(
+            {
+                "text": None,
+                "metadata": {
+                    "result_source": item.get("result_source"),
+                    "rank": item.get("rank"),
+                },
+                "source": doc_id,
+                "source_id": None,
+                "path": None,
+                "page_number": None,
+                "pdf_basename": None,
+                "pdf_page": None,
+            }
+        )
+    return hits
 
 
 def build_agentic_query_request(
-    request: AgenticQueryRequest,
     *,
+    query: str,
+    top_k: int,
     config: AgenticConfig,
     lancedb_uri: str,
     table_name: str,
@@ -28,11 +60,11 @@ def build_agentic_query_request(
     embed_model: str,
     embed_model_provider_prefix: str | None,
     embed_api_key: str,
-) -> QueryRequest:
+) -> WorkflowQueryRequest:
     """Map server-owned service settings onto the shared agentic query request."""
-    return QueryRequest(
-        query=request.query,
-        retrieval=QueryRetrievalOptions(top_k=request.top_k),
+    return WorkflowQueryRequest(
+        query=query,
+        retrieval=QueryRetrievalOptions(top_k=top_k),
         embed=QueryEmbedOptions(
             embed_invoke_url=embed_endpoint or None,
             embed_model_name=embed_model or None,
@@ -57,8 +89,9 @@ def build_agentic_query_request(
 
 
 def run_agentic_query(
-    request: AgenticQueryRequest,
     *,
+    query: str,
+    top_k: int,
     config: AgenticConfig,
     lancedb_uri: str,
     table_name: str,
@@ -66,10 +99,11 @@ def run_agentic_query(
     embed_model: str,
     embed_model_provider_prefix: str | None,
     embed_api_key: str,
-) -> AgenticQueryResponse:
-    """Execute one agentic retrieval query without changing agent internals."""
+) -> QueryResponse:
+    """Execute one agentic retrieval query and return ``QueryResponse`` hits."""
     query_request = build_agentic_query_request(
-        request,
+        query=query,
+        top_k=top_k,
         config=config,
         lancedb_uri=lancedb_uri,
         table_name=table_name,
@@ -78,4 +112,5 @@ def run_agentic_query(
         embed_model_provider_prefix=embed_model_provider_prefix,
         embed_api_key=embed_api_key,
     )
-    return AgenticQueryResponse(results=agentic_query_documents(query_request))
+    ranked = agentic_query_documents(query_request)
+    return QueryResponse(results=[QueryResult(hits=agentic_ranked_to_hits(ranked))])

--- a/nemo_retriever/src/nemo_retriever/service/agentic_query.py
+++ b/nemo_retriever/src/nemo_retriever/service/agentic_query.py
@@ -27,10 +27,19 @@ def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]
     ``doc_id`` in ``source``, records ``result_source`` / ``rank`` under
     ``metadata``, and leaves chunk-level fields (``text``, ``page_number``,
     scores, …) unset.
+
+    Rows without a non-empty ``doc_id`` are a contract violation: the agentic
+    workflow already skips blank ids on retrieve hops, and a hit with
+    ``source=null`` is useless to clients. Raise rather than emit a null source.
     """
     hits: list[dict[str, Any]] = []
     for item in ranked:
-        doc_id = str(item.get("doc_id") or "") or None
+        doc_id = str(item.get("doc_id") or "").strip()
+        if not doc_id:
+            raise ValueError(
+                "agentic ranked result is missing a non-empty doc_id "
+                f"(rank={item.get('rank')!r}, result_source={item.get('result_source')!r})"
+            )
         hits.append(
             {
                 "text": None,

--- a/nemo_retriever/src/nemo_retriever/service/agentic_query.py
+++ b/nemo_retriever/src/nemo_retriever/service/agentic_query.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service boundary for the existing in-process agentic retrieval workflow."""
+
+from __future__ import annotations
+
+from nemo_retriever.query.options import (
+    QueryAgenticOptions,
+    QueryEmbedOptions,
+    QueryRequest,
+    QueryRetrievalOptions,
+    QueryStorageOptions,
+)
+from nemo_retriever.query.workflow import agentic_query_documents
+from nemo_retriever.service.config import AgenticConfig
+from nemo_retriever.service.query_schema import AgenticQueryRequest, AgenticQueryResponse
+
+
+def build_agentic_query_request(
+    request: AgenticQueryRequest,
+    *,
+    config: AgenticConfig,
+    lancedb_uri: str,
+    table_name: str,
+    embed_endpoint: str,
+    embed_model: str,
+    embed_model_provider_prefix: str | None,
+    embed_api_key: str,
+) -> QueryRequest:
+    """Map server-owned service settings onto the shared agentic query request."""
+    return QueryRequest(
+        query=request.query,
+        retrieval=QueryRetrievalOptions(top_k=request.top_k),
+        embed=QueryEmbedOptions(
+            embed_invoke_url=embed_endpoint or None,
+            embed_model_name=embed_model or None,
+            embed_model_provider_prefix=embed_model_provider_prefix,
+            embed_api_key=embed_api_key or None,
+        ),
+        storage=QueryStorageOptions(
+            lancedb_uri=lancedb_uri,
+            table_name=table_name,
+        ),
+        agentic=QueryAgenticOptions(
+            enabled=True,
+            llm_model=config.llm_model,
+            invoke_url=config.invoke_url,
+            reasoning_effort=config.reasoning_effort,
+            backend_top_k=config.backend_top_k,
+            react_max_steps=config.react_max_steps,
+            text_truncation=config.text_truncation,
+            temperature=config.temperature,
+        ),
+    )
+
+
+def run_agentic_query(
+    request: AgenticQueryRequest,
+    *,
+    config: AgenticConfig,
+    lancedb_uri: str,
+    table_name: str,
+    embed_endpoint: str,
+    embed_model: str,
+    embed_model_provider_prefix: str | None,
+    embed_api_key: str,
+) -> AgenticQueryResponse:
+    """Execute one agentic retrieval query without changing agent internals."""
+    query_request = build_agentic_query_request(
+        request,
+        config=config,
+        lancedb_uri=lancedb_uri,
+        table_name=table_name,
+        embed_endpoint=embed_endpoint,
+        embed_model=embed_model,
+        embed_model_provider_prefix=embed_model_provider_prefix,
+        embed_api_key=embed_api_key,
+    )
+    return AgenticQueryResponse(results=agentic_query_documents(query_request))

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -157,6 +157,17 @@ def mcp_stdio(
     ),
     concurrency: int = typer.Option(8, "--concurrency", min=1, help="Max concurrent MCP document uploads."),
     request_timeout_s: float = typer.Option(60.0, "--request-timeout", min=0.1, help="HTTP request timeout."),
+    enable_agentic_query: bool = typer.Option(
+        False,
+        "--agentic-query/--no-agentic-query",
+        help="Expose the agentic_query MCP tool.",
+    ),
+    agentic_request_timeout_s: float = typer.Option(
+        1800.0,
+        "--agentic-request-timeout",
+        min=1.0,
+        help="HTTP timeout for agentic_query.",
+    ),
     ingest_timeout_s: float = typer.Option(1800.0, "--ingest-timeout", min=1.0, help="Document ingest timeout."),
     poll_interval_s: float = typer.Option(2.0, "--poll-interval", min=0.1, help="Status polling interval."),
     enable_write_tools: bool = typer.Option(
@@ -174,8 +185,10 @@ def mcp_stdio(
         auth_header_name=auth_header_name,
         max_concurrency=concurrency,
         request_timeout_s=request_timeout_s,
+        agentic_request_timeout_s=agentic_request_timeout_s,
         ingest_timeout_s=ingest_timeout_s,
         poll_interval_s=poll_interval_s,
         enable_write_tools=enable_write_tools,
+        enable_agentic_query=enable_agentic_query,
     )
     build_mcp(settings).run(transport="stdio")

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -227,6 +227,30 @@ class LLMConfig(RichModel):
         return self
 
 
+class AgenticConfig(RichModel):
+    """Server-owned configuration for agentic (ReAct) retrieval queries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    llm_model: str | None = None
+    invoke_url: str | None = None
+    reasoning_effort: str | None = "high"
+    backend_top_k: int = Field(default=20, ge=1)
+    react_max_steps: int = Field(default=50, ge=1)
+    text_truncation: int = Field(default=0, ge=0)
+    temperature: float = Field(default=0.0, ge=0.0)
+    request_timeout_s: float = Field(default=1800.0, gt=0)
+
+    @model_validator(mode="after")
+    def _validate_remote_model(self) -> "AgenticConfig":
+        if self.enabled and not (self.invoke_url or "").strip():
+            raise ValueError("agentic.invoke_url must be set when agentic.enabled is true")
+        if self.enabled and not (self.llm_model or "").strip():
+            raise ValueError("agentic.llm_model must be set when agentic.enabled is true")
+        return self
+
+
 class ResourceLimitsConfig(RichModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -480,6 +504,7 @@ class ServiceConfig(RichModel):
     nim_endpoints: NimEndpointsConfig = Field(default_factory=NimEndpointsConfig)
     local_models: LocalModelsConfig = Field(default_factory=LocalModelsConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
+    agentic: AgenticConfig = Field(default_factory=AgenticConfig)
     resources: ResourceLimitsConfig = Field(default_factory=ResourceLimitsConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)

--- a/nemo_retriever/src/nemo_retriever/service/mcp_server.py
+++ b/nemo_retriever/src/nemo_retriever/service/mcp_server.py
@@ -222,10 +222,11 @@ class ServiceMCPClient:
         *,
         top_k: int = 5,
     ) -> dict[str, Any]:
+        """Call ``POST /v1/query`` with ``agentic=true`` (long timeout)."""
         async with self._client(timeout_s=self._settings.agentic_request_timeout_s) as client:
             resp = await client.post(
-                "/v1/agentic/query",
-                json={"query": query, "top_k": top_k},
+                "/v1/query",
+                json={"query": query, "top_k": top_k, "format": "hits", "agentic": True},
             )
         self._raise_for_status(resp)
         return dict(self._json_or_text(resp))
@@ -528,7 +529,9 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
             name="agentic_query",
             description=(
                 "Run the configured agentic (ReAct) retrieval workflow over ingested "
-                "documents and return ranked document IDs."
+                "documents via POST /v1/query with agentic=true. Returns the standard "
+                "hits envelope: source holds doc_id; result_source and rank are under "
+                "metadata; chunk-level fields are unset for document-level results."
             ),
         )
         async def agentic_query(query: str, top_k: int = 5) -> dict[str, Any]:

--- a/nemo_retriever/src/nemo_retriever/service/mcp_server.py
+++ b/nemo_retriever/src/nemo_retriever/service/mcp_server.py
@@ -77,9 +77,11 @@ class ServiceMCPSettings:
     auth_header_name: str = "Authorization"
     max_concurrency: int = 8
     request_timeout_s: float = 60.0
+    agentic_request_timeout_s: float = 1800.0
     ingest_timeout_s: float = 1800.0
     poll_interval_s: float = 2.0
     enable_write_tools: bool = True
+    enable_agentic_query: bool = False
 
     @property
     def normalized_base_url(self) -> str:
@@ -111,9 +113,11 @@ def settings_from_service_config(config: ServiceConfig) -> ServiceMCPSettings:
         auth_header_name=config.auth.header_name,
         max_concurrency=mcp_cfg.max_concurrency,
         request_timeout_s=mcp_cfg.request_timeout_s,
+        agentic_request_timeout_s=config.agentic.request_timeout_s,
         ingest_timeout_s=mcp_cfg.ingest_timeout_s,
         poll_interval_s=mcp_cfg.poll_interval_s,
         enable_write_tools=mcp_cfg.enable_write_tools,
+        enable_agentic_query=config.agentic.enabled,
     )
 
 
@@ -209,6 +213,20 @@ class ServiceMCPClient:
         body.setdefault("format", format)
         async with self._client() as client:
             resp = await client.post("/v1/query", json=body)
+        self._raise_for_status(resp)
+        return dict(self._json_or_text(resp))
+
+    async def agentic_query(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+    ) -> dict[str, Any]:
+        async with self._client(timeout_s=self._settings.agentic_request_timeout_s) as client:
+            resp = await client.post(
+                "/v1/agentic/query",
+                json={"query": query, "top_k": top_k},
+            )
         self._raise_for_status(resp)
         return dict(self._json_or_text(resp))
 
@@ -448,7 +466,8 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
         instructions=(
             "Use these tools to interact with a running NVIDIA NeMo Retriever "
             "service. Ingest documents, check job status, query the configured "
-            "VectorDB, and ask the configured answer-generation endpoint."
+            "VectorDB, run agentic retrieval when configured, and ask the "
+            "configured answer-generation endpoint."
         ),
     )
 
@@ -502,6 +521,18 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
         payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         return await service.query(query, top_k=top_k, format=format, payload=payload)
+
+    if settings.enable_agentic_query:
+
+        @mcp.tool(
+            name="agentic_query",
+            description=(
+                "Run the configured agentic (ReAct) retrieval workflow over ingested "
+                "documents and return ranked document IDs."
+            ),
+        )
+        async def agentic_query(query: str, top_k: int = 5) -> dict[str, Any]:
+            return await service.agentic_query(query, top_k=top_k)
 
     @mcp.tool(name="answer", description="Search ingested documents and generate an answer.")
     async def answer(

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -36,6 +36,23 @@ class QueryResponse(BaseModel):
         return [result.hits for result in self.results]
 
 
+class AgenticQueryRequest(BaseModel):
+    """One query for the server-configured agentic retrieval pipeline."""
+
+    query: str = Field(min_length=1)
+    top_k: int = Field(default=5, ge=1, le=1000)
+
+
+class AgenticQueryResult(BaseModel):
+    rank: int
+    doc_id: str
+    result_source: str
+
+
+class AgenticQueryResponse(BaseModel):
+    results: list[AgenticQueryResult]
+
+
 class Locator(BaseModel):
     """Where an evidence item lives in its source (page / segment / timestamp / bbox)."""
 

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 QueryFormat = Literal["hits", "evidence"]
 
@@ -23,9 +23,34 @@ class QueryRequest(BaseModel):
         default="hits",
         description=(
             "Output shape: 'hits' (default) returns raw retrieval hits; 'evidence' "
-            "returns the fidelity-tagged, citation-ready {evidence, coverage} shape."
+            "returns the fidelity-tagged, citation-ready {evidence, coverage} shape. "
+            "Agentic queries require format='hits'."
         ),
     )
+    agentic: bool = Field(
+        default=False,
+        description=(
+            "When true, run the server-configured agentic (ReAct) retrieval workflow. "
+            "Requires agentic.enabled in service configuration. Response uses the same "
+            "hits envelope as dense/hybrid query; document-level agentic results map "
+            "doc_id onto source, keep result_source/rank in metadata, and leave "
+            "chunk-level fields unset (null)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_agentic_request(self) -> "QueryRequest":
+        if not self.agentic:
+            return self
+        if not isinstance(self.query, str):
+            raise ValueError("agentic queries require a single query string, not a list")
+        if not self.query.strip():
+            raise ValueError("agentic query must be a non-empty string")
+        if len(self.query) > MAX_AGENTIC_QUERY_CHARS:
+            raise ValueError(f"agentic query exceeds max length of {MAX_AGENTIC_QUERY_CHARS} characters")
+        if self.format != "hits":
+            raise ValueError("agentic queries require format='hits'")
+        return self
 
 
 class QueryResult(BaseModel):
@@ -39,23 +64,6 @@ class QueryResponse(BaseModel):
         if expected_results is not None and len(self.results) != expected_results:
             raise ValueError(f"expected {expected_results} result set(s), got {len(self.results)}")
         return [result.hits for result in self.results]
-
-
-class AgenticQueryRequest(BaseModel):
-    """One query for the server-configured agentic retrieval pipeline."""
-
-    query: str = Field(min_length=1, max_length=MAX_AGENTIC_QUERY_CHARS)
-    top_k: int = Field(default=5, ge=1, le=1000)
-
-
-class AgenticQueryResult(BaseModel):
-    rank: int
-    doc_id: str
-    result_source: str
-
-
-class AgenticQueryResponse(BaseModel):
-    results: list[AgenticQueryResult]
 
 
 class Locator(BaseModel):

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -10,6 +10,11 @@ from pydantic import BaseModel, Field
 
 QueryFormat = Literal["hits", "evidence"]
 
+# Agentic queries are replayed into every step of a multi-step LLM loop, so an
+# oversized query multiplies prompt cost and latency. Roughly 1k tokens of
+# natural-language question is far above any realistic retrieval query.
+MAX_AGENTIC_QUERY_CHARS = 4096
+
 
 class QueryRequest(BaseModel):
     query: str | list[str]
@@ -39,7 +44,7 @@ class QueryResponse(BaseModel):
 class AgenticQueryRequest(BaseModel):
     """One query for the server-configured agentic retrieval pipeline."""
 
-    query: str = Field(min_length=1)
+    query: str = Field(min_length=1, max_length=MAX_AGENTIC_QUERY_CHARS)
     top_k: int = Field(default=5, ge=1, le=1000)
 
 

--- a/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
+++ b/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
@@ -97,6 +97,20 @@ llm:
   rag_system_prompt_prefix: null
   reasoning_enabled: true
 
+# Agentic (ReAct) retrieval exposed through POST /v1/agentic/query and the
+# agentic_query MCP tool. Service mode requires a remote OpenAI-compatible
+# invoke_url and llm_model when enabled.
+agentic:
+  enabled: false
+  llm_model: null
+  invoke_url: null
+  reasoning_effort: high
+  backend_top_k: 20
+  react_max_steps: 50
+  text_truncation: 0
+  temperature: 0.0
+  request_timeout_s: 1800.0
+
 # Pipeline worker pools.  Workers are abstract dispatchers — sizing
 # depends on whether they do local GPU work or fan out to remote NIMs.
 # For CPU-only NIM-forwarding nodes, higher worker counts are fine.

--- a/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
+++ b/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
@@ -97,7 +97,7 @@ llm:
   rag_system_prompt_prefix: null
   reasoning_enabled: true
 
-# Agentic (ReAct) retrieval exposed through POST /v1/agentic/query and the
+# Agentic (ReAct) retrieval exposed through POST /v1/query with agentic=true and the
 # agentic_query MCP tool. Service mode requires a remote OpenAI-compatible
 # invoke_url and llm_model when enabled.
 agentic:

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -1643,20 +1643,25 @@ async def answer(req: ServiceAnswerRequest, request: Request) -> Response | Answ
 
 
 # ------------------------------------------------------------------
-# POST /v1/query  — vector search (proxied to vectordb pod)
+# POST /v1/query  — vector search / agentic retrieval (proxied to vectordb)
 # ------------------------------------------------------------------
 
 
 @router.post(
     "/query",
-    summary="Search ingested documents by semantic similarity or hybrid retrieval",
+    summary="Search ingested documents by semantic similarity, hybrid, or agentic retrieval",
 )
 async def query(request: Request) -> Response:
     """Proxy a query request to the VectorDB service.
 
     * **gateway / standalone** — forwards the JSON body to the vectordb pod.
     * **worker** — returns 404 (workers don't handle queries).
+
+    When the body sets ``agentic: true``, the long agentic timeout is used and
+    the service must have agentic retrieval configured.
     """
+    import json
+
     import httpx
 
     config = request.app.state.config
@@ -1678,9 +1683,26 @@ async def query(request: Request) -> Response:
     target = f"{vectordb_url}/v1/query"
 
     body = await request.body()
+    agentic = False
+    try:
+        parsed = json.loads(body.decode("utf-8") if isinstance(body, (bytes, bytearray)) else body)
+        agentic = bool(parsed.get("agentic")) if isinstance(parsed, dict) else False
+    except (UnicodeDecodeError, json.JSONDecodeError, AttributeError, TypeError):
+        agentic = False
+
+    if agentic and not config.agentic.enabled:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Agentic retrieval is not enabled in the service configuration. "
+                "Set agentic.enabled with llm_model and invoke_url."
+            ),
+        )
+
+    timeout = config.agentic.request_timeout_s if agentic else 60.0
 
     try:
-        async with httpx.AsyncClient(timeout=60.0) as client:
+        async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.post(
                 target,
                 content=body,
@@ -1688,63 +1710,6 @@ async def query(request: Request) -> Response:
             )
     except Exception as exc:
         logger.exception("Failed to proxy query to vectordb at %s", target)
-        raise HTTPException(
-            status_code=502,
-            detail=f"Failed to reach VectorDB service: {type(exc).__name__}: {exc}",
-        )
-
-    return Response(
-        content=resp.content,
-        status_code=resp.status_code,
-        media_type="application/json",
-    )
-
-
-# ------------------------------------------------------------------
-# POST /v1/agentic/query — agentic retrieval (proxied to vectordb pod)
-# ------------------------------------------------------------------
-
-
-@router.post(
-    "/agentic/query",
-    summary="Search ingested documents with the configured agentic retrieval workflow",
-)
-async def agentic_query(request: Request) -> Response:
-    """Proxy an agentic query request to the VectorDB service."""
-    import httpx
-
-    config = request.app.state.config
-
-    if not config.vectordb.enabled:
-        raise HTTPException(
-            status_code=404,
-            detail="VectorDB is not enabled in the service configuration.",
-        )
-    if not config.agentic.enabled:
-        raise HTTPException(
-            status_code=404,
-            detail="Agentic retrieval is not enabled in the service configuration.",
-        )
-
-    mode = _mode(request)
-    if mode in ("realtime", "batch"):
-        raise HTTPException(
-            status_code=404,
-            detail="Agentic query endpoint is not available on worker pods. Use the gateway.",
-        )
-
-    target = f"{config.vectordb.vectordb_url.rstrip('/')}/v1/agentic/query"
-    body = await request.body()
-
-    try:
-        async with httpx.AsyncClient(timeout=config.agentic.request_timeout_s) as client:
-            resp = await client.post(
-                target,
-                content=body,
-                headers={"Content-Type": "application/json"},
-            )
-    except Exception as exc:
-        logger.exception("Failed to proxy agentic query to vectordb at %s", target)
         raise HTTPException(
             status_code=502,
             detail=f"Failed to reach VectorDB service: {type(exc).__name__}: {exc}",

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -1701,6 +1701,63 @@ async def query(request: Request) -> Response:
 
 
 # ------------------------------------------------------------------
+# POST /v1/agentic/query — agentic retrieval (proxied to vectordb pod)
+# ------------------------------------------------------------------
+
+
+@router.post(
+    "/agentic/query",
+    summary="Search ingested documents with the configured agentic retrieval workflow",
+)
+async def agentic_query(request: Request) -> Response:
+    """Proxy an agentic query request to the VectorDB service."""
+    import httpx
+
+    config = request.app.state.config
+
+    if not config.vectordb.enabled:
+        raise HTTPException(
+            status_code=404,
+            detail="VectorDB is not enabled in the service configuration.",
+        )
+    if not config.agentic.enabled:
+        raise HTTPException(
+            status_code=404,
+            detail="Agentic retrieval is not enabled in the service configuration.",
+        )
+
+    mode = _mode(request)
+    if mode in ("realtime", "batch"):
+        raise HTTPException(
+            status_code=404,
+            detail="Agentic query endpoint is not available on worker pods. Use the gateway.",
+        )
+
+    target = f"{config.vectordb.vectordb_url.rstrip('/')}/v1/agentic/query"
+    body = await request.body()
+
+    try:
+        async with httpx.AsyncClient(timeout=config.agentic.request_timeout_s) as client:
+            resp = await client.post(
+                target,
+                content=body,
+                headers={"Content-Type": "application/json"},
+            )
+    except Exception as exc:
+        logger.exception("Failed to proxy agentic query to vectordb at %s", target)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to reach VectorDB service: {type(exc).__name__}: {exc}",
+        )
+
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type="application/json",
+    )
+
+
+# ------------------------------------------------------------------
 # GET /v1/internal/document-result/{id}  — gateway ← worker row cache
 # POST /v1/internal/job-callback  — worker → gateway completion hook
 # ------------------------------------------------------------------

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -4,10 +4,11 @@
 
 """Standalone VectorDB microservice backed by LanceDB.
 
-Provides three endpoints:
+Provides four endpoints:
 
 - ``POST /internal/vectordb/write`` -- append embedding rows from ingest workers
 - ``POST /v1/query``               -- embed query text and search the index
+- ``POST /v1/agentic/query``       -- run the ReAct retrieval workflow (opt-in)
 - ``GET  /v1/health``              -- liveness probe
 
 Run with a remote NIM embed endpoint::
@@ -33,6 +34,7 @@ import argparse
 import asyncio
 import logging
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Union
 
@@ -337,8 +339,15 @@ class VectorDBState:
 
 _state: VectorDBState | None = None
 _query_semaphore: asyncio.Semaphore | None = None
+_agentic_executor: ThreadPoolExecutor | None = None
+_agentic_slots: threading.BoundedSemaphore | None = None
 
 MAX_CONCURRENT_QUERIES = 4
+
+# Agentic retrieval runs a multi-step ReAct loop that can occupy a thread for
+# minutes and cannot be interrupted once started, so it gets its own small pool
+# instead of sharing capacity with plain /v1/query.
+MAX_CONCURRENT_AGENTIC_QUERIES = 2
 
 
 def create_vectordb_app(
@@ -361,7 +370,7 @@ def create_vectordb_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        global _state, _query_semaphore
+        global _state, _query_semaphore, _agentic_executor, _agentic_slots
         _state = VectorDBState(
             lancedb_uri=lancedb_uri,
             table_name=table_name,
@@ -376,6 +385,12 @@ def create_vectordb_app(
             gpu_memory_utilization=gpu_memory_utilization,
         )
         _query_semaphore = asyncio.Semaphore(MAX_CONCURRENT_QUERIES)
+        if agentic_config.enabled:
+            _agentic_executor = ThreadPoolExecutor(
+                max_workers=MAX_CONCURRENT_AGENTIC_QUERIES,
+                thread_name_prefix="agentic-query",
+            )
+            _agentic_slots = threading.BoundedSemaphore(MAX_CONCURRENT_AGENTIC_QUERIES)
         logger.info(
             "VectorDB service started: uri=%s table=%s embed_mode=%s max_concurrent_queries=%d",
             lancedb_uri,
@@ -392,6 +407,12 @@ def create_vectordb_app(
         yield
         _state = None
         _query_semaphore = None
+        if _agentic_executor is not None:
+            # Detach from in-flight ReAct work rather than blocking shutdown on
+            # LLM calls that may still have minutes left on their timeout.
+            _agentic_executor.shutdown(wait=False, cancel_futures=True)
+            _agentic_executor = None
+        _agentic_slots = None
         logger.info("VectorDB service stopped")
 
     app = FastAPI(
@@ -509,19 +530,48 @@ def create_vectordb_app(
                 ),
             )
 
+        executor, slots = _agentic_executor, _agentic_slots
+        if executor is None or slots is None:
+            raise HTTPException(503, "Agentic retrieval workers are not running")
+
+        # The ReAct workflow is blocking and cannot be interrupted, so a caller
+        # that times out or disconnects does not free the worker. Admission is
+        # therefore tied to the worker's real lifetime: the slot is released from
+        # the future's done callback, never on request exit.
+        if not slots.acquire(blocking=False):
+            logger.warning(
+                "Rejecting agentic query: all %d agentic workers are busy",
+                MAX_CONCURRENT_AGENTIC_QUERIES,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    f"All {MAX_CONCURRENT_AGENTIC_QUERIES} agentic retrieval workers are busy. "
+                    "Retry once an in-flight query finishes."
+                ),
+                headers={"Retry-After": "30"},
+            )
+
         try:
-            async with _query_semaphore:
-                return await asyncio.to_thread(
-                    run_agentic_query,
-                    req,
-                    config=agentic_config,
-                    lancedb_uri=_state.lancedb_uri,
-                    table_name=_state.table_name,
-                    embed_endpoint=_state.embed_endpoint,
-                    embed_model=_state.embed_model,
-                    embed_model_provider_prefix=_state.embed_model_provider_prefix,
-                    embed_api_key=_state.embed_api_key,
-                )
+            future = executor.submit(
+                run_agentic_query,
+                req,
+                config=agentic_config,
+                lancedb_uri=_state.lancedb_uri,
+                table_name=_state.table_name,
+                embed_endpoint=_state.embed_endpoint,
+                embed_model=_state.embed_model,
+                embed_model_provider_prefix=_state.embed_model_provider_prefix,
+                embed_api_key=_state.embed_api_key,
+            )
+        except RuntimeError as exc:
+            slots.release()
+            raise HTTPException(503, "VectorDB is shutting down") from exc
+
+        future.add_done_callback(lambda _future: slots.release())
+
+        try:
+            return await asyncio.wrap_future(future)
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -4,11 +4,10 @@
 
 """Standalone VectorDB microservice backed by LanceDB.
 
-Provides four endpoints:
+Provides three endpoints:
 
 - ``POST /internal/vectordb/write`` -- append embedding rows from ingest workers
-- ``POST /v1/query``               -- embed query text and search the index
-- ``POST /v1/agentic/query``       -- run the ReAct retrieval workflow (opt-in)
+- ``POST /v1/query``               -- embed+search, or agentic ReAct when ``agentic=true``
 - ``GET  /v1/health``              -- liveness probe
 
 Run with a remote NIM embed endpoint::
@@ -53,8 +52,6 @@ from nemo_retriever.query.evidence import build_evidence_result
 from nemo_retriever.service.agentic_query import run_agentic_query
 from nemo_retriever.service.config import AgenticConfig
 from nemo_retriever.service.query_schema import (
-    AgenticQueryRequest,
-    AgenticQueryResponse,
     EvidenceQueryResponse,
     EvidenceResult,
     QueryRequest,
@@ -461,6 +458,9 @@ def create_vectordb_app(
         if _state is None:
             raise HTTPException(503, "VectorDB not initialised")
 
+        if req.agentic:
+            return await _run_agentic_query(req)
+
         if _state.embed_mode == "none":
             raise HTTPException(
                 501,
@@ -499,10 +499,16 @@ def create_vectordb_app(
 
         return QueryResponse(results=[QueryResult(hits=hits) for hits in hits_per_query])
 
-    @app.post("/v1/agentic/query", response_model=AgenticQueryResponse, tags=["query"])
-    async def agentic_query(req: AgenticQueryRequest) -> AgenticQueryResponse:
+    async def _run_agentic_query(req: QueryRequest) -> QueryResponse:
         if not agentic_config.enabled:
-            raise HTTPException(status_code=404, detail="Agentic retrieval is not enabled.")
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Agentic retrieval is not enabled in the VectorDB configuration. "
+                    "Start with --agentic and a remote LLM invoke URL/model, or set "
+                    "agentic.enabled in the service config."
+                ),
+            )
         if _state is None:
             raise HTTPException(503, "VectorDB not initialised")
         if _state.embed_mode == "none":
@@ -514,7 +520,7 @@ def create_vectordb_app(
         if _state.embed_mode != "remote":
             raise HTTPException(
                 501,
-                "Agentic service queries currently require a remote embedding endpoint.",
+                "Agentic service queries require a remote embedding endpoint.",
             )
         if not _state.table_exists:
             raise HTTPException(
@@ -552,10 +558,12 @@ def create_vectordb_app(
                 headers={"Retry-After": "30"},
             )
 
+        assert isinstance(req.query, str)
         try:
             future = executor.submit(
                 run_agentic_query,
-                req,
+                query=req.query,
+                top_k=req.top_k,
                 config=agentic_config,
                 lancedb_uri=_state.lancedb_uri,
                 table_name=_state.table_name,
@@ -615,7 +623,7 @@ def main() -> None:
     parser.add_argument(
         "--agentic",
         action="store_true",
-        help="Enable POST /v1/agentic/query using the existing agentic retrieval workflow.",
+        help="Enable agentic=true on POST /v1/query using the agentic retrieval workflow.",
     )
     parser.add_argument("--agentic-llm-model", default="", help="Agentic retrieval chat model.")
     parser.add_argument(

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -48,7 +48,11 @@ from nemo_retriever.common.vdb.lancedb_capabilities import (
     inspect_lancedb_table_object,
 )
 from nemo_retriever.query.evidence import build_evidence_result
+from nemo_retriever.service.agentic_query import run_agentic_query
+from nemo_retriever.service.config import AgenticConfig
 from nemo_retriever.service.query_schema import (
+    AgenticQueryRequest,
+    AgenticQueryResponse,
     EvidenceQueryResponse,
     EvidenceResult,
     QueryRequest,
@@ -350,8 +354,10 @@ def create_vectordb_app(
     hf_cache_dir: str | None = None,
     device: str | None = None,
     gpu_memory_utilization: float = 0.45,
+    agentic_config: AgenticConfig | None = None,
 ) -> FastAPI:
     """Build the VectorDB FastAPI application."""
+    agentic_config = agentic_config or AgenticConfig()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -472,6 +478,53 @@ def create_vectordb_app(
 
         return QueryResponse(results=[QueryResult(hits=hits) for hits in hits_per_query])
 
+    @app.post("/v1/agentic/query", response_model=AgenticQueryResponse, tags=["query"])
+    async def agentic_query(req: AgenticQueryRequest) -> AgenticQueryResponse:
+        if not agentic_config.enabled:
+            raise HTTPException(status_code=404, detail="Agentic retrieval is not enabled.")
+        if _state is None:
+            raise HTTPException(503, "VectorDB not initialised")
+        if _state.embed_mode == "none":
+            raise HTTPException(
+                501,
+                "No embedding backend configured. Set --embed-endpoint for a remote "
+                "NIM or --local-embed for in-pod Hugging Face query embedding.",
+            )
+        if _state.embed_mode != "remote":
+            raise HTTPException(
+                501,
+                "Agentic service queries currently require a remote embedding endpoint.",
+            )
+        if not _state.table_exists:
+            raise HTTPException(
+                status_code=422,
+                detail="No data has been ingested yet. Ingest documents first, then query.",
+            )
+        if req.top_k > agentic_config.backend_top_k:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"top_k ({req.top_k}) cannot exceed the configured agentic "
+                    f"backend_top_k ({agentic_config.backend_top_k})."
+                ),
+            )
+
+        try:
+            async with _query_semaphore:
+                return await asyncio.to_thread(
+                    run_agentic_query,
+                    req,
+                    config=agentic_config,
+                    lancedb_uri=_state.lancedb_uri,
+                    table_name=_state.table_name,
+                    embed_endpoint=_state.embed_endpoint,
+                    embed_model=_state.embed_model,
+                    embed_model_provider_prefix=_state.embed_model_provider_prefix,
+                    embed_api_key=_state.embed_api_key,
+                )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
     return app
 
 
@@ -509,6 +562,23 @@ def main() -> None:
         default=0.45,
         help="vLLM GPU memory fraction when --local-embed-backend=vllm.",
     )
+    parser.add_argument(
+        "--agentic",
+        action="store_true",
+        help="Enable POST /v1/agentic/query using the existing agentic retrieval workflow.",
+    )
+    parser.add_argument("--agentic-llm-model", default="", help="Agentic retrieval chat model.")
+    parser.add_argument(
+        "--agentic-invoke-url",
+        default="",
+        help="OpenAI-compatible chat completions endpoint for agentic retrieval.",
+    )
+    parser.add_argument("--agentic-reasoning-effort", default="high")
+    parser.add_argument("--agentic-backend-top-k", type=int, default=20)
+    parser.add_argument("--agentic-react-max-steps", type=int, default=50)
+    parser.add_argument("--agentic-text-truncation", type=int, default=0)
+    parser.add_argument("--agentic-temperature", type=float, default=0.0)
+    parser.add_argument("--agentic-request-timeout", type=float, default=1800.0)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=7671)
     parser.add_argument("--log-level", default="info")
@@ -534,6 +604,17 @@ def main() -> None:
         hf_cache_dir=args.hf_cache_dir or None,
         device=args.device or None,
         gpu_memory_utilization=args.gpu_memory_utilization,
+        agentic_config=AgenticConfig(
+            enabled=args.agentic,
+            llm_model=args.agentic_llm_model or None,
+            invoke_url=args.agentic_invoke_url or None,
+            reasoning_effort=args.agentic_reasoning_effort or None,
+            backend_top_k=args.agentic_backend_top_k,
+            react_max_steps=args.agentic_react_max_steps,
+            text_truncation=args.agentic_text_truncation,
+            temperature=args.agentic_temperature,
+            request_timeout_s=args.agentic_request_timeout,
+        ),
     )
     uvicorn.run(app, host=args.host, port=args.port)
 

--- a/nemo_retriever/tests/test_service_agentic_query.py
+++ b/nemo_retriever/tests/test_service_agentic_query.py
@@ -22,6 +22,7 @@ from nemo_retriever.service.config import (
     VectorDbConfig,
 )
 from nemo_retriever.service.query_schema import (
+    MAX_AGENTIC_QUERY_CHARS,
     AgenticQueryRequest,
     AgenticQueryResponse,
     AgenticQueryResult,
@@ -157,6 +158,74 @@ def test_agentic_query_rejects_top_k_above_backend_depth(tmp_path) -> None:
 
     assert response.status_code == 422
     assert "cannot exceed" in response.json()["detail"]
+
+
+def test_agentic_query_rejects_query_above_length_limit(tmp_path) -> None:
+    app = create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        embed_endpoint="https://embed.example/v1/embeddings",
+        agentic_config=AgenticConfig(
+            enabled=True,
+            llm_model="model",
+            invoke_url="https://llm.example/v1/chat/completions",
+        ),
+    )
+
+    with (
+        patch.object(VectorDBState, "table_exists", new_callable=PropertyMock, return_value=True),
+        patch.object(vectordb_module, "run_agentic_query") as run_query,
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/agentic/query",
+            json={"query": "x" * (MAX_AGENTIC_QUERY_CHARS + 1)},
+        )
+
+    assert response.status_code == 422
+    run_query.assert_not_called()
+
+
+def test_agentic_query_slots_are_bounded_and_released_by_the_worker(tmp_path) -> None:
+    """Capacity follows the worker thread, not the caller: a saturated pool sheds
+    load with 503 instead of queueing behind non-cancellable ReAct work, and a
+    completed query returns its slot."""
+    app = create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        embed_endpoint="https://embed.example/v1/embeddings",
+        agentic_config=AgenticConfig(
+            enabled=True,
+            llm_model="model",
+            invoke_url="https://llm.example/v1/chat/completions",
+        ),
+    )
+    expected = AgenticQueryResponse(results=[])
+
+    with (
+        patch.object(VectorDBState, "table_exists", new_callable=PropertyMock, return_value=True),
+        patch.object(vectordb_module, "run_agentic_query", return_value=expected),
+        TestClient(app) as client,
+    ):
+        slots = vectordb_module._agentic_slots
+        assert slots is not None
+
+        # Stand in for in-flight workers whose callers have already gone away.
+        for _ in range(vectordb_module.MAX_CONCURRENT_AGENTIC_QUERIES):
+            assert slots.acquire(blocking=False) is True
+
+        busy = client.post("/v1/agentic/query", json={"query": "revenue trend"})
+
+        assert busy.status_code == 503
+        assert busy.headers["Retry-After"] == "30"
+        # Plain /v1/query capacity is untouched by agentic saturation.
+        assert vectordb_module._query_semaphore is not None
+        assert vectordb_module._query_semaphore.locked() is False
+
+        slots.release()
+        accepted = client.post("/v1/agentic/query", json={"query": "revenue trend"})
+
+        assert accepted.status_code == 200
+        # The worker released its own slot on completion.
+        assert slots.acquire(blocking=False) is True
 
 
 def test_service_proxies_agentic_query_to_vectordb(

--- a/nemo_retriever/tests/test_service_agentic_query.py
+++ b/nemo_retriever/tests/test_service_agentic_query.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+import nemo_retriever.service.vectordb_app as vectordb_module
+from nemo_retriever.service.app import create_app
+from nemo_retriever.service.agentic_query import build_agentic_query_request
+from nemo_retriever.service.config import (
+    AgenticConfig,
+    LoggingConfig,
+    PipelinePoolConfig,
+    ServiceConfig,
+    VectorDbConfig,
+)
+from nemo_retriever.service.query_schema import (
+    AgenticQueryRequest,
+    AgenticQueryResponse,
+    AgenticQueryResult,
+)
+from nemo_retriever.service.vectordb_app import VectorDBState, create_vectordb_app
+
+
+def test_agentic_service_config_requires_remote_model_and_endpoint() -> None:
+    with pytest.raises(ValidationError, match="agentic.invoke_url"):
+        AgenticConfig(enabled=True, llm_model="model")
+    with pytest.raises(ValidationError, match="agentic.llm_model"):
+        AgenticConfig(
+            enabled=True,
+            invoke_url="https://llm.example/v1/chat/completions",
+        )
+
+
+def test_build_agentic_query_request_maps_server_owned_configuration() -> None:
+    request = build_agentic_query_request(
+        AgenticQueryRequest(query="revenue trend", top_k=3),
+        config=AgenticConfig(
+            enabled=True,
+            llm_model="model",
+            invoke_url="https://llm.example/v1/chat/completions",
+            backend_top_k=25,
+            react_max_steps=7,
+        ),
+        lancedb_uri="/indexes/finance",
+        table_name="finance",
+        embed_endpoint="https://embed.example/v1/embeddings",
+        embed_model="embed-model",
+        embed_model_provider_prefix="openai",
+        embed_api_key="embed-key",
+    )
+
+    assert request.query == "revenue trend"
+    assert request.retrieval.top_k == 3
+    assert request.storage.lancedb_uri == "/indexes/finance"
+    assert request.storage.table_name == "finance"
+    assert request.embed.embed_invoke_url == "https://embed.example/v1/embeddings"
+    assert request.embed.embed_model_name == "embed-model"
+    assert request.embed.embed_model_provider_prefix == "openai"
+    assert request.embed.embed_api_key == "embed-key"
+    assert request.agentic.enabled is True
+    assert request.agentic.llm_model == "model"
+    assert request.agentic.invoke_url == "https://llm.example/v1/chat/completions"
+    assert request.agentic.backend_top_k == 25
+    assert request.agentic.react_max_steps == 7
+
+
+def test_agentic_query_endpoint_is_disabled_by_default(tmp_path) -> None:
+    app = create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        embed_endpoint="https://embed.example/v1/embeddings",
+    )
+
+    with TestClient(app) as client:
+        response = client.post("/v1/agentic/query", json={"query": "q"})
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Agentic retrieval is not enabled."
+
+
+def test_agentic_query_endpoint_runs_shared_workflow(tmp_path) -> None:
+    app = create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        table_name="finance",
+        embed_endpoint="https://embed.example/v1/embeddings",
+        embed_model="embed-model",
+        agentic_config=AgenticConfig(
+            enabled=True,
+            llm_model="model",
+            invoke_url="https://llm.example/v1/chat/completions",
+        ),
+    )
+    expected = AgenticQueryResponse(
+        results=[
+            AgenticQueryResult(
+                rank=1,
+                doc_id="report.pdf",
+                result_source="selection_agent",
+            )
+        ]
+    )
+
+    with (
+        patch.object(VectorDBState, "table_exists", new_callable=PropertyMock, return_value=True),
+        patch.object(vectordb_module, "run_agentic_query", return_value=expected) as run_query,
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/agentic/query",
+            json={"query": "revenue trend", "top_k": 3},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "results": [
+            {
+                "rank": 1,
+                "doc_id": "report.pdf",
+                "result_source": "selection_agent",
+            }
+        ]
+    }
+    request = run_query.call_args.args[0]
+    assert request == AgenticQueryRequest(query="revenue trend", top_k=3)
+    assert run_query.call_args.kwargs["lancedb_uri"] == str(tmp_path)
+    assert run_query.call_args.kwargs["table_name"] == "finance"
+    assert run_query.call_args.kwargs["embed_api_key"] == ""
+
+
+def test_agentic_query_rejects_top_k_above_backend_depth(tmp_path) -> None:
+    app = create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        embed_endpoint="https://embed.example/v1/embeddings",
+        agentic_config=AgenticConfig(
+            enabled=True,
+            llm_model="model",
+            invoke_url="https://llm.example/v1/chat/completions",
+            backend_top_k=5,
+        ),
+    )
+
+    with (
+        patch.object(VectorDBState, "table_exists", new_callable=PropertyMock, return_value=True),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/agentic/query",
+            json={"query": "revenue trend", "top_k": 6},
+        )
+
+    assert response.status_code == 422
+    assert "cannot exceed" in response.json()["detail"]
+
+
+def test_service_proxies_agentic_query_to_vectordb(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def _stub_work(_item):
+        return 0, []
+
+    monkeypatch.setattr(
+        "nemo_retriever.service.services.pipeline_executor.create_realtime_work_fn",
+        lambda _config: _stub_work,
+    )
+    monkeypatch.setattr(
+        "nemo_retriever.service.services.pipeline_executor.create_batch_work_fn",
+        lambda _config: _stub_work,
+    )
+    config = ServiceConfig(
+        mode="standalone",
+        logging=LoggingConfig(file=str(tmp_path / "service.log")),
+        pipeline=PipelinePoolConfig(realtime_workers=1, batch_workers=1),
+        vectordb=VectorDbConfig(
+            enabled=True,
+            vectordb_url="http://vectordb:7671",
+        ),
+        agentic=AgenticConfig(
+            enabled=True,
+            llm_model="model",
+            invoke_url="https://llm.example/v1/chat/completions",
+            request_timeout_s=321.0,
+        ),
+    )
+    seen: dict[str, object] = {}
+
+    class _FakeResponse:
+        status_code = 200
+        content = json.dumps({"results": []}).encode()
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            seen["timeout"] = kwargs["timeout"]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs) -> _FakeResponse:
+            seen["url"] = url
+            seen["body"] = json.loads(kwargs["content"])
+            return _FakeResponse()
+
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+
+    with TestClient(create_app(config)) as client:
+        response = client.post(
+            "/v1/agentic/query",
+            json={"query": "revenue trend", "top_k": 3},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"results": []}
+    assert seen == {
+        "timeout": 321.0,
+        "url": "http://vectordb:7671/v1/agentic/query",
+        "body": {"query": "revenue trend", "top_k": 3},
+    }

--- a/nemo_retriever/tests/test_service_agentic_query.py
+++ b/nemo_retriever/tests/test_service_agentic_query.py
@@ -13,7 +13,10 @@ from pydantic import ValidationError
 
 import nemo_retriever.service.vectordb_app as vectordb_module
 from nemo_retriever.service.app import create_app
-from nemo_retriever.service.agentic_query import build_agentic_query_request
+from nemo_retriever.service.agentic_query import (
+    agentic_ranked_to_hits,
+    build_agentic_query_request,
+)
 from nemo_retriever.service.config import (
     AgenticConfig,
     LoggingConfig,
@@ -23,9 +26,9 @@ from nemo_retriever.service.config import (
 )
 from nemo_retriever.service.query_schema import (
     MAX_AGENTIC_QUERY_CHARS,
-    AgenticQueryRequest,
-    AgenticQueryResponse,
-    AgenticQueryResult,
+    QueryRequest,
+    QueryResponse,
+    QueryResult,
 )
 from nemo_retriever.service.vectordb_app import VectorDBState, create_vectordb_app
 
@@ -40,9 +43,19 @@ def test_agentic_service_config_requires_remote_model_and_endpoint() -> None:
         )
 
 
+def test_query_request_agentic_requires_hits_format() -> None:
+    with pytest.raises(ValidationError, match="single query string"):
+        QueryRequest(query=["a", "b"], agentic=True)
+    with pytest.raises(ValidationError, match="non-empty"):
+        QueryRequest(query="   ", agentic=True)
+    with pytest.raises(ValidationError, match="format='hits'"):
+        QueryRequest(query="q", agentic=True, format="evidence")
+
+
 def test_build_agentic_query_request_maps_server_owned_configuration() -> None:
     request = build_agentic_query_request(
-        AgenticQueryRequest(query="revenue trend", top_k=3),
+        query="revenue trend",
+        top_k=3,
         config=AgenticConfig(
             enabled=True,
             llm_model="model",
@@ -73,20 +86,36 @@ def test_build_agentic_query_request_maps_server_owned_configuration() -> None:
     assert request.agentic.react_max_steps == 7
 
 
-def test_agentic_query_endpoint_is_disabled_by_default(tmp_path) -> None:
+def test_agentic_ranked_to_hits_maps_doc_id_onto_query_hit_envelope() -> None:
+    hits = agentic_ranked_to_hits([{"rank": 1, "doc_id": "report.pdf", "result_source": "selection_agent"}])
+    assert hits == [
+        {
+            "text": None,
+            "metadata": {"result_source": "selection_agent", "rank": 1},
+            "source": "report.pdf",
+            "source_id": None,
+            "path": None,
+            "page_number": None,
+            "pdf_basename": None,
+            "pdf_page": None,
+        }
+    ]
+
+
+def test_agentic_query_flag_rejected_when_disabled(tmp_path) -> None:
     app = create_vectordb_app(
         lancedb_uri=str(tmp_path),
         embed_endpoint="https://embed.example/v1/embeddings",
     )
 
     with TestClient(app) as client:
-        response = client.post("/v1/agentic/query", json={"query": "q"})
+        response = client.post("/v1/query", json={"query": "q", "agentic": True})
 
-    assert response.status_code == 404
-    assert response.json()["detail"] == "Agentic retrieval is not enabled."
+    assert response.status_code == 400
+    assert "not enabled" in response.json()["detail"]
 
 
-def test_agentic_query_endpoint_runs_shared_workflow(tmp_path) -> None:
+def test_agentic_true_runs_react_workflow_on_v1_query(tmp_path) -> None:
     app = create_vectordb_app(
         lancedb_uri=str(tmp_path),
         table_name="finance",
@@ -98,12 +127,18 @@ def test_agentic_query_endpoint_runs_shared_workflow(tmp_path) -> None:
             invoke_url="https://llm.example/v1/chat/completions",
         ),
     )
-    expected = AgenticQueryResponse(
+    expected = QueryResponse(
         results=[
-            AgenticQueryResult(
-                rank=1,
-                doc_id="report.pdf",
-                result_source="selection_agent",
+            QueryResult(
+                hits=agentic_ranked_to_hits(
+                    [
+                        {
+                            "rank": 1,
+                            "doc_id": "report.pdf",
+                            "result_source": "selection_agent",
+                        }
+                    ]
+                )
             )
         ]
     )
@@ -114,22 +149,31 @@ def test_agentic_query_endpoint_runs_shared_workflow(tmp_path) -> None:
         TestClient(app) as client,
     ):
         response = client.post(
-            "/v1/agentic/query",
-            json={"query": "revenue trend", "top_k": 3},
+            "/v1/query",
+            json={"query": "revenue trend", "top_k": 3, "agentic": True},
         )
 
     assert response.status_code == 200
     assert response.json() == {
         "results": [
             {
-                "rank": 1,
-                "doc_id": "report.pdf",
-                "result_source": "selection_agent",
+                "hits": [
+                    {
+                        "text": None,
+                        "metadata": {"result_source": "selection_agent", "rank": 1},
+                        "source": "report.pdf",
+                        "source_id": None,
+                        "path": None,
+                        "page_number": None,
+                        "pdf_basename": None,
+                        "pdf_page": None,
+                    }
+                ]
             }
         ]
     }
-    request = run_query.call_args.args[0]
-    assert request == AgenticQueryRequest(query="revenue trend", top_k=3)
+    assert run_query.call_args.kwargs["query"] == "revenue trend"
+    assert run_query.call_args.kwargs["top_k"] == 3
     assert run_query.call_args.kwargs["lancedb_uri"] == str(tmp_path)
     assert run_query.call_args.kwargs["table_name"] == "finance"
     assert run_query.call_args.kwargs["embed_api_key"] == ""
@@ -152,8 +196,8 @@ def test_agentic_query_rejects_top_k_above_backend_depth(tmp_path) -> None:
         TestClient(app) as client,
     ):
         response = client.post(
-            "/v1/agentic/query",
-            json={"query": "revenue trend", "top_k": 6},
+            "/v1/query",
+            json={"query": "revenue trend", "top_k": 6, "agentic": True},
         )
 
     assert response.status_code == 422
@@ -177,8 +221,8 @@ def test_agentic_query_rejects_query_above_length_limit(tmp_path) -> None:
         TestClient(app) as client,
     ):
         response = client.post(
-            "/v1/agentic/query",
-            json={"query": "x" * (MAX_AGENTIC_QUERY_CHARS + 1)},
+            "/v1/query",
+            json={"query": "x" * (MAX_AGENTIC_QUERY_CHARS + 1), "agentic": True},
         )
 
     assert response.status_code == 422
@@ -198,7 +242,7 @@ def test_agentic_query_slots_are_bounded_and_released_by_the_worker(tmp_path) ->
             invoke_url="https://llm.example/v1/chat/completions",
         ),
     )
-    expected = AgenticQueryResponse(results=[])
+    expected = QueryResponse(results=[QueryResult(hits=[])])
 
     with (
         patch.object(VectorDBState, "table_exists", new_callable=PropertyMock, return_value=True),
@@ -208,27 +252,24 @@ def test_agentic_query_slots_are_bounded_and_released_by_the_worker(tmp_path) ->
         slots = vectordb_module._agentic_slots
         assert slots is not None
 
-        # Stand in for in-flight workers whose callers have already gone away.
         for _ in range(vectordb_module.MAX_CONCURRENT_AGENTIC_QUERIES):
             assert slots.acquire(blocking=False) is True
 
-        busy = client.post("/v1/agentic/query", json={"query": "revenue trend"})
+        busy = client.post("/v1/query", json={"query": "revenue trend", "agentic": True})
 
         assert busy.status_code == 503
         assert busy.headers["Retry-After"] == "30"
-        # Plain /v1/query capacity is untouched by agentic saturation.
         assert vectordb_module._query_semaphore is not None
         assert vectordb_module._query_semaphore.locked() is False
 
         slots.release()
-        accepted = client.post("/v1/agentic/query", json={"query": "revenue trend"})
+        accepted = client.post("/v1/query", json={"query": "revenue trend", "agentic": True})
 
         assert accepted.status_code == 200
-        # The worker released its own slot on completion.
         assert slots.acquire(blocking=False) is True
 
 
-def test_service_proxies_agentic_query_to_vectordb(
+def test_gateway_proxies_agentic_flag_to_vectordb(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
@@ -262,7 +303,7 @@ def test_service_proxies_agentic_query_to_vectordb(
 
     class _FakeResponse:
         status_code = 200
-        content = json.dumps({"results": []}).encode()
+        content = json.dumps({"results": [{"hits": []}]}).encode()
 
     class _FakeAsyncClient:
         def __init__(self, *args, **kwargs) -> None:
@@ -283,14 +324,46 @@ def test_service_proxies_agentic_query_to_vectordb(
 
     with TestClient(create_app(config)) as client:
         response = client.post(
-            "/v1/agentic/query",
-            json={"query": "revenue trend", "top_k": 3},
+            "/v1/query",
+            json={"query": "revenue trend", "top_k": 3, "agentic": True},
         )
 
     assert response.status_code == 200
-    assert response.json() == {"results": []}
+    assert response.json() == {"results": [{"hits": []}]}
     assert seen == {
         "timeout": 321.0,
-        "url": "http://vectordb:7671/v1/agentic/query",
-        "body": {"query": "revenue trend", "top_k": 3},
+        "url": "http://vectordb:7671/v1/query",
+        "body": {"query": "revenue trend", "top_k": 3, "agentic": True},
     }
+
+
+def test_service_rejects_agentic_flag_when_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def _stub_work(_item):
+        return 0, []
+
+    monkeypatch.setattr(
+        "nemo_retriever.service.services.pipeline_executor.create_realtime_work_fn",
+        lambda _config: _stub_work,
+    )
+    monkeypatch.setattr(
+        "nemo_retriever.service.services.pipeline_executor.create_batch_work_fn",
+        lambda _config: _stub_work,
+    )
+    config = ServiceConfig(
+        mode="standalone",
+        logging=LoggingConfig(file=str(tmp_path / "service.log")),
+        pipeline=PipelinePoolConfig(realtime_workers=1, batch_workers=1),
+        vectordb=VectorDbConfig(enabled=True, vectordb_url="http://vectordb:7671"),
+    )
+
+    with TestClient(create_app(config)) as client:
+        response = client.post(
+            "/v1/query",
+            json={"query": "revenue trend", "agentic": True},
+        )
+
+    assert response.status_code == 400
+    assert "not enabled" in response.json()["detail"]

--- a/nemo_retriever/tests/test_service_mcp.py
+++ b/nemo_retriever/tests/test_service_mcp.py
@@ -82,7 +82,7 @@ def test_query_tool_client_posts_payload_and_auth_header() -> None:
     assert result["results"][0]["hits"][0]["text"] == "match"
 
 
-def test_agentic_query_client_posts_to_dedicated_endpoint() -> None:
+def test_agentic_query_client_posts_agentic_flag_on_v1_query() -> None:
     seen: dict[str, Any] = {}
 
     def _handler(request: httpx.Request) -> httpx.Response:
@@ -90,7 +90,24 @@ def test_agentic_query_client_posts_to_dedicated_endpoint() -> None:
         seen["body"] = json.loads(request.content)
         return httpx.Response(
             200,
-            json={"results": [{"rank": 1, "doc_id": "report.pdf", "result_source": "selection_agent"}]},
+            json={
+                "results": [
+                    {
+                        "hits": [
+                            {
+                                "text": None,
+                                "metadata": {"result_source": "selection_agent", "rank": 1},
+                                "source": "report.pdf",
+                                "source_id": None,
+                                "path": None,
+                                "page_number": None,
+                                "pdf_basename": None,
+                                "pdf_page": None,
+                            }
+                        ]
+                    }
+                ]
+            },
         )
 
     client = ServiceMCPClient(
@@ -105,10 +122,10 @@ def test_agentic_query_client_posts_to_dedicated_endpoint() -> None:
     result = _run(client.agentic_query("What is indexed?", top_k=2))
 
     assert seen == {
-        "path": "/v1/agentic/query",
-        "body": {"query": "What is indexed?", "top_k": 2},
+        "path": "/v1/query",
+        "body": {"query": "What is indexed?", "top_k": 2, "format": "hits", "agentic": True},
     }
-    assert result["results"][0]["doc_id"] == "report.pdf"
+    assert result["results"][0]["hits"][0]["source"] == "report.pdf"
 
 
 def test_agentic_query_tool_is_additive_and_config_gated() -> None:

--- a/nemo_retriever/tests/test_service_mcp.py
+++ b/nemo_retriever/tests/test_service_mcp.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 
 from nemo_retriever.service.app import create_app
 from nemo_retriever.service.config import (
+    AgenticConfig,
     AuthConfig,
     LoggingConfig,
     MCPConfig,
@@ -24,6 +25,7 @@ from nemo_retriever.service.mcp_server import (
     MCPDocumentInput,
     ServiceMCPClient,
     ServiceMCPSettings,
+    build_mcp,
     settings_from_service_config,
 )
 from nemo_retriever.service.services.pipeline_pool import WorkItem
@@ -78,6 +80,61 @@ def test_query_tool_client_posts_payload_and_auth_header() -> None:
         },
     }
     assert result["results"][0]["hits"][0]["text"] == "match"
+
+
+def test_agentic_query_client_posts_to_dedicated_endpoint() -> None:
+    seen: dict[str, Any] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"results": [{"rank": 1, "doc_id": "report.pdf", "result_source": "selection_agent"}]},
+        )
+
+    client = ServiceMCPClient(
+        ServiceMCPSettings(
+            base_url="http://service:7670",
+            enable_agentic_query=True,
+            agentic_request_timeout_s=300.0,
+        ),
+        transport=httpx.MockTransport(_handler),
+    )
+
+    result = _run(client.agentic_query("What is indexed?", top_k=2))
+
+    assert seen == {
+        "path": "/v1/agentic/query",
+        "body": {"query": "What is indexed?", "top_k": 2},
+    }
+    assert result["results"][0]["doc_id"] == "report.pdf"
+
+
+def test_agentic_query_tool_is_additive_and_config_gated() -> None:
+    plain_tools = {tool.name for tool in _run(build_mcp(ServiceMCPSettings()).list_tools())}
+    agentic_tools = {tool.name for tool in _run(build_mcp(ServiceMCPSettings(enable_agentic_query=True)).list_tools())}
+
+    assert "query" in plain_tools
+    assert "agentic_query" not in plain_tools
+    assert "query" in agentic_tools
+    assert "agentic_query" in agentic_tools
+
+
+def test_settings_from_service_config_enables_agentic_query() -> None:
+    settings = settings_from_service_config(
+        ServiceConfig(
+            agentic=AgenticConfig(
+                enabled=True,
+                llm_model="model",
+                invoke_url="https://llm.example/v1/chat/completions",
+                request_timeout_s=321.0,
+            ),
+        )
+    )
+
+    assert settings.enable_agentic_query is True
+    assert settings.agentic_request_timeout_s == 321.0
 
 
 def test_ingest_documents_accepts_inline_base64_upload() -> None:


### PR DESCRIPTION
## Description

- Add server-owned AgenticConfig and thin service adapters so existing agentic_query_documents() can run in service mode without changing AgenticRetriever internals.

- Expose POST /v1/agentic/query on the VectorDB app (execution) and gateway proxy; add config-gated MCP tool agentic_query alongside unchanged plain query.

- Wire Helm/retriever-service.yaml so gateway gets enablement + timeout from ConfigMap, and the VectorDB deployment gets --agentic* CLI flags + API key when a remote LLM URL is set.

- Service mode requires remote invoke_url + llm_model (and remote embed); request body stays {query, top_k} with server-owned ReAct knobs. Hits remain slim (rank / doc_id / result_source).

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
