### PR TITLE
docs: drop macOS Intel (x86_64) from supported client platforms

### DIFF
--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -5,7 +5,7 @@ This section walks you from **access and prerequisites** through **first deploym
 Typical order:
 
 1. [Get your API key](api-keys.md) (NGC / API access as required by your workflow).
-2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, and software stack. Local GPU inference requires Linux; remote NIM workflows can use the base package on Windows x64 and macOS as well.
+2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, and software stack. Local GPU inference requires Linux; remote NIM workflows can use the base package on Windows x64 and macOS Apple Silicon (arm64) as well. macOS Intel (x86_64) is not supported.
 3. Choose a path in [Deployment options](deployment-options.md) — local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service.
 4. Explore [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md) for end-to-end examples.
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -2,7 +2,7 @@
 
 Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, and—if you use them—advanced features (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance on this page.
 
-**Platform summary:** Supported **local GPU inference** requires **Linux** and CUDA 13. For **remote NIM inference**, the base Python package also installs on **Windows x64** and **macOS x64/ARM64**; local GPU inference is not supported on those platforms.
+**Platform summary:** Supported **local GPU inference** requires **Linux** and CUDA 13. For **remote NIM inference**, the base Python package also installs on **Windows x64** and **macOS Apple Silicon (arm64)**; local GPU inference is not supported on those platforms. **macOS Intel (x86_64) is not supported** — `pip`/`uv` installs fail because Ray no longer publishes Intel Mac wheels.
 
 > **Note — NVIDIA AI Enterprise (NVAIE) support**
 >
@@ -10,7 +10,7 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 
 ## Software Requirements { #software-requirements }
 
-- Linux operating systems (Ubuntu 22.04 or later recommended) for supported local GPU inference. For remote NIM inference, the base package can also be installed on Windows x64 and macOS x64/ARM64; local GPU inference is not supported on those platforms.
+- Linux operating systems (Ubuntu 22.04 or later recommended) for supported local GPU inference. For remote NIM inference, the base package can also be installed on Windows x64 and macOS Apple Silicon (arm64); local GPU inference is not supported on those platforms. macOS Intel (x86_64) is not supported: package installation fails because Ray `>=2.56.1` has no Intel Mac wheels (including in-process library mode).
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (local GPU inference only; NVIDIA Driver >= `580`, CUDA >= `13.0`)
 - [Python](https://www.python.org/downloads/) `3.12` — required to install and run the NeMo Retriever Library Python API, CLI, and related packages from PyPI (for example `pip` or `uv`). Older Python versions will fail dependency resolution without a clear error.
 - [UV Python package and environment manager](https://docs.astral.sh/uv/getting-started/installation/) (optional; recommended for creating isolated environments)

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -5,7 +5,7 @@ NeMo Retriever Library is a retrieval-augmented generation (RAG) ingestion pipel
 This quick start guide shows how to run NeMo Retriever Library as a library in local Python processes without containers. Choose one inference path:
 
 - **Local GPU (Linux):** Pull and run [Nemotron RAG models from Hugging Face](https://huggingface.co/collections/nvidia/nemotron-rag) on your GPU(s). Requires CUDA 13.x and the `[local]` extra.
-- **Remote NIM:** Call build.nvidia.com hosted or self-hosted NeMo Retriever NIM endpoints over the network. The base package installs on Linux, Windows x64, and macOS; no local GPU is required.
+- **Remote NIM:** Call build.nvidia.com hosted or self-hosted NeMo Retriever NIM endpoints over the network. The base package installs on Linux, Windows x64, and macOS Apple Silicon (arm64); no local GPU is required. macOS Intel (x86_64) is not supported.
 
 The steps below cover environment setup, installation, and a first ingestion run. For Kubernetes or container deployments, refer to [Deployment at a glance](#deployment-at-a-glance) and the [Pre-Requisites & Support Matrix](https://docs.nvidia.com/nemo/retriever/latest/extraction/prerequisites-support-matrix/).
 


### PR DESCRIPTION
## Summary

- Update the Pre-Requisites & Support Matrix platform summary and Software Requirements to state that **macOS Intel (x86_64) is not supported** for PyPI installs (Ray `>=2.56.1` has no Intel Mac wheels), while **Apple Silicon (arm64)** remains supported for slim remote/NIM-only installs alongside Windows x64.
- Align the package README Remote NIM install line with the same platform set.

## Context

Team decision (Slack): abandon Intel Mac support so Ray can move to 2.56+ for CVE remediation. Eng change is in #2440 (removes `macos-26-intel` CI and bumps Ray). Randy asked for changelog + install-guide notes. Changelog language is in draft #2434.

## Merge coordination

- Prefer merge **after or with** #2440 so docs match `main` dependency reality.
- Related changelog: draft #2434

## Test plan

- [ ] Confirm wording matches #2440 Ray pin and CI matrix (arm64 only on macOS)
- [ ] Spot-check support matrix Platform summary + Software Requirements
- [ ] Spot-check README Remote NIM bullet
- [ ] No remaining "macOS x64/ARM64" or unqualified macOS support claims in these two files
