### PR TITLE
feat: enable table structure by default for library ingest

### DIFF
--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -520,7 +520,7 @@ class ExtractParams(_ParamsModel):
     # Run PageElementDetection (layout/yolox). Required by TableStructure and
     # OCR. Safe to disable for text-only ingests.
     use_page_elements: bool = True
-    use_table_structure: bool = False
+    use_table_structure: bool = True
     table_output_format: Optional[Literal["pseudo_markdown", "markdown"]] = None
     dpi: int = 200
     image_format: str = "jpeg"

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -838,7 +838,10 @@ def build_extract_params(nim: "NimEndpointsConfig", local: "LocalModelsConfig | 
     from nemo_retriever.common.params import ExtractParams
 
     local = local or _default_local_models_config()
-    kwargs: dict[str, Any] = {}
+    # ``ExtractParams`` defaults Table Structure on for the in-process and
+    # batch library APIs. Service mode keeps its existing endpoint/local-model
+    # policy: enable it only when the service owns a NIM URL or local models.
+    kwargs: dict[str, Any] = {"use_table_structure": False}
     if nim.page_elements_invoke_url:
         kwargs["page_elements_invoke_url"] = nim.page_elements_invoke_url
     if nim.ocr_invoke_url:

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -318,6 +318,15 @@ def test_graph_ingestor_action_methods_materialize_default_params() -> None:
     assert isinstance(ingestor._embed_params, EmbedParams)
 
 
+@pytest.mark.parametrize("run_mode", ["inprocess", "batch"])
+def test_library_extract_defaults_enable_table_structure(run_mode: str) -> None:
+    ingestor = GraphIngestor(run_mode=run_mode).extract()
+
+    assert ingestor._extract_params is not None
+    assert ingestor._extract_params.use_table_structure is True
+    assert ingestor._extract_params.table_output_format == "markdown"
+
+
 def test_extract_unified_defaults() -> None:
     """`.extract()` defaults: infer extraction_mode at graph-build time and no chunking unless opted in."""
     ingestor = GraphIngestor(run_mode="inprocess").extract()

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -548,8 +548,8 @@ def test_root_ingest_passes_embedding_overrides_without_stage_flags(monkeypatch,
     extract_params = fake_ingestor.extract.call_args.args[0]
     assert isinstance(extract_params, ExtractParams)
     assert extract_params.use_page_elements is True
-    assert extract_params.use_table_structure is False
-    assert extract_params.table_output_format == "pseudo_markdown"
+    assert extract_params.use_table_structure is True
+    assert extract_params.table_output_format == "markdown"
 
     embed_params = fake_ingestor.embed.call_args.args[0]
     assert isinstance(embed_params, EmbedParams)

--- a/nemo_retriever/tests/test_service_local_models.py
+++ b/nemo_retriever/tests/test_service_local_models.py
@@ -78,6 +78,13 @@ def test_build_extract_params_local_enables_table_structure() -> None:
     assert ep.page_elements_invoke_url is None
 
 
+def test_build_extract_params_service_default_leaves_table_structure_disabled() -> None:
+    ep = build_extract_params(NimEndpointsConfig(), LocalModelsConfig())
+
+    assert ep.use_table_structure is False
+    assert ep.table_output_format == "pseudo_markdown"
+
+
 def test_build_extract_params_nim_url_wins_over_local_flags() -> None:
     nim = NimEndpointsConfig(table_structure_invoke_url="http://table-nim/v1/infer")
     local = LocalModelsConfig(enabled=True)

--- a/nemo_retriever/tests/test_table_structure.py
+++ b/nemo_retriever/tests/test_table_structure.py
@@ -526,8 +526,8 @@ class TestExtractParams:
         from nemo_retriever.common.params.models import ExtractParams
 
         params = ExtractParams()
-        assert params.use_table_structure is False
-        assert params.table_output_format == "pseudo_markdown"
+        assert params.use_table_structure is True
+        assert params.table_output_format == "markdown"
         assert params.table_structure_invoke_url is None
 
     def test_auto_enable_when_invoke_url_provided(self) -> None:
@@ -537,11 +537,12 @@ class TestExtractParams:
         assert params.use_table_structure is True
         assert params.table_output_format == "markdown"
 
-    def test_no_auto_enable_when_invoke_url_absent(self) -> None:
+    def test_explicit_disable_without_invoke_url(self) -> None:
         from nemo_retriever.common.params.models import ExtractParams
 
-        params = ExtractParams(table_structure_invoke_url=None)
+        params = ExtractParams(use_table_structure=False)
         assert params.use_table_structure is False
+        assert params.table_output_format == "pseudo_markdown"
 
     def test_auto_markdown_when_use_table_structure(self) -> None:
         from nemo_retriever.common.params.models import ExtractParams


### PR DESCRIPTION
## Summary

- Enable Table Structure by default for the in-process and batch library ingestion APIs.
- Preserve the service policy: a service without a Table Structure NIM endpoint or enabled local models keeps the stage disabled.
- Cover the library modes, CLI construction, and service boundary with regression tests.

## Motivation

The default library extraction pipeline already enables Page Elements, OCR, and table extraction, but omitted Table Structure. This makes the default local path materially different from the standard Helm service deployment. The change creates a controlled ref for benchmark runs to measure the accuracy, latency, and cost effect before treating it as a final product decision.

## Validation

`uv run pytest -q tests/test_table_structure.py tests/test_ingest_interface.py tests/test_root_cli_workflow.py tests/test_service_local_models.py tests/test_service_pipeline_spec.py`

Result: `270 passed, 2 deselected`.
