### PR TITLE
Parallelize batch text extraction

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -78,6 +78,7 @@ def batch_tuning_to_node_overrides(
     caption_gpus_per_actor: float | None = None,
     video_frame_params: Any | None = None,
     store_params: Any | None = None,
+    extraction_mode: str | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Translate BatchTuningParams from stage params into RayDataExecutor node_overrides.
 
@@ -89,6 +90,8 @@ def batch_tuning_to_node_overrides(
 
     PDF extract concurrency is capped so that it cannot exhaust the cluster CPU
     budget when all other persistent actors are running simultaneously.
+    Plain-text extraction scales conservatively with cluster CPUs while
+    remaining CPU-only so the embedding GPU stays available downstream.
     """
     auto_allow_no_gpu = bool(cluster_resources is not None and cluster_resources.available_gpu_count() == 0)
     effective_allow_no_gpu = allow_no_gpu if allow_no_gpu is not None else auto_allow_no_gpu
@@ -357,6 +360,20 @@ def batch_tuning_to_node_overrides(
         _set(PDFExtractionActor.__name__, "batch_size", pdf_bs)
         _set(PDFExtractionActor.__name__, "concurrency", pdf_extract_tasks)
         _set(PDFExtractionActor.__name__, "num_cpus", pdf_extract_cpus if pdf_extract_cpus != 1.0 else None)
+
+    # High-cardinality text corpora otherwise inherit Ray Data's single-actor
+    # default for this callable-class operator. Keep the pool deliberately
+    # bounded to avoid turning small-file reads into a shared-storage storm.
+    if extraction_mode == "text" and cluster_resources is not None:
+        cpus = cluster_resources.total_cpu_count()
+        if cpus > 0:
+            # RayDataExecutor indexes overrides by the graph node name. Graph
+            # resolution swaps the operator class to MultiTypeExtractCPUActor
+            # but intentionally preserves this archetype node name.
+            node_name = MultiTypeExtractOperator.__name__
+            _set(node_name, "concurrency", max(1, min(cpus // 4, 8)))
+            _set(node_name, "num_cpus", 1)
+            _force_cpu_only(node_name)
 
     # VideoSplitActor: one ffmpeg subprocess per input video, ~1-2 CPU cores
     # per actor during decode. Default Ray Data concurrency=1 serialises every

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -843,6 +843,7 @@ class GraphIngestor(ingestor):
             allow_no_gpu=effective_allow_no_gpu,
             caption_params=self._caption_params,
             video_frame_params=effective_extraction.video_frame_params,
+            extraction_mode=effective_extraction.extraction_mode,
         )
         executor = RayDataExecutor(
             graph,

--- a/nemo_retriever/tests/graph/test_ingestor_runtime.py
+++ b/nemo_retriever/tests/graph/test_ingestor_runtime.py
@@ -1,0 +1,66 @@
+import pytest
+
+from nemo_retriever.common.params import EmbedParams, ExtractParams
+from nemo_retriever.common.ray_resource_hueristics import ClusterResources, Resources
+from nemo_retriever.graph.ingestor_runtime import batch_tuning_to_node_overrides, build_graph
+from nemo_retriever.graph.operator_resolution import resolve_graph
+
+
+def _cluster(cpu_count: int) -> ClusterResources:
+    resources = Resources(cpu_count=cpu_count, gpu_count=1)
+    return ClusterResources(total_resources=resources, available_resources=resources)
+
+
+def test_batch_tuning_to_node_overrides_parallelizes_text_extraction_on_cpu() -> None:
+    overrides = batch_tuning_to_node_overrides(
+        extract_params=ExtractParams(),
+        embed_params=EmbedParams(model_name="nvidia/llama-nemotron-embed-1b-v2"),
+        cluster_resources=_cluster(32),
+        extraction_mode="text",
+    )
+
+    assert overrides["MultiTypeExtractOperator"] == {
+        "concurrency": 8,
+        "num_cpus": 1,
+        "num_gpus": 0.0,
+    }
+
+
+@pytest.mark.parametrize(("cpu_count", "expected_concurrency"), [(1, 1), (8, 2), (32, 8), (224, 8)])
+def test_batch_tuning_to_node_overrides_bounds_text_extraction_pool(cpu_count: int, expected_concurrency: int) -> None:
+    overrides = batch_tuning_to_node_overrides(
+        extract_params=ExtractParams(),
+        embed_params=None,
+        cluster_resources=_cluster(cpu_count),
+        extraction_mode="text",
+    )
+
+    assert overrides["MultiTypeExtractOperator"]["concurrency"] == expected_concurrency
+
+
+def test_batch_tuning_to_node_overrides_leaves_non_text_multi_type_actor_unchanged() -> None:
+    overrides = batch_tuning_to_node_overrides(
+        extract_params=ExtractParams(),
+        embed_params=None,
+        cluster_resources=_cluster(32),
+        extraction_mode="auto",
+    )
+
+    assert "MultiTypeExtractOperator" not in overrides
+
+
+def test_text_extraction_override_targets_preserved_resolved_graph_node_name() -> None:
+    cluster = _cluster(32)
+    graph = build_graph(extraction_mode="text", extract_params=ExtractParams(), stage_order=("extract",))
+    resolved_graph = resolve_graph(graph, cluster)
+    overrides = batch_tuning_to_node_overrides(
+        extract_params=ExtractParams(),
+        embed_params=None,
+        cluster_resources=cluster,
+        extraction_mode="text",
+    )
+
+    assert resolved_graph.roots[0].name == "MultiTypeExtractOperator"
+    assert resolved_graph.roots[0].operator_class.__name__ == "MultiTypeExtractCPUActor"
+    assert resolved_graph.roots[0].name in overrides
+    assert "MultiTypeExtractCPUActor" not in overrides

--- a/nemo_retriever/tests/ingestor/test_graph_ingestor.py
+++ b/nemo_retriever/tests/ingestor/test_graph_ingestor.py
@@ -1,0 +1,39 @@
+from nemo_retriever.common.params import EmbedParams
+from nemo_retriever.common.ray_resource_hueristics import ClusterResources, Resources
+from nemo_retriever.graph.pipeline_graph import Graph
+from nemo_retriever.ingestor.graph_ingestor import GraphIngestor
+
+
+def test_graph_ingestor_applies_parallel_cpu_overrides_for_batch_text(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeExecutor:
+        def __init__(self, graph, **kwargs):
+            self.graph = graph
+            captured["node_overrides"] = kwargs["node_overrides"]
+
+        def ingest(self, data):
+            return {"data": data, "graph": self.graph}
+
+    cluster = ClusterResources(
+        total_resources=Resources(cpu_count=32, gpu_count=1),
+        available_resources=Resources(cpu_count=32, gpu_count=1),
+    )
+
+    monkeypatch.setattr("nemo_retriever.ingestor.graph_ingestor.build_graph", lambda **kwargs: Graph())
+    monkeypatch.setattr(
+        "nemo_retriever.ingestor.graph_ingestor.GraphIngestor._ensure_batch_runtime",
+        lambda self: (object(), cluster),
+    )
+    monkeypatch.setattr("nemo_retriever.ingestor.graph_ingestor.RayDataExecutor", _FakeExecutor)
+
+    ingestor = GraphIngestor(run_mode="batch", documents=["/tmp/input.txt"])
+    ingestor.extract(extraction_mode="text")
+    ingestor.embed(EmbedParams(model_name="nvidia/llama-nemotron-embed-1b-v2"))
+    ingestor.ingest()
+
+    assert captured["node_overrides"]["MultiTypeExtractOperator"] == {
+        "concurrency": 8,
+        "num_cpus": 1,
+        "num_gpus": 0.0,
+    }


### PR DESCRIPTION
## Summary

- plan a bounded CPU actor pool for high-cardinality batch text extraction
- key the override by the preserved `MultiTypeExtractOperator` graph-node name
- keep extraction CPU-only and leave non-text modes unchanged
- add graph-resolution and `GraphIngestor` regression coverage

## Root cause

`resolve_graph()` replaces `MultiTypeExtractOperator` with `MultiTypeExtractCPUActor` but intentionally preserves the graph node name. `RayDataExecutor` indexes `node_overrides` by that preserved name. Targeting the resolved actor-class name therefore missed the override and silently used Ray's default single callable-class actor.

## Runtime evidence

On the same deterministic 10k BrowseComp-Plus input on one H100 NVL / 32 CPUs:

- active extractors: 1 -> 8
- extraction completion: about 377s -> 66s (5.7x)
- output rows: 75,065 before and after
- each corrected extractor used one CPU and zero GPUs

End-to-end BrowseComp ingest remained about 14 minutes because GPU embedding and a separate non-overlapped vector-store tail became the critical path. That store behavior is intentionally out of scope for this fix.

A corrected BRIGHT Biology 10k run completed in 88.6s at 113.0 rows/s.

## Validation

- focused graph/runtime tests: 8 passed
- ingest-focused suite used during acceptance: 128 passed, 3 skipped, 3 deselected
- targeted pre-commit checks passed: whitespace, EOF, large-file, AST, debug, Black, and Flake8
- no deprecated NRL harness changes
