### PR TITLE
Batch vLLM reranker scoring across queries

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/local/nemotron_rerank_vl_v2.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/nemotron_rerank_vl_v2.py
@@ -297,27 +297,20 @@ class NemotronRerankVLV2VLLM(BaseModel):
         if not pairs:
             return []
 
-        # Group consecutive pairs by query so each (query, [docs...]) goes to
-        # vLLM in a single batched score() call instead of one round-trip per pair.
-        scores: List[float] = [0.0] * len(pairs)
-        i = 0
-        while i < len(pairs):
-            q = pairs[i][0]
-            j = i
-            doc_inputs: list[Any] = []
-            while j < len(pairs) and pairs[j][0] == q:
-                _, d = pairs[j]
-                img = images_b64[j] if (images_b64 is not None and j < len(images_b64)) else None
-                d = self._truncate_doc_text(q, d, has_image=bool(img))
-                doc_inputs.append(self._build_document(d, img))
-                j += 1
-            outputs = self._llm.score(
-                q,
-                doc_inputs,
-                chat_template=SCORE_TEMPLATE,
-            )
-            for k, out in enumerate(outputs):
-                scores[i + k] = out.outputs.score
-            i = j
+        query_inputs: list[str] = []
+        doc_inputs: list[Any] = []
+        for index, (query, document) in enumerate(pairs):
+            image = images_b64[index] if images_b64 is not None and index < len(images_b64) else None
+            document = self._truncate_doc_text(query, document, has_image=bool(image))
+            query_inputs.append(query)
+            doc_inputs.append(self._build_document(document, image))
 
-        return scores
+        # vLLM schedules this aligned N-to-N list within its memory limit. A single
+        # call lets it combine candidates from multiple queries in one engine queue.
+        outputs = self._llm.score(
+            query_inputs,
+            doc_inputs,
+            use_tqdm=False,
+            chat_template=SCORE_TEMPLATE,
+        )
+        return [output.outputs.score for output in outputs]

--- a/nemo_retriever/tests/test_nemotron_rerank_vl_v2.py
+++ b/nemo_retriever/tests/test_nemotron_rerank_vl_v2.py
@@ -162,17 +162,48 @@ class TestNemotronRerankVLV2VLLMScore:
         assert docs[1] == "Paris is..."
 
     def test_score_pairs_text_only(self, reranker):
+        from nemo_retriever.models.local.nemotron_rerank_vl_v2 import SCORE_TEMPLATE
+
         out1 = MagicMock()
         out1.outputs.score = 1.0
         out2 = MagicMock()
         out2.outputs.score = 2.0
 
-        reranker._llm.score.side_effect = [[out1], [out2]]
+        reranker._llm.score.return_value = [out1, out2]
 
         scores = reranker.score_pairs([("q1", "d1"), ("q2", "d2")])
 
         assert scores == [1.0, 2.0]
-        assert reranker._llm.score.call_count == 2
+        reranker._llm.score.assert_called_once_with(
+            ["q1", "q2"],
+            ["d1", "d2"],
+            use_tqdm=False,
+            chat_template=SCORE_TEMPLATE,
+        )
+
+    def test_score_pairs_batches_multimodal_inputs(self, reranker):
+        from nemo_retriever.models.local.nemotron_rerank_vl_v2 import SCORE_TEMPLATE
+
+        outputs = [MagicMock(), MagicMock(), MagicMock()]
+        for index, output in enumerate(outputs):
+            output.outputs.score = float(index)
+        reranker._llm.score.return_value = outputs
+
+        scores = reranker.score_pairs(
+            [("q1", "d1"), ("q1", "d2"), ("q2", "d3")],
+            images_b64=["image-1", None, "image-3"],
+        )
+
+        assert scores == [0.0, 1.0, 2.0]
+        query_inputs, doc_inputs = reranker._llm.score.call_args.args
+        assert query_inputs == ["q1", "q1", "q2"]
+        assert doc_inputs[0]["content"][0]["image_url"]["url"].endswith("image-1")
+        assert doc_inputs[1] == "d2"
+        assert doc_inputs[2]["content"][0]["image_url"]["url"].endswith("image-3")
+        assert reranker._llm.score.call_args.kwargs == {
+            "use_tqdm": False,
+            "chat_template": SCORE_TEMPLATE,
+        }
 
     def test_score_chat_template_passed(self, reranker):
         from nemo_retriever.models.local.nemotron_rerank_vl_v2 import SCORE_TEMPLATE


### PR DESCRIPTION
## Summary
- submit aligned query/document pairs to one vLLM `LLM.score()` call
- let vLLM memory-schedule candidates across queries while preserving output and multimodal alignment
- disable per-call progress output for the batched path

## Why
The vLLM reranker grouped candidates by query and made one synchronous engine call per query. vLLM supports memory-aware N-to-N scoring and recommends submitting all inputs together, so those round trips prevented cross-query scheduling.

## Validation
- `135 passed`: VL reranker, Retriever batch-query, and actor/operator tests
- `23 passed`: final focused VL reranker suite
- Ruff and `git diff --check` pass
- Full ViDoRe v3 Energy A/B, 1,848 queries on one H100 80GB: 2.792 to 2.934 QPS (+5.08%) with NRB query batch size 4
- nDCG@10: 0.651244 to 0.651541; Recall@10: 0.716534 to 0.717165

BF16 scores near rank boundaries are batch-sensitive: 51/1,848 Energy queries changed top-10 membership at batch size 4. Aggregate quality moved slightly upward. The paired NRB change keeps the generic default at one and opts only the offline nightly into the measured batch-size-four throughput/latency knee.