### PR TITLE
docs: add composition-time agent guidance (AGENTS.md) - coding agents draft/update docs while the change is being made.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Agent Instructions — NeMo Retriever
+
+These standards apply to AI coding agents working in this repository (Cursor, Claude Code, and compatible hosts).
+
+## Project Overview
+
+NVIDIA NeMo Retriever Library (NRL) is the multimodal extraction and retrieval library formerly known in docs as NV-Ingest. Published customer documentation lives primarily under `docs/docs/extraction/` and builds with MkDocs (`docs/mkdocs.yml`). Library and Helm sources live under `nemo_retriever/`.
+
+## Repository Map
+
+| Path | Purpose |
+|------|---------|
+| `docs/docs/extraction/` | Published NRL extraction documentation (MkDocs) |
+| `docs/mkdocs.yml` | Nav, redirects, and MkDocs config |
+| `nemo_retriever/` | Library source, CLI, Helm chart, and in-repo README examples |
+| `nemo_retriever/tests/` | Library tests |
+| `.github/workflows/` | CI, including NRL docs publish workflows |
+
+## Documentation
+
+- Treat `docs/docs/extraction/` and related MkDocs pages as the source of truth for user-facing NRL documentation. Follow [`docs/AGENTS.md`](docs/AGENTS.md).
+- Before completing a code change, determine whether it changes a **user-visible** surface. This includes a public API, CLI, configuration, Helm values or defaults, workflow, error message or error contract, supported file type, or other supported product behavior.
+- When it does and the host supports subagents, start a documentation authoring subagent while the primary agent continues the implementation. Direct it to read `docs/AGENTS.md`, update the affected docs, and run validation. Give it the changed sources and user-visible impact.
+- Reconcile the authoring subagent's documentation changes and validation evidence before completing the implementation. Include the required documentation in the same change when the repository workflow allows a combined PR. If policy requires a **docs-only** follow-up PR, open that PR in the same task and link it from the code PR.
+- If the host cannot run subagents, read `docs/AGENTS.md` in the primary task, complete the documentation work, and run its documented validation. Do not omit required documentation because parallel execution is unavailable.
+- Do not document defaults or behavior that `main` does not have yet.
+- Documentation PRs that change published NRL prose must stay docs-scoped. Do not change `nemo_retriever/src/**`, tests, Helm chart behavior, lockfiles, or runtime CI env on a docs PR unless the user explicitly requests eng work.
+- Verified product surfaces that often need docs updates: Python `create_ingestor` / `GraphIngestor` APIs, `retriever` CLI, Helm chart README and values, support matrix and NIM defaults, authentication and environment variables, error and troubleshoot guidance, and release notes.
+
+### NVIDIA DORI Routing
+
+Select the documentation path from current host capabilities.
+Do not ask the user to classify themselves or store repository-scoped identity
+state during a normal documentation task.
+
+1. Check whether the current agent exposes `dori_handle` or `dori_route` and
+   `dori_collections`.
+   If the user explicitly asks not to use DORI, use the
+   [Writing Style Guide](docs/AGENTS.md#writing-style-guide) instead.
+2. When those tools are available, list the installed collections.
+   - If a collection source contains `tech-docs/skill-library`, use DORI for
+     task routing.
+   - If the collection is missing, inaccessible, or cannot be verified,
+     continue with the
+     [Writing Style Guide](docs/AGENTS.md#writing-style-guide).
+3. When the DORI tools are unavailable, continue with the Writing Style Guide.
+   Do not inspect a shell-visible CLI, install software, or configure the host
+   during a normal documentation task.
+4. Use [NVIDIA DORI Setup](docs/DORI_SETUP.md) only when the user explicitly
+   asks to install or configure DORI.
+
+Capability detection does not approve installation or host configuration.
+DORI unavailability must not block documentation work.
+
+## Engineering Guardrails
+
+- Prefer small, focused diffs that match existing style.
+- Do not invent APIs, CLI flags, Helm keys, or defaults. Verify against checked-in source or tests.
+- Never commit secrets, API keys, or credentials.
+- Do not add lint, hooks, or CI from agent guidance alone. Those require a separately reviewed repository change.
+- Do not create or modify `CLAUDE.md` as part of documentation-agent setup.
+
+## Validation Shortcuts
+
+| Change type | Validation |
+|-------------|------------|
+| Docs under `docs/` | From `docs/`: `python -m mkdocs build --strict --config-file mkdocs.yml` when the environment supports it |
+| Library code | Run the targeted tests that cover the changed modules |
+| Docs-only PR scope | `git diff --name-only upstream/main...HEAD` and confirm no runtime/out-of-scope paths |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,4 +66,4 @@ DORI unavailability must not block documentation work.
 |-------------|------------|
 | Docs under `docs/` | From `docs/`: `python -m mkdocs build --strict --config-file mkdocs.yml` when the environment supports it |
 | Library code | Run the targeted tests that cover the changed modules |
-| Docs-only PR scope | `git diff --name-only upstream/main...HEAD` and confirm no runtime/out-of-scope paths |
+| Docs-only PR scope | `git diff --name-only upstream/main...HEAD` (or `origin/main...HEAD`) and confirm no runtime/out-of-scope paths |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,107 @@
+# Documentation Agent Guide
+
+You are a documentation engineer and writer for NeMo Retriever Library (NRL) user-facing docs.
+Treat `docs/docs/extraction/` as the primary source of truth for published extraction content.
+MkDocs config and redirects live in `docs/mkdocs.yml`.
+
+## Role
+
+- Write clear, accurate, task-oriented documentation for developers who install, configure, and run NeMo Retriever Library.
+- Preserve the reader's workflow: explain what to do, when to do it, and how to verify it.
+- Prefer small, focused edits that match the structure of the current page.
+- Verify commands, defaults, API names, and behavior against checked-in source, tests, Helm values, or CLI help.
+- Use existing documentation, issues, and PRs to locate claims and rationale, not as behavior authority.
+- Keep product naming consistent: **NeMo Retriever Library** (NRL). Avoid reintroducing NV-Ingest as the current product name except in historical release-note context.
+
+## Writing Style Guide
+
+Apply these rules to documentation, examples, headings, UI text, and release notes that you create or edit.
+
+- Write in a professional, active, conversational voice.
+- Use active voice whenever possible. Use present tense for product behavior.
+  Address the reader in second person as "you."
+- Keep sentences concise. Prefer sentences with fewer than 30 words.
+- End every sentence with a period.
+- Use plain English and precise technical terms. Avoid jargon, filler,
+  colloquialisms, and flowery marketing claims.
+- Avoid contractions in technical documentation. Write "do not," "cannot,"
+  and "it is."
+- Write "NVIDIA" in all caps and use "an NVIDIA," not "a NVIDIA."
+- Spell out uncommon abbreviations on first use. Spell out LLM, RAG, SLM, VLM,
+  and MoE on first use when the audience may not know them.
+- Use NVIDIA spellings such as data center, dataset, open source, pretrained,
+  startup, webpage, website, and Wi-Fi.
+- Replace Latinisms with plain English. Use "for example," "that is," "and so
+  on," "through," and "compared to."
+- Use "refer to" instead of "see," "can" instead of "may" for possibility,
+  and "after" instead of "once" for time.
+- Do not use "please" in technical instructions.
+- Use numerals for specific values, parameters, measurements, and values of 10
+  or more. Spell out zero through nine in general prose.
+- Include a space between a number and its unit. Use a comma in numbers with
+  four or more digits.
+- Prefer statement-style headings. Use question headings only on FAQ pages.
+- Use the Oxford comma. Put periods inside quotation marks in U.S. style.
+- Use hyphens only for compound modifiers before nouns. Do not hyphenate an
+  adverb that ends in "ly."
+- Format commands, code, filenames, paths, flags, environment variables, API identifiers, and literal values as code.
+- Use bold for UI elements and the greater-than sign for UI navigation.
+- Avoid rhetorical questions, emoji, em dashes, and unnecessary bold text.
+- Introduce lists, tables, code examples, and images with a complete sentence.
+  Use parallel construction in lists.
+- Use descriptive link text. Do not use raw URLs in running text or generic
+  link text such as "click here" or "read more."
+- Write dates as Month DD, YYYY. Omit the year when it matches the publication
+  year.
+- Provide useful alt text and preserve a logical heading hierarchy.
+- Verify commands, flags, API names, defaults, and technical claims against
+  source code or another checked-in source of truth.
+- Do not rewrite literal code, identifiers, commands, URLs, or quoted terminal
+  and API output to satisfy prose rules.
+- Apply rules to improve clarity. Do not make mechanical changes that reduce
+  technical accuracy or readability.
+
+### NRL documentation patterns
+
+- Prefer end-to-end examples that include `.ingest()` when showing `create_ingestor` / `GraphIngestor` usage, unless the page intentionally stops before ingest for inspection.
+- Keep Helm, CLI, and Python guidance aligned with current `main` defaults. Soften or omit claims until code matches.
+- For NIM catalogs and build links, prefer the support matrix and topic pages over inventing new tables.
+- Preserve MkDocs redirects in `docs/mkdocs.yml` when renaming or retiring pages.
+- On documentation PRs, change what readers are told, not what the library does by default, unless the user explicitly requests eng work.
+
+## Use Additional NVIDIA Documentation Tools
+
+Follow [NVIDIA DORI Routing](../AGENTS.md#nvidia-dori-routing).
+Use the following DORI workflow only when current host capabilities include the
+verified NVIDIA documentation Skill Library. Complete the documentation before
+the developer opens the pull or merge request.
+
+1. Route the documentation task through DORI. Include the changed source files,
+   the user-visible impact, the documentation that might need updates, and the
+   required validation.
+2. Follow the skill or workflow that DORI returns. Verify product behavior
+   against checked-in sources before drafting.
+3. When the host supports subagents, start a documentation subagent while the
+   primary developer finishes the implementation. Reconcile the documentation
+   changes and validation evidence before opening the pull or merge request.
+4. When the host does not support subagents, complete the same documentation
+   work in the primary task.
+
+If the verified Skill Library is unavailable, inaccessible, or fails, skip DORI.
+Do not attempt routing, prompt for setup, or ask for or persist a user
+classification. Continue using the Writing Style Guide above.
+
+## Before Editing
+
+- Read the full target page before editing it.
+- Map code changes to existing pages before proposing a new page.
+- Check `docs/mkdocs.yml` navigation and redirects before adding, renaming, or removing pages.
+- Prefer updating an existing topic page over creating a parallel page with overlapping guidance.
+- For docs-only work, keep the PR scoped to documentation paths. Do not mix runtime code changes.
+
+## Verification
+
+- From the `docs/` directory, run `python -m mkdocs build --strict --config-file mkdocs.yml` when the environment supports it.
+- Run `git diff --check` on changed Markdown files when available.
+- For docs-only PRs, run `git diff --name-only upstream/main...HEAD` (or `origin/main...HEAD`) and confirm the diff stays in allowed documentation paths.
+- Leave validation items unchecked unless you actually ran the applicable command.

--- a/docs/DORI_SETUP.md
+++ b/docs/DORI_SETUP.md
@@ -1,0 +1,106 @@
+# NVIDIA DORI Setup
+
+Use this guide only when the user explicitly asks to install or configure NVIDIA DORI.
+Before inspecting or installing private components, ask the user to confirm that they can access `gitlab-master.nvidia.com`.
+If the user does not confirm access, stop this setup and use the checked-in [Writing Style Guide](AGENTS.md#writing-style-guide).
+Access confirmation does not approve installation or host configuration.
+
+Use these internal sources for the current installation and registration instructions:
+
+- [NVIDIA Skill Library](https://gitlab-master.nvidia.com/tech-docs/skill-library) contains documentation-focused Agent Skills and guidance for installing them with DORI and other supported hosts.
+- [NVIDIA Template Library](https://gitlab-master.nvidia.com/tech-docs/template-library) contains reusable documentation templates and guidance for installing its template skills with DORI.
+
+## Inspect the Environment
+
+1. Check for DORI MCP tools.
+   - If the current agent exposes `dori_handle` or `dori_route`, do not reconfigure the host.
+   - When `dori_collections` is available, verify that a collection source contains `tech-docs/skill-library`.
+   - If the Skill Library is missing, identify it as the only missing component and continue to [Confirm Changes](#confirm-changes).
+2. When DORI MCP tools are unavailable, inspect the command-line interface (CLI).
+   - Run `command -v dori` (or the host equivalent).
+   - If the CLI exists, run `dori collections list --json`.
+   - Treat a collection whose source contains `tech-docs/skill-library` as the installed Skill Library.
+3. Identify the host from explicit runtime context.
+   Do not infer the host from the model name or repository files.
+4. Run `dori setup auto --dry-run` as a cross-check when the CLI exists.
+   - If auto-detection conflicts with the explicit host, use the explicit host.
+   - If no explicit host exists and auto-detection is uncertain, ask which host is running.
+
+Use the following host commands:
+
+| Explicit Host | Setup Command |
+|---|---|
+| Codex CLI or Desktop | `dori setup codex` |
+| Cursor | `dori setup cursor --scope user` |
+| Claude Code | `dori setup claude-code --scope user` |
+| Claude Desktop | `dori setup claude` |
+| VS Code with GitHub Copilot | `dori setup vscode --scope user` |
+| Kiro | `dori setup kiro` |
+| Google Antigravity | `dori setup antigravity` |
+
+Keep the listed `--scope user` option.
+Project or combined scope requires separate repository-owner authorization because it can create a repository MCP configuration file.
+
+## Confirm Changes
+
+Report each missing component.
+Before an installation or host configuration change, ask:
+
+> DORI setup is incomplete: `<missing components>`.
+> Do you want me to install or configure these components in your user environment?
+
+Continue only after explicit approval.
+The user's private-source access confirmation does not approve these changes.
+If the user declines, use the [Writing Style Guide](AGENTS.md#writing-style-guide).
+
+## Install Missing Components
+
+When DORI MCP is unavailable and `dori` is missing, require an existing `uv` command.
+
+- If `uv` is missing, stop and direct the user to the [internal DORI installation guide](https://gitlab-master.nvidia.com/tech-docs/dori/-/blob/main/docs/get-started/install.md).
+  Do not download or execute an installer script.
+- If `uv` exists, install the pinned DORI tool version from the internal guide for your host.
+  Prefer the version and index URL documented in the Skill Library or DORI install guide at the time of setup.
+
+When DORI MCP is unavailable and the Skill Library is missing, run:
+
+```bash
+dori install gitlab:tech-docs/skill-library --all --yes
+```
+
+When DORI MCP is available but the Skill Library is missing:
+
+1. Run `dori_collections(action="install", source="gitlab:tech-docs/skill-library")`.
+2. Run `dori_refresh`.
+3. Verify the source with `dori_collections(action="list")`.
+
+Do not depend on a shell-visible CLI or reconfigure the host on the DORI MCP path.
+
+## Configure and Validate the Host
+
+Complete this section only when DORI MCP is unavailable.
+After the CLI becomes available, run `dori setup auto --dry-run` if it did not run during inspection.
+If auto-detection conflicts with the explicit host, use the explicit host.
+If no explicit host exists and auto-detection is uncertain, ask which host is running.
+After approval, run the setup command for the resolved host.
+Then perform the following checks:
+
+1. Run the selected command with `--validate`.
+2. Run `dori doctor health --json`.
+3. Require a passing host validation and `"ok": true` health.
+
+Follow the activation action that DORI reports.
+The action can require an application restart, a new session, a window reload, or enabling the MCP server.
+
+Until the current agent exposes DORI tools, continue the original task with the [Writing Style Guide](AGENTS.md#writing-style-guide).
+
+## Protect Credentials and Repository State
+
+- Never search for, request, print, copy, export, or embed a token, password, cookie, SSH key, or credential-bearing URL.
+- Let `uv`, Git, and DORI use credentials that the user already configured.
+  If access is denied or authentication is missing, stop and refer to the internal DORI installation guide.
+- Do not create repository-scoped identity or authorization files.
+  Confirm private-source access only for an explicit setup request.
+- Do not bypass approval controls for writes outside the repository.
+- Do not create or commit project-scoped DORI state or MCP configuration without separate repository-owner authorization.
+- Do not retry a failed installation in the same task.


### PR DESCRIPTION
## Summary

Follow-up to #2429. That PR delivered the **review-time** half of the agentic docs workflow (a Greptile rule that flags concrete documentation drift on PRs). This PR carries the **composition-time** half that was intentionally split out for its own review.

Adds repository agent guidance so compatible coding agents (Cursor, Claude Code, and similar) recognize user-visible changes and draft documentation to NVIDIA writing standards *during development*, before handoff to technical review.

- `AGENTS.md`: root guidance that detects user-visible surface changes (public API, CLI, config, Helm defaults, errors, supported file types) and starts documentation work in parallel. Includes a capability-gated DORI routing subsection.
- `docs/AGENTS.md`: writing guide and NRL doc patterns for published MkDocs extraction docs.
- `docs/DORI_SETUP.md`: optional DORI install/config, used only when a user explicitly requests it.

## Why this is separate from #2429

@KyleZheng1284 correctly noted that a root `AGENTS.md` is repository-wide guidance that affects every contributor's agent session, so it does not belong in a Greptile config change. Splitting it here gives that guidance its own focused review.

## How the two layers relate

The two PRs operate at different points in the development lifecycle. #2429 remains the review safety net; this PR adds the earlier composition-time behavior.

| Scenario | With #2429 Greptile rule only | With this `AGENTS.md` guidance also implemented |
|----------|--------------------------------|--------------------------------------------------|
| A coding agent changes a public API, CLI option, configuration default, Helm value, error contract, or supported format | Nothing happens until the change is pushed and Greptile reviews the PR. | A compatible coding agent recognizes the user-visible impact during development and starts the related documentation work before handoff. |
| Documentation is required | Greptile flags a concrete stale, incorrect, contradictory, or missing page after the PR exists. The author then returns to implementation to correct it. | The agent reads `docs/AGENTS.md`, updates the affected docs in the same task when policy permits, and reconciles the docs with the implementation before completion. |
| The host supports subagents | Greptile does not participate in the local development session. | The primary coding agent can start a documentation subagent in parallel and provide it with the changed sources, user impact, likely pages, and validation requirements. |
| The host does not support subagents | No composition-time behavior is added. | The primary agent follows the same checked-in documentation guidance itself; lack of parallel execution does not become a reason to omit docs. |
| The change is internal-only or there is no concrete mismatch | Greptile should not request documentation or speculate. | The coding agent determines that no user-facing documentation change is required and continues without unnecessary docs work. |
| NVIDIA writing guidance is needed | The Greptile rule checks technical currentness; it does not provide a repository writing guide. | `docs/AGENTS.md` places compact writing standards beside the documentation so drafts begin with the expected structure, terminology, accuracy, and style. |
| DORI is unavailable or not requested | Not applicable. | The agent immediately uses the checked-in Writing Style Guide. It does not install software, configure the host, or block the task. |

In short: #2429 detects documentation drift at review time. This PR aims to prevent the same drift while the change is being composed. Greptile remains necessary because `AGENTS.md` is passive guidance and compatible hosts do not guarantee that they will discover or follow it.

## Notes

- Passive guidance only. Hosts that load `AGENTS.md` follow it; it does not guarantee discovery, and it does not add lint, hooks, or CI (those require a separately reviewed change).
- Does not create or modify `CLAUDE.md`.
- DORI routing degrades gracefully: when DORI tools or the verified collection are unavailable, agents continue with the checked-in Writing Style Guide.

## Test plan

- [ ] Confirm an agent host loading `AGENTS.md` surfaces the documentation routing on a user-visible code change
- [ ] Confirm DORI routing falls back to the Writing Style Guide when DORI tools are absent
- [ ] Confirm no runtime code, tests, Helm behavior, lockfiles, or CI env are touched

