### PR TITLE
chore(helm): bump object-detection & OCR NIMs to 2.0.1

### DIFF
--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -478,7 +478,7 @@ gated on three conditions ALL holding:
 | `nimOperator.ocr.image`              | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` | Default OCR NIM image. |
 | `nimOperator.vlm_embed.enabled`        | `true`  | Multimodal embedding NIM (also used by the vectordb Pod). |
 | `nimOperator.vlm_embed.nimServiceName` | `llama-nemotron-embed-vl-1b-v2` | NIMService / in-cluster DNS name. |
-| `nimOperator.vlm_embed.image`          | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.2.2` | Default VLM embed NIM image. |
+| `nimOperator.vlm_embed.image`          | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0` | Default VLM embed NIM image. |
 | `nimOperator.rerankqa.enabled`         | `false` | VL reranker NIM (optional; not auto-wired). Set `true` to opt in. Default `false` so chart installs honor the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md) and do not silently provision an extra ≈ 3.1 GiB GPU NIM. The image points at the **VL** SKU (`llama-nemotron-rerank-vl-1b-v2`) per [prerequisites-support-matrix.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#default-helm-nims) — the text-only `llama-nemotron-rerank-1b-v2` silently degrades multimodal reranking and is not the documented POR. |
 | `nimOperator.rerankqa.image`           | `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0` | Default optional VL reranker NIM image. |
 | `nimOperator.nemotron_parse.enabled`   | `false` | Structured-parse NIM (optional). Set `true` when using `method="nemotron_parse"`. Default `false` so chart installs honor the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md). Image tag follows the [image tag conventions](#image-tag-conventions). |
@@ -1212,7 +1212,7 @@ your release tag). Defaults below match
 | Page Elements | `page_elements` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1` |
 | Table Structure | `table_structure` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1` |
 | OCR | `ocr` | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` |
-| VL embed | `vlm_embed` | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.2.2` |
+| VL embed | `vlm_embed` | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0` |
 | VL reranker (optional) | `rerankqa` | `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0` |
 | Nemotron Parse (optional) | `nemotron_parse` | `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant` |
 | Omni caption (optional) | `nemotron_3_nano_omni_30b_a3b_reasoning` | `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` |

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -473,12 +473,12 @@ gated on three conditions ALL holding:
 | `nims.enabled`                         | `true`  | Master switch. Set false to render no NIM resources. |
 | `nimOperator.page_elements.enabled` | `true` | Page Elements 2.0 service; auto-wired to `/v1/page-elements`. |
 | `nimOperator.table_structure.enabled` | `true` | Table Structure 2.0 service; auto-wired to `/v1/table-structure`. |
-| `nimOperator.<page_elements|table_structure>.image` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.0` | Both services use the combined image but select distinct models. |
+| `nimOperator.<page_elements|table_structure>.image` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1` | Both services use the combined image but select distinct models. |
 | `nimOperator.ocr.enabled`              | `true`  | OCR NIM. |
-| `nimOperator.ocr.image`              | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.0` | Default OCR NIM image. |
+| `nimOperator.ocr.image`              | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` | Default OCR NIM image. |
 | `nimOperator.vlm_embed.enabled`        | `true`  | Multimodal embedding NIM (also used by the vectordb Pod). |
 | `nimOperator.vlm_embed.nimServiceName` | `llama-nemotron-embed-vl-1b-v2` | NIMService / in-cluster DNS name. |
-| `nimOperator.vlm_embed.image`          | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0` | Default VLM embed NIM image. |
+| `nimOperator.vlm_embed.image`          | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.2.2` | Default VLM embed NIM image. |
 | `nimOperator.rerankqa.enabled`         | `false` | VL reranker NIM (optional; not auto-wired). Set `true` to opt in. Default `false` so chart installs honor the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md) and do not silently provision an extra ≈ 3.1 GiB GPU NIM. The image points at the **VL** SKU (`llama-nemotron-rerank-vl-1b-v2`) per [prerequisites-support-matrix.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#default-helm-nims) — the text-only `llama-nemotron-rerank-1b-v2` silently degrades multimodal reranking and is not the documented POR. |
 | `nimOperator.rerankqa.image`           | `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0` | Default optional VL reranker NIM image. |
 | `nimOperator.nemotron_parse.enabled`   | `false` | Structured-parse NIM (optional). Set `true` when using `method="nemotron_parse"`. Default `false` so chart installs honor the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md). Image tag follows the [image tag conventions](#image-tag-conventions). |
@@ -599,7 +599,7 @@ Every NIM in this chart pins an exact NGC image tag in `values.yaml`
 
 | Family | Example | Meaning |
 | ------ | ------- | ------- |
-| Plain semver | `nemotron-object-detection:2.0.0` | A standard NIM release, identical bytes on every pull. Used by the four core NIMs and the reranker / ASR NIMs. |
+| Plain semver | `nemotron-object-detection:2.0.1` | A standard NIM release, identical bytes on every pull. Used by the four core NIMs and the reranker / ASR NIMs. |
 | `<semver>-variant` | `nemotron-parse-v1.2:1.7.0-variant`, `nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` | The Nemotron Parse and Nemotron 3 Nano Omni 30B builds that ship per-GPU TensorRT engine variants the NIM Operator selects from at reconciliation time (refer to the Omni and Parse rows in the [model hardware requirements](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#model-hardware-requirements) table). The `-variant` suffix is the NGC tag that ships alongside this chart and matches footnote ³ of the support matrix. |
 
 For air-gapped mirror pipelines: mirror the *exact* tag — both the
@@ -1209,10 +1209,10 @@ your release tag). Defaults below match
 | Role | `nimOperator` key | Default image (`repository:tag`) |
 |------|-------------------|----------------------------------|
 | Retriever service | — | `service.image.repository`:`service.image.tag` (override for production) |
-| Page Elements | `page_elements` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.0` |
-| Table Structure | `table_structure` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.0` |
-| OCR | `ocr` | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.0` |
-| VL embed | `vlm_embed` | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0` |
+| Page Elements | `page_elements` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1` |
+| Table Structure | `table_structure` | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1` |
+| OCR | `ocr` | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` |
+| VL embed | `vlm_embed` | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.2.2` |
 | VL reranker (optional) | `rerankqa` | `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0` |
 | Nemotron Parse (optional) | `nemotron_parse` | `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant` |
 | Omni caption (optional) | `nemotron_3_nano_omni_30b_a3b_reasoning` | `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` |
@@ -1272,10 +1272,10 @@ nimOperator:
 
 ```bash
 docker login nvcr.io -u '$oauthtoken' -p "$NGC_API_KEY"
-docker pull nvcr.io/nim/nvidia/nemotron-object-detection:2.0.0
-docker tag nvcr.io/nim/nvidia/nemotron-object-detection:2.0.0 \
-  <PRIVATE_REGISTRY>/nemotron-object-detection:2.0.0
-docker push <PRIVATE_REGISTRY>/nemotron-object-detection:2.0.0
+docker pull nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1
+docker tag nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1 \
+  <PRIVATE_REGISTRY>/nemotron-object-detection:2.0.1
+docker push <PRIVATE_REGISTRY>/nemotron-object-detection:2.0.1
 ```
 
 For bulk sync, prefer [skopeo](https://github.com/containers/skopeo) or

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -1215,7 +1215,7 @@ nimOperator:
     nimServiceName: llama-nemotron-embed-vl-1b-v2
     image:
       repository: nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2
-      tag: "2.2.2"
+      tag: "2.3.0"
       pullPolicy: IfNotPresent
       pullSecrets:
         - ngc-secret

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -1036,7 +1036,7 @@ nimOperator:
     modelDownloadMode: nimService
     image:
       repository: nvcr.io/nim/nvidia/nemotron-object-detection
-      tag: "2.0.0"
+      tag: "2.0.1"
       pullPolicy: IfNotPresent
       pullSecrets:
         - ngc-secret
@@ -1094,7 +1094,7 @@ nimOperator:
     modelDownloadMode: nimService
     image:
       repository: nvcr.io/nim/nvidia/nemotron-object-detection
-      tag: "2.0.0"
+      tag: "2.0.1"
       pullPolicy: IfNotPresent
       pullSecrets:
         - ngc-secret
@@ -1153,7 +1153,7 @@ nimOperator:
     nimServiceName: nemotron-ocr-v2
     image:
       repository: nvcr.io/nim/nvidia/nemotron-ocr-v2
-      tag: "2.0.0"
+      tag: "2.0.1"
       pullPolicy: IfNotPresent
       pullSecrets:
         - ngc-secret
@@ -1215,7 +1215,7 @@ nimOperator:
     nimServiceName: llama-nemotron-embed-vl-1b-v2
     image:
       repository: nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2
-      tag: "2.3.0"
+      tag: "2.2.2"
       pullPolicy: IfNotPresent
       pullSecrets:
         - ngc-secret

--- a/nemo_retriever/tests/test_helm_nim_model_download_mode.py
+++ b/nemo_retriever/tests/test_helm_nim_model_download_mode.py
@@ -71,7 +71,7 @@ def test_defaults_use_direct_pvc_for_affected_2x_services() -> None:
         }
         assert "nimCache" not in service["spec"]["storage"]
 
-    assert _find(docs, "NIMService", "llama-nemotron-embed-vl-1b-v2")["spec"]["image"]["tag"] == "2.2.2"
+    assert _find(docs, "NIMService", "llama-nemotron-embed-vl-1b-v2")["spec"]["image"]["tag"] == "2.3.0"
     assert _find(docs, "NIMService", "llama-nemotron-rerank-vl-1b-v2")["spec"]["image"]["tag"] == "2.3.0"
 
     embed = _find(docs, "NIMService", "llama-nemotron-embed-vl-1b-v2")["spec"]

--- a/nemo_retriever/tests/test_helm_nim_model_download_mode.py
+++ b/nemo_retriever/tests/test_helm_nim_model_download_mode.py
@@ -71,7 +71,7 @@ def test_defaults_use_direct_pvc_for_affected_2x_services() -> None:
         }
         assert "nimCache" not in service["spec"]["storage"]
 
-    assert _find(docs, "NIMService", "llama-nemotron-embed-vl-1b-v2")["spec"]["image"]["tag"] == "2.3.0"
+    assert _find(docs, "NIMService", "llama-nemotron-embed-vl-1b-v2")["spec"]["image"]["tag"] == "2.2.2"
     assert _find(docs, "NIMService", "llama-nemotron-rerank-vl-1b-v2")["spec"]["image"]["tag"] == "2.3.0"
 
     embed = _find(docs, "NIMService", "llama-nemotron-embed-vl-1b-v2")["spec"]

--- a/nemo_retriever/tests/test_helm_nimcache_model_profile.py
+++ b/nemo_retriever/tests/test_helm_nimcache_model_profile.py
@@ -275,7 +275,7 @@ class NimCacheModelProfileTests(TestCase):
         )
         self.assertEqual(
             ocr_cache["spec"]["source"]["ngc"]["modelPuller"],
-            "nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.0",
+            "nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1",
         )
 
         ocr_service = next(
@@ -287,7 +287,7 @@ class NimCacheModelProfileTests(TestCase):
             ocr_service["spec"]["image"]["repository"],
             "nvcr.io/nim/nvidia/nemotron-ocr-v2",
         )
-        self.assertEqual(ocr_service["spec"]["image"]["tag"], "2.0.0")
+        self.assertEqual(ocr_service["spec"]["image"]["tag"], "2.0.1")
 
         configmaps = [doc for doc in docs if doc.get("kind") == "ConfigMap"]
         self.assertTrue(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Bumps default NIM image tags in the Nemo Retriever Helm chart (`nemo_retriever/helm`):

- `nemotron-object-detection` (used by both `page_elements` and `table_structure`): `2.0.0` → `2.0.1`
- `nemotron-ocr-v2` (`ocr`): `2.0.0` → `2.0.1`

The VL embed NIM (`llama-nemotron-embed-vl-1b-v2`) is left unchanged at `2.3.0`.

Changes:
- `nemo_retriever/helm/values.yaml` — the object-detection and OCR image tags.
- `nemo_retriever/helm/README.md` — mirror image tables, the "Image tag conventions" example, and the air-gapped `docker pull/tag/push` example.
- `nemo_retriever/tests/test_helm_nimcache_model_profile.py` — updated the assertions pinning the OCR tag to `2.0.1`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<sub>Note: the Helm render tests shell out to `helm template`; the `helm` binary could not be installed in this environment (restricted network), so those tests were not executed here. `values.yaml` was validated as well-formed YAML with the expected tags.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fed55-db14-7e42-bbdd-a05362275d38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fed55-db14-7e42-bbdd-a05362275d38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

