### PR TITLE
fix: preflight batch actor pools against Ray resources

### DIFF
--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -12,6 +12,10 @@ Use this guide to document practical recommendations for:
 - NIM endpoint sizing and concurrency settings
 - Benchmarking methodology and repeatable test setups
 
-## Coming soon
+## Batch resource sizing
 
-Populate this page with validated settings and example profiles as they are reviewed.
+In batch mode, NeMo Retriever Library sizes unspecified Ray actor pools from the CPU and GPU resources that Ray reports as available immediately before the pipeline is submitted. This prevents default extraction, OCR, and embedding pools from reserving more resources than the cluster can schedule.
+
+If you set `BatchTuningParams` worker counts or direct `node_overrides`, those requests must fit the available Ray CPU and GPU budget. The library validates the final plan before submitting work and raises an error when it is infeasible. Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity before retrying.
+
+Use the Ray dashboard to verify the available-resource snapshot and the planned worker allocation when you tune throughput.

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -48,7 +48,8 @@ For per-feature GPU memory, disk, and co-residency rules, refer to [Model hardwa
 
 ### Resource Consumption Notes
 
-- The pipeline performs runtime allocation of parallel resources based on system configuration
+- Batch mode sizes unspecified actor pools from the CPU and GPU resources that Ray reports as available at pipeline submission.
+- Explicit batch worker counts and direct Ray node overrides must fit the available resource budget. The library rejects infeasible plans before submission.
 - Memory usage can reach up to the full system capacity for large document processing
 - CPU utilization scales with the number of concurrent processing tasks
 - GPU is required for inference using HuggingFace models or NIMs

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -64,6 +64,7 @@ inspect row columns and service logs directly.
 | A per-document entry in `ServiceIngestResult.failures` | Upload or pipeline processing failed after a service job was created | Correlate the document ID with the job ID and service logs. Other documents in the same result can still have succeeded. |
 | Successful ingest with fewer rows than inputs (caption or ASR enabled) | Caption inference failed before row collection, or ASR dropped failed rows and logged warnings | Re-run with logging enabled. For caption, verify endpoint credentials and payload limits. For ASR, verify gRPC endpoint, `function_id`, and `NVIDIA_API_KEY`. |
 | OOM, worker exit, or pod restart | Host or GPU resources were exhausted, or an orchestrator terminated the worker | Reduce batch size or concurrency, use smaller document groups, and inspect host, Ray, Kubernetes, and NIM resource telemetry. |
+| `Infeasible Ray CPU/GPU plan` | Explicit worker counts or node overrides exceed resources currently available to Ray. | Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity. Refer to the [performance guide](performance_guide.md). |
 
 The service can retry some transient transport, `429`, and `5xx` failures.
 Report the final status returned after retries, not an intermediate warning.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - "Vector databases": extraction/vdbs.md
   - "7. Deployment & operations":
       - "Ray and distributed ingest": extraction/ray-logging.md
+      - "Batch resource sizing": extraction/performance_guide.md
   - "8. Customize & extend":
       - "Customize & extend": extraction/customize-extend.md
   - "9. Integrations & ecosystem":
@@ -228,7 +229,6 @@ exclude_docs: |
   extraction/agentic-retrieval-concept.md
   extraction/workflow-build-searchable-collection.md
   extraction/vector-db-partners.md
-  extraction/performance_guide.md
 
 extra:
   generator: false

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -252,6 +252,7 @@ class RayDataExecutor(AbstractExecutor):
         self._default_num_gpus = num_gpus
         self._node_overrides = node_overrides or {}
         self._auto_concurrency_nodes = auto_concurrency_nodes or set()
+        self._resources_preflight_complete = False
 
     def _has_remote_endpoint(self, node: Node) -> bool:
         """Return whether a node delegates inference to a remote endpoint."""
@@ -404,7 +405,7 @@ class RayDataExecutor(AbstractExecutor):
             except FileNotFoundError as exc:
                 raise_input_path_not_found(input_paths or [], exc)
         nodes = self._linearize(resolved_graph)
-        if nodes:
+        if nodes and not self._resources_preflight_complete:
             self._preflight_resources(nodes, cluster.available_cpu_count(), available_gpus)
         for node in nodes:
             overrides = dict(self._node_overrides.get(node.name, {}))

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -37,6 +37,28 @@ logger = logging.getLogger(__name__)
 _DEFAULT_GPU_OPERATOR_NUM_GPUS = OCR_GPUS_PER_ACTOR
 
 
+def _concurrency_target(concurrency: Any) -> int:
+    """Return the largest actor-pool size that resource planning can permit."""
+    if isinstance(concurrency, tuple):
+        return int(concurrency[1] if len(concurrency) == 3 else concurrency[0])
+    return int(concurrency)
+
+
+def _concurrency_initial(concurrency: Any) -> int:
+    """Return the number of actors Ray creates when the pool starts."""
+    if isinstance(concurrency, tuple) and len(concurrency) == 3:
+        return int(concurrency[2])
+    return 1
+
+
+def _planned_concurrency(concurrency: Any, planned: int) -> Any:
+    """Preserve Ray's actor-pool tuple while capping its maximum size."""
+    if isinstance(concurrency, tuple) and len(concurrency) == 3:
+        minimum, _maximum, initial = (int(value) for value in concurrency)
+        return (minimum, max(minimum, initial, planned), initial)
+    return planned
+
+
 def preflight_executors(executors: list[Any], cluster_resources: ClusterResources) -> None:
     """Plan all lazy executor pools against one shared Ray resource snapshot."""
     entries = []
@@ -46,24 +68,24 @@ def preflight_executors(executors: list[Any], cluster_resources: ClusterResource
         for node in executor._linearize(resolve_graph(executor.graph, cluster_resources)):
             override = executor._node_overrides.get(node.name, {})
             concurrency = override.get("concurrency", 1)
-            if isinstance(concurrency, tuple):
-                concurrency = concurrency[-1] if len(concurrency) == 3 else concurrency[0]
             entries.append(
                 (
                     executor,
                     node.name,
-                    int(concurrency),
+                    concurrency,
+                    _concurrency_target(concurrency),
+                    _concurrency_initial(concurrency),
                     float(override.get("num_cpus", executor._default_num_cpus)),
                     executor._scheduled_num_gpus(node, override, available_gpus),
                     node.name in executor._auto_concurrency_nodes,
                 )
             )
-    fixed = [item for item in entries if not item[5]]
-    auto = [item for item in entries if item[5]]
-    fixed_cpu = sum(item[2] * item[3] for item in fixed)
-    fixed_gpu = sum(item[2] * item[4] for item in fixed)
-    min_cpu = sum(item[3] for item in auto)
-    min_gpu = sum(item[4] for item in auto)
+    fixed = [item for item in entries if not item[7]]
+    auto = [item for item in entries if item[7]]
+    fixed_cpu = sum(item[3] * item[5] for item in fixed)
+    fixed_gpu = sum(item[3] * item[6] for item in fixed)
+    min_cpu = sum(item[4] * item[5] for item in auto)
+    min_gpu = sum(item[4] * item[6] for item in auto)
     if fixed_cpu + min_cpu > available_cpus or fixed_gpu + min_gpu > available_gpus:
         raise ValueError(
             "Infeasible Ray CPU/GPU plan: requested at least "
@@ -72,27 +94,27 @@ def preflight_executors(executors: list[Any], cluster_resources: ClusterResource
             "Reduce explicit *_workers or node_overrides concurrency, or wait for cluster capacity."
         )
     used_cpu, used_gpu = fixed_cpu + min_cpu, fixed_gpu + min_gpu
-    planned = {(id(item[0]), item[1]): 1 for item in auto}
+    planned = {(id(item[0]), item[1]): item[4] for item in auto}
     while True:
         candidates = sorted(
-            (item for item in auto if planned[(id(item[0]), item[1])] < item[2]),
-            key=lambda item: planned[(id(item[0]), item[1])] / item[2],
+            (item for item in auto if planned[(id(item[0]), item[1])] < item[3]),
+            key=lambda item: planned[(id(item[0]), item[1])] / item[3],
         )
         selected = next(
             (
                 item
                 for item in candidates
-                if used_cpu + item[3] <= available_cpus and used_gpu + item[4] <= available_gpus
+                if used_cpu + item[5] <= available_cpus and used_gpu + item[6] <= available_gpus
             ),
             None,
         )
         if selected is None:
             break
         planned[(id(selected[0]), selected[1])] += 1
-        used_cpu += selected[3]
-        used_gpu += selected[4]
-    for executor, name, _count, _cpu, _gpu, _auto in auto:
-        executor._node_overrides[name]["concurrency"] = planned[(id(executor), name)]
+        used_cpu += selected[5]
+        used_gpu += selected[6]
+    for executor, name, concurrency, _target, _initial, _cpu, _gpu, _auto in auto:
+        executor._node_overrides[name]["concurrency"] = _planned_concurrency(concurrency, planned[(id(executor), name)])
     for executor in executors:
         executor._resources_preflight_complete = True
 
@@ -292,22 +314,22 @@ class RayDataExecutor(AbstractExecutor):
         for node in nodes:
             override = self._node_overrides.get(node.name, {})
             concurrency = override.get("concurrency", 1)
-            if isinstance(concurrency, tuple):
-                concurrency = concurrency[-1] if len(concurrency) == 3 else concurrency[0]
             entries.append(
                 (
                     node.name,
-                    int(concurrency),
+                    concurrency,
+                    _concurrency_target(concurrency),
+                    _concurrency_initial(concurrency),
                     float(override.get("num_cpus", self._default_num_cpus)),
                     self._scheduled_num_gpus(node, override, available_gpus),
                 )
             )
         fixed = [item for item in entries if item[0] not in self._auto_concurrency_nodes]
         auto = [item for item in entries if item[0] in self._auto_concurrency_nodes]
-        fixed_cpu = sum(count * cpu for _name, count, cpu, _gpu in fixed)
-        fixed_gpu = sum(count * gpu for _name, count, _cpu, gpu in fixed)
-        minimum_cpu = sum(cpu for _name, _count, cpu, _gpu in auto)
-        minimum_gpu = sum(gpu for _name, _count, _cpu, gpu in auto)
+        fixed_cpu = sum(count * cpu for _name, _concurrency, count, _initial, cpu, _gpu in fixed)
+        fixed_gpu = sum(count * gpu for _name, _concurrency, count, _initial, _cpu, gpu in fixed)
+        minimum_cpu = sum(initial * cpu for _name, _concurrency, _count, initial, cpu, _gpu in auto)
+        minimum_gpu = sum(initial * gpu for _name, _concurrency, _count, initial, _cpu, gpu in auto)
         if fixed_cpu + minimum_cpu > available_cpus or fixed_gpu + minimum_gpu > available_gpus:
             raise ValueError(
                 "Infeasible Ray CPU/GPU plan: requested at least "
@@ -316,28 +338,28 @@ class RayDataExecutor(AbstractExecutor):
                 "Reduce explicit *_workers or node_overrides concurrency, or wait for cluster capacity."
             )
         used_cpu, used_gpu = fixed_cpu + minimum_cpu, fixed_gpu + minimum_gpu
-        planned = {name: 1 for name, _count, _cpu, _gpu in auto}
+        planned = {name: initial for name, _concurrency, _count, initial, _cpu, _gpu in auto}
         while True:
             candidates = sorted(
-                (item for item in auto if planned[item[0]] < item[1]),
-                key=lambda item: planned[item[0]] / item[1],
+                (item for item in auto if planned[item[0]] < item[2]),
+                key=lambda item: planned[item[0]] / item[2],
             )
             selected = next(
                 (
                     item
                     for item in candidates
-                    if used_cpu + item[2] <= available_cpus and used_gpu + item[3] <= available_gpus
+                    if used_cpu + item[4] <= available_cpus and used_gpu + item[5] <= available_gpus
                 ),
                 None,
             )
             if selected is None:
                 break
-            name, _count, cpu, gpu = selected
+            name, _concurrency, _count, _initial, cpu, gpu = selected
             planned[name] += 1
             used_cpu += cpu
             used_gpu += gpu
-        for name, count in planned.items():
-            self._node_overrides[name]["concurrency"] = count
+        for name, concurrency, _count, _initial, _cpu, _gpu in auto:
+            self._node_overrides[name]["concurrency"] = _planned_concurrency(concurrency, planned[name])
 
     @staticmethod
     def _linearize(graph: Graph) -> List[Node]:

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -117,6 +117,7 @@ def preflight_executors(executors: list[Any], cluster_resources: ClusterResource
         executor._node_overrides[name]["concurrency"] = _planned_concurrency(concurrency, planned[(id(executor), name)])
     for executor in executors:
         executor._resources_preflight_complete = True
+        executor._preflight_cluster_resources = cluster_resources
 
 
 class AbstractExecutor(ABC):
@@ -267,6 +268,7 @@ class RayDataExecutor(AbstractExecutor):
         auto_concurrency_nodes: Optional[Set[str]] = None,
     ) -> None:
         super().__init__(graph)
+        self._preflight_cluster_resources: ClusterResources | None = None
         self._ray_address = ray_address
         self._default_batch_size = batch_size
         self._default_batch_format = batch_format
@@ -415,7 +417,7 @@ class RayDataExecutor(AbstractExecutor):
         ctx.enable_rich_progress_bars = True
         ctx.use_ray_tqdm = False
 
-        cluster = gather_cluster_resources(ray)
+        cluster = self._preflight_cluster_resources or gather_cluster_resources(ray)
         available_gpus = cluster.available_gpu_count()
         resolved_graph = resolve_graph(self.graph, cluster)
 

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -200,7 +200,14 @@ class RayDataExecutor(AbstractExecutor):
             concurrency = override.get("concurrency", 1)
             if isinstance(concurrency, tuple):
                 concurrency = concurrency[-1] if len(concurrency) == 3 else concurrency[0]
-            entries.append((node.name, int(concurrency), float(override.get("num_cpus", self._default_num_cpus)), float(override.get("num_gpus", self._default_num_gpus))))
+            entries.append(
+                (
+                    node.name,
+                    int(concurrency),
+                    float(override.get("num_cpus", self._default_num_cpus)),
+                    float(override.get("num_gpus", self._default_num_gpus)),
+                )
+            )
         fixed = [item for item in entries if item[0] not in self._auto_concurrency_nodes]
         auto = [item for item in entries if item[0] in self._auto_concurrency_nodes]
         fixed_cpu = sum(count * cpu for _name, count, cpu, _gpu in fixed)
@@ -221,7 +228,14 @@ class RayDataExecutor(AbstractExecutor):
                 (item for item in auto if planned[item[0]] < item[1]),
                 key=lambda item: planned[item[0]] / item[1],
             )
-            selected = next((item for item in candidates if used_cpu + item[2] <= available_cpus and used_gpu + item[3] <= available_gpus), None)
+            selected = next(
+                (
+                    item
+                    for item in candidates
+                    if used_cpu + item[2] <= available_cpus and used_gpu + item[3] <= available_gpus
+                ),
+                None,
+            )
             if selected is None:
                 break
             name, _count, cpu, gpu = selected

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 import pandas as pd
 
 from nemo_retriever.operators.gpu_operator import GPUOperator
@@ -181,6 +181,7 @@ class RayDataExecutor(AbstractExecutor):
         num_cpus: float = 1,
         num_gpus: float = 0,
         node_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
+        auto_concurrency_nodes: Optional[Set[str]] = None,
     ) -> None:
         super().__init__(graph)
         self._ray_address = ray_address
@@ -189,6 +190,46 @@ class RayDataExecutor(AbstractExecutor):
         self._default_num_cpus = num_cpus
         self._default_num_gpus = num_gpus
         self._node_overrides = node_overrides or {}
+        self._auto_concurrency_nodes = auto_concurrency_nodes or set()
+
+    def _preflight_resources(self, nodes: List[Node], available_cpus: int, available_gpus: int) -> None:
+        """Reduce unspecified pools and reject infeasible explicit plans."""
+        entries = []
+        for node in nodes:
+            override = self._node_overrides.get(node.name, {})
+            concurrency = override.get("concurrency", 1)
+            if isinstance(concurrency, tuple):
+                concurrency = concurrency[-1] if len(concurrency) == 3 else concurrency[0]
+            entries.append((node.name, int(concurrency), float(override.get("num_cpus", self._default_num_cpus)), float(override.get("num_gpus", self._default_num_gpus))))
+        fixed = [item for item in entries if item[0] not in self._auto_concurrency_nodes]
+        auto = [item for item in entries if item[0] in self._auto_concurrency_nodes]
+        fixed_cpu = sum(count * cpu for _name, count, cpu, _gpu in fixed)
+        fixed_gpu = sum(count * gpu for _name, count, _cpu, gpu in fixed)
+        minimum_cpu = sum(cpu for _name, _count, cpu, _gpu in auto)
+        minimum_gpu = sum(gpu for _name, _count, _cpu, gpu in auto)
+        if fixed_cpu + minimum_cpu > available_cpus or fixed_gpu + minimum_gpu > available_gpus:
+            raise ValueError(
+                "Infeasible Ray CPU/GPU plan: requested at least "
+                f"{fixed_cpu + minimum_cpu:g} CPUs and {fixed_gpu + minimum_gpu:g} GPUs, but Ray reports "
+                f"{available_cpus} CPUs and {available_gpus} GPUs available. "
+                "Reduce explicit *_workers or node_overrides concurrency, or wait for cluster capacity."
+            )
+        used_cpu, used_gpu = fixed_cpu + minimum_cpu, fixed_gpu + minimum_gpu
+        planned = {name: 1 for name, _count, _cpu, _gpu in auto}
+        while True:
+            candidates = sorted(
+                (item for item in auto if planned[item[0]] < item[1]),
+                key=lambda item: planned[item[0]] / item[1],
+            )
+            selected = next((item for item in candidates if used_cpu + item[2] <= available_cpus and used_gpu + item[3] <= available_gpus), None)
+            if selected is None:
+                break
+            name, _count, cpu, gpu = selected
+            planned[name] += 1
+            used_cpu += cpu
+            used_gpu += gpu
+        for name, count in planned.items():
+            self._node_overrides[name]["concurrency"] = count
 
     @staticmethod
     def _linearize(graph: Graph) -> List[Node]:
@@ -256,6 +297,8 @@ class RayDataExecutor(AbstractExecutor):
             except FileNotFoundError as exc:
                 raise_input_path_not_found(input_paths or [], exc)
         nodes = self._linearize(resolved_graph)
+        if nodes:
+            self._preflight_resources(nodes, cluster.available_cpu_count(), available_gpus)
         for node in nodes:
             overrides = dict(self._node_overrides.get(node.name, {}))
             target_num_rows_per_block = overrides.pop("target_num_rows_per_block", None)

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -13,6 +13,7 @@ import pandas as pd
 from nemo_retriever.operators.gpu_operator import GPUOperator
 from nemo_retriever.graph.pipeline_graph import Graph, Node
 from nemo_retriever.graph.operator_resolution import resolve_graph
+from nemo_retriever.common.ray_resource_hueristics import ClusterResources
 from nemo_retriever.common.input_files import (
     _is_explicit_glob_path,
     expand_input_file_patterns,
@@ -34,6 +35,66 @@ logger = logging.getLogger(__name__)
 # Heuristic GPU fraction for GPUOperator nodes that load a local model.
 # Reuses the same baseline constant as the batch ingest mode.
 _DEFAULT_GPU_OPERATOR_NUM_GPUS = OCR_GPUS_PER_ACTOR
+
+
+def preflight_executors(executors: list[Any], cluster_resources: ClusterResources) -> None:
+    """Plan all lazy executor pools against one shared Ray resource snapshot."""
+    entries = []
+    available_cpus = cluster_resources.available_cpu_count()
+    available_gpus = cluster_resources.available_gpu_count()
+    for executor in executors:
+        for node in executor._linearize(resolve_graph(executor.graph, cluster_resources)):
+            override = executor._node_overrides.get(node.name, {})
+            concurrency = override.get("concurrency", 1)
+            if isinstance(concurrency, tuple):
+                concurrency = concurrency[-1] if len(concurrency) == 3 else concurrency[0]
+            entries.append(
+                (
+                    executor,
+                    node.name,
+                    int(concurrency),
+                    float(override.get("num_cpus", executor._default_num_cpus)),
+                    executor._scheduled_num_gpus(node, override, available_gpus),
+                    node.name in executor._auto_concurrency_nodes,
+                )
+            )
+    fixed = [item for item in entries if not item[5]]
+    auto = [item for item in entries if item[5]]
+    fixed_cpu = sum(item[2] * item[3] for item in fixed)
+    fixed_gpu = sum(item[2] * item[4] for item in fixed)
+    min_cpu = sum(item[3] for item in auto)
+    min_gpu = sum(item[4] for item in auto)
+    if fixed_cpu + min_cpu > available_cpus or fixed_gpu + min_gpu > available_gpus:
+        raise ValueError(
+            "Infeasible Ray CPU/GPU plan: requested at least "
+            f"{fixed_cpu + min_cpu:g} CPUs and {fixed_gpu + min_gpu:g} GPUs, but Ray reports "
+            f"{available_cpus} CPUs and {available_gpus} GPUs available. "
+            "Reduce explicit *_workers or node_overrides concurrency, or wait for cluster capacity."
+        )
+    used_cpu, used_gpu = fixed_cpu + min_cpu, fixed_gpu + min_gpu
+    planned = {(id(item[0]), item[1]): 1 for item in auto}
+    while True:
+        candidates = sorted(
+            (item for item in auto if planned[(id(item[0]), item[1])] < item[2]),
+            key=lambda item: planned[(id(item[0]), item[1])] / item[2],
+        )
+        selected = next(
+            (
+                item
+                for item in candidates
+                if used_cpu + item[3] <= available_cpus and used_gpu + item[4] <= available_gpus
+            ),
+            None,
+        )
+        if selected is None:
+            break
+        planned[(id(selected[0]), selected[1])] += 1
+        used_cpu += selected[3]
+        used_gpu += selected[4]
+    for executor, name, _count, _cpu, _gpu, _auto in auto:
+        executor._node_overrides[name]["concurrency"] = planned[(id(executor), name)]
+    for executor in executors:
+        executor._resources_preflight_complete = True
 
 
 class AbstractExecutor(ABC):

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -192,6 +192,38 @@ class RayDataExecutor(AbstractExecutor):
         self._node_overrides = node_overrides or {}
         self._auto_concurrency_nodes = auto_concurrency_nodes or set()
 
+    def _has_remote_endpoint(self, node: Node) -> bool:
+        """Return whether a node delegates inference to a remote endpoint."""
+        if any("invoke_url" in key and bool(value) for key, value in node.operator_kwargs.items()):
+            return True
+        return any(
+            hasattr(value, "model_dump")
+            and any("invoke_url" in key and bool(item) for key, item in value.model_dump(exclude_none=True).items())
+            for value in node.operator_kwargs.values()
+        )
+
+    def _scheduled_num_gpus(self, node: Node, overrides: Dict[str, Any], available_gpus: int) -> float:
+        """Resolve the GPU reservation passed to Ray for a graph node."""
+        if "num_gpus" in overrides:
+            return float(overrides["num_gpus"])
+        if not issubclass(node.operator_class, GPUOperator) or self._has_remote_endpoint(node):
+            return float(self._default_num_gpus)
+        if available_gpus > 0:
+            from nemo_retriever.operators.extract.parse.nemotron_parse import NemotronParseActor, NemotronParseGPUActor
+            from nemo_retriever.operators.extract.caption.caption import CaptionGPUActor
+
+            if issubclass(node.operator_class, (NemotronParseActor, NemotronParseGPUActor, CaptionGPUActor)):
+                return max(float(self._default_num_gpus), VLLM_GPUS_PER_ACTOR)
+            return max(float(self._default_num_gpus), _DEFAULT_GPU_OPERATOR_NUM_GPUS)
+        logger.warning(
+            "Node %r is a GPUOperator with no remote endpoint but the Ray cluster reports 0 available GPUs. "
+            "The actor will be scheduled with num_gpus=0 and will likely fail to load its model. "
+            "Pass --ocr-invoke-url / --page-elements-invoke-url / --embed-invoke-url to use remote endpoints, "
+            "or ensure GPUs are visible to Ray.",
+            node.name,
+        )
+        return float(self._default_num_gpus)
+
     def _preflight_resources(self, nodes: List[Node], available_cpus: int, available_gpus: int) -> None:
         """Reduce unspecified pools and reject infeasible explicit plans."""
         entries = []
@@ -205,7 +237,7 @@ class RayDataExecutor(AbstractExecutor):
                     node.name,
                     int(concurrency),
                     float(override.get("num_cpus", self._default_num_cpus)),
-                    float(override.get("num_gpus", self._default_num_gpus)),
+                    self._scheduled_num_gpus(node, override, available_gpus),
                 )
             )
         fixed = [item for item in entries if item[0] not in self._auto_concurrency_nodes]
@@ -342,57 +374,8 @@ class RayDataExecutor(AbstractExecutor):
                 batch_size = None
                 target_num_rows_per_block = None
 
-            # When no explicit num_gpus override is given, auto-detect from the
-            # GPUOperator mixin using actual cluster GPU availability.
-            if "num_gpus" in overrides:
-                num_gpus = overrides.pop("num_gpus")
-            elif issubclass(node.operator_class, GPUOperator):
-                has_remote_endpoint = any("invoke_url" in k and bool(v) for k, v in node.operator_kwargs.items())
-                # For composite operators (e.g. MultiTypeExtractOperator) the
-                # invoke URLs live inside a nested ExtractParams object rather
-                # than as top-level kwargs.  Check those too.
-                if not has_remote_endpoint:
-                    for v in node.operator_kwargs.values():
-                        if hasattr(v, "model_dump"):
-                            has_remote_endpoint = any(
-                                "invoke_url" in k and bool(val) for k, val in v.model_dump(exclude_none=True).items()
-                            )
-                            if has_remote_endpoint:
-                                break
-                if has_remote_endpoint:
-                    # Remote endpoint handles the model — no local GPU needed.
-                    num_gpus = self._default_num_gpus
-                elif available_gpus > 0:
-                    # Local model, GPUs present: assign the heuristic fraction so
-                    # Ray can co-schedule multiple actors per GPU.
-                    # Exception: actors backed by vLLM (NemotronParse, Caption)
-                    # manage their own KV-cache and require exclusive GPU access.
-                    from nemo_retriever.operators.extract.parse.nemotron_parse import (
-                        NemotronParseActor,
-                        NemotronParseGPUActor,
-                    )
-                    from nemo_retriever.operators.extract.caption.caption import CaptionGPUActor
-
-                    if issubclass(node.operator_class, (NemotronParseActor, NemotronParseGPUActor, CaptionGPUActor)):
-                        num_gpus = max(self._default_num_gpus, VLLM_GPUS_PER_ACTOR)
-                    else:
-                        num_gpus = max(self._default_num_gpus, _DEFAULT_GPU_OPERATOR_NUM_GPUS)
-                else:
-                    # No GPUs in the cluster — operator will likely fail to load
-                    # its CUDA model.  Warn loudly rather than silently requesting
-                    # a fraction that would stall the pipeline indefinitely.
-                    logger.warning(
-                        "Node %r is a GPUOperator with no remote endpoint but "
-                        "the Ray cluster reports 0 available GPUs. "
-                        "The actor will be scheduled with num_gpus=0 and will "
-                        "likely fail to load its model. Pass --ocr-invoke-url / "
-                        "--page-elements-invoke-url / --embed-invoke-url to use "
-                        "remote endpoints, or ensure GPUs are visible to Ray.",
-                        node.name,
-                    )
-                    num_gpus = self._default_num_gpus
-            else:
-                num_gpus = self._default_num_gpus
+            num_gpus = self._scheduled_num_gpus(node, overrides, available_gpus)
+            overrides.pop("num_gpus", None)
 
             if requires_global_batch:
                 # ``num_blocks=1`` is exact; ``target_num_rows_per_block`` is a

--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -54,7 +54,10 @@ def _batch_tuning(params: Any) -> Any:
 
 
 def default_concurrency_node_names(
-    extract_params: Any | None, embed_params: Any | None, store_params: Any | None, caption_params: Any | None,
+    extract_params: Any | None,
+    embed_params: Any | None,
+    store_params: Any | None,
+    caption_params: Any | None,
 ) -> set[str]:
     """Return pools whose concurrency came from an unspecified default."""
     names: set[str] = set()
@@ -67,7 +70,9 @@ def default_concurrency_node_names(
             PDFExtractionActor.__name__: "pdf_extract_workers",
             NemotronParseActor.__name__: "nemotron_parse_workers",
         }
-        names.update(name for name, field in worker_fields.items() if not _positive(getattr(extract_tuning, field, None)))
+        names.update(
+            name for name, field in worker_fields.items() if not _positive(getattr(extract_tuning, field, None))
+        )
     embed_tuning = _batch_tuning(embed_params)
     if embed_params is not None and not _positive(getattr(embed_tuning, "embed_workers", None)):
         names.add(_BatchEmbedActor.__name__)

--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -53,6 +53,32 @@ def _batch_tuning(params: Any) -> Any:
     return getattr(params, "batch_tuning", None)
 
 
+def default_concurrency_node_names(
+    extract_params: Any | None, embed_params: Any | None, store_params: Any | None, caption_params: Any | None,
+) -> set[str]:
+    """Return pools whose concurrency came from an unspecified default."""
+    names: set[str] = set()
+    extract_tuning = _batch_tuning(extract_params)
+    if extract_params is not None:
+        worker_fields = {
+            resolve_ocr_archetype(extract_params).__name__: "ocr_workers",
+            PageElementDetectionActor.__name__: "page_elements_workers",
+            TableStructureActor.__name__: "table_structure_workers",
+            PDFExtractionActor.__name__: "pdf_extract_workers",
+            NemotronParseActor.__name__: "nemotron_parse_workers",
+        }
+        names.update(name for name, field in worker_fields.items() if not _positive(getattr(extract_tuning, field, None)))
+    embed_tuning = _batch_tuning(embed_params)
+    if embed_params is not None and not _positive(getattr(embed_tuning, "embed_workers", None)):
+        names.add(_BatchEmbedActor.__name__)
+    store_tuning = _batch_tuning(store_params)
+    if store_params is not None and not _positive(getattr(store_tuning, "store_workers", None)):
+        names.add(StoreOperator.__name__)
+    if caption_params is not None:
+        names.add(CaptionActor.__name__)
+    return names
+
+
 def _positive(value: Any) -> Any:
     return value if value not in (None, 0, 0.0, "", False) else None
 

--- a/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
@@ -88,7 +88,7 @@ class ExtractionBranchExecutor:
         effective_allow_no_gpu = self.allow_no_gpu or cluster_resources.available_gpu_count() == 0
         branch_datasets: list[Any] = []
         branch_executors: list[RayDataExecutor] = []
-        branch_inputs: list[tuple[RayDataExecutor, list[str], list[dict[str, str]]]] = []
+        branch_inputs: list[tuple[RayDataExecutor, Any]] = []
         for branch in self.branches:
             effective_extraction = self._resolve_branch(branch)
             logger.info(
@@ -107,14 +107,20 @@ class ExtractionBranchExecutor:
                 caption_params=None,
                 video_frame_params=effective_extraction.video_frame_params,
             )
-            executor = self._ray_executor(
-                graph,
-                derived_overrides,
-                default_concurrency_node_names(effective_extraction.extract_params, None, None, None),
-            )
-            branch_executors.append(executor)
             file_paths, inline_rows = self._partition_branch_inputs(branch)
-            branch_inputs.append((executor, file_paths, inline_rows))
+            inputs = []
+            if file_paths:
+                inputs.append(file_paths)
+            if inline_rows:
+                inputs.append(ray_module.data.from_items(inline_rows))
+            for input_data in inputs:
+                executor = self._ray_executor(
+                    graph,
+                    derived_overrides,
+                    default_concurrency_node_names(effective_extraction.extract_params, None, None, None),
+                )
+                branch_executors.append(executor)
+                branch_inputs.append((executor, input_data))
 
         logger.info("Retriever ingest post-extraction stages: %s", format_post_stage_summary(self.post_extract_order))
         post_graph = build_post_extract_graph(
@@ -144,11 +150,8 @@ class ExtractionBranchExecutor:
         if hasattr(cluster_resources, "available_cpu_count"):
             preflight_executors([*branch_executors, post_executor], cluster_resources)
 
-        for executor, file_paths, inline_rows in branch_inputs:
-            if file_paths:
-                branch_datasets.append(executor.build_dataset(file_paths))
-            if inline_rows:
-                branch_datasets.append(executor.build_dataset(ray_module.data.from_items(inline_rows)))
+        for executor, input_data in branch_inputs:
+            branch_datasets.append(executor.build_dataset(input_data))
         normalized = normalize_ray_branch_datasets(branch_datasets)
         combined = normalized[0]
         for branch_ds in normalized[1:]:

--- a/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
@@ -13,7 +13,10 @@ from typing import Any, Callable
 
 from nemo_retriever.graph import InprocessExecutor, RayDataExecutor
 from nemo_retriever.graph.ingestor_runtime import (
-    batch_tuning_to_node_overrides, build_graph, build_post_extract_graph, default_concurrency_node_names,
+    batch_tuning_to_node_overrides,
+    build_graph,
+    build_post_extract_graph,
+    default_concurrency_node_names,
 )
 from nemo_retriever.ingestor.manifest import (
     ExtractionBranchPlan,
@@ -102,7 +105,8 @@ class ExtractionBranchExecutor:
                 video_frame_params=effective_extraction.video_frame_params,
             )
             executor = self._ray_executor(
-                graph, derived_overrides,
+                graph,
+                derived_overrides,
                 default_concurrency_node_names(effective_extraction.extract_params, None, None, None),
             )
             file_paths, inline_rows = self._partition_branch_inputs(branch)
@@ -137,7 +141,8 @@ class ExtractionBranchExecutor:
             video_frame_params=None,
         )
         return self._ray_executor(
-            post_graph, post_overrides,
+            post_graph,
+            post_overrides,
             default_concurrency_node_names(None, self.embed_params, self.store_params, self.caption_params),
         ).ingest(combined)
 
@@ -201,7 +206,10 @@ class ExtractionBranchExecutor:
         )
 
     def _ray_executor(
-        self, graph: Any, derived_overrides: dict[str, dict[str, Any]], auto_concurrency_nodes: set[str],
+        self,
+        graph: Any,
+        derived_overrides: dict[str, dict[str, Any]],
+        auto_concurrency_nodes: set[str],
     ) -> RayDataExecutor:
         return RayDataExecutor(
             graph,

--- a/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
@@ -12,7 +12,9 @@ from io import BytesIO
 from typing import Any, Callable
 
 from nemo_retriever.graph import InprocessExecutor, RayDataExecutor
-from nemo_retriever.graph.ingestor_runtime import batch_tuning_to_node_overrides, build_graph, build_post_extract_graph
+from nemo_retriever.graph.ingestor_runtime import (
+    batch_tuning_to_node_overrides, build_graph, build_post_extract_graph, default_concurrency_node_names,
+)
 from nemo_retriever.ingestor.manifest import (
     ExtractionBranchPlan,
     ResolvedExtractionInputs,
@@ -99,7 +101,10 @@ class ExtractionBranchExecutor:
                 caption_params=None,
                 video_frame_params=effective_extraction.video_frame_params,
             )
-            executor = self._ray_executor(graph, derived_overrides)
+            executor = self._ray_executor(
+                graph, derived_overrides,
+                default_concurrency_node_names(effective_extraction.extract_params, None, None, None),
+            )
             file_paths, inline_rows = self._partition_branch_inputs(branch)
             if file_paths:
                 branch_datasets.append(executor.build_dataset(file_paths))
@@ -131,7 +136,10 @@ class ExtractionBranchExecutor:
             caption_params=self.caption_params,
             video_frame_params=None,
         )
-        return self._ray_executor(post_graph, post_overrides).ingest(combined)
+        return self._ray_executor(
+            post_graph, post_overrides,
+            default_concurrency_node_names(None, self.embed_params, self.store_params, self.caption_params),
+        ).ingest(combined)
 
     def _execute_inprocess(self) -> Any:
         frames = []
@@ -192,7 +200,9 @@ class ExtractionBranchExecutor:
             stage_order=(),
         )
 
-    def _ray_executor(self, graph: Any, derived_overrides: dict[str, dict[str, Any]]) -> RayDataExecutor:
+    def _ray_executor(
+        self, graph: Any, derived_overrides: dict[str, dict[str, Any]], auto_concurrency_nodes: set[str],
+    ) -> RayDataExecutor:
         return RayDataExecutor(
             graph,
             ray_address=self.ray_address,
@@ -200,6 +210,7 @@ class ExtractionBranchExecutor:
             num_cpus=self.num_cpus,
             num_gpus=self.num_gpus,
             node_overrides=merge_node_overrides(derived_overrides, self.node_overrides),
+            auto_concurrency_nodes=auto_concurrency_nodes - set(self.node_overrides),
         )
 
     def _inprocess_branch_input(self, branch: ExtractionBranchPlan) -> Any:

--- a/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
@@ -88,6 +88,7 @@ class ExtractionBranchExecutor:
         effective_allow_no_gpu = self.allow_no_gpu or cluster_resources.available_gpu_count() == 0
         branch_datasets: list[Any] = []
         branch_executors: list[RayDataExecutor] = []
+        branch_inputs: list[tuple[RayDataExecutor, list[str], list[dict[str, str]]]] = []
         for branch in self.branches:
             effective_extraction = self._resolve_branch(branch)
             logger.info(
@@ -113,15 +114,7 @@ class ExtractionBranchExecutor:
             )
             branch_executors.append(executor)
             file_paths, inline_rows = self._partition_branch_inputs(branch)
-            if file_paths:
-                branch_datasets.append(executor.build_dataset(file_paths))
-            if inline_rows:
-                branch_datasets.append(executor.build_dataset(ray_module.data.from_items(inline_rows)))
-
-        normalized = normalize_ray_branch_datasets(branch_datasets)
-        combined = normalized[0]
-        for branch_ds in normalized[1:]:
-            combined = combined.union(branch_ds)
+            branch_inputs.append((executor, file_paths, inline_rows))
 
         logger.info("Retriever ingest post-extraction stages: %s", format_post_stage_summary(self.post_extract_order))
         post_graph = build_post_extract_graph(
@@ -150,6 +143,16 @@ class ExtractionBranchExecutor:
         )
         if hasattr(cluster_resources, "available_cpu_count"):
             preflight_executors([*branch_executors, post_executor], cluster_resources)
+
+        for executor, file_paths, inline_rows in branch_inputs:
+            if file_paths:
+                branch_datasets.append(executor.build_dataset(file_paths))
+            if inline_rows:
+                branch_datasets.append(executor.build_dataset(ray_module.data.from_items(inline_rows)))
+        normalized = normalize_ray_branch_datasets(branch_datasets)
+        combined = normalized[0]
+        for branch_ds in normalized[1:]:
+            combined = combined.union(branch_ds)
         return post_executor.ingest(combined)
 
     def _execute_inprocess(self) -> Any:

--- a/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
@@ -12,6 +12,7 @@ from io import BytesIO
 from typing import Any, Callable
 
 from nemo_retriever.graph import InprocessExecutor, RayDataExecutor
+from nemo_retriever.graph.executor import preflight_executors
 from nemo_retriever.graph.ingestor_runtime import (
     batch_tuning_to_node_overrides,
     build_graph,
@@ -86,6 +87,7 @@ class ExtractionBranchExecutor:
         ray_module, cluster_resources = self.ensure_batch_runtime()
         effective_allow_no_gpu = self.allow_no_gpu or cluster_resources.available_gpu_count() == 0
         branch_datasets: list[Any] = []
+        branch_executors: list[RayDataExecutor] = []
         for branch in self.branches:
             effective_extraction = self._resolve_branch(branch)
             logger.info(
@@ -109,6 +111,7 @@ class ExtractionBranchExecutor:
                 derived_overrides,
                 default_concurrency_node_names(effective_extraction.extract_params, None, None, None),
             )
+            branch_executors.append(executor)
             file_paths, inline_rows = self._partition_branch_inputs(branch)
             if file_paths:
                 branch_datasets.append(executor.build_dataset(file_paths))
@@ -140,11 +143,14 @@ class ExtractionBranchExecutor:
             caption_params=self.caption_params,
             video_frame_params=None,
         )
-        return self._ray_executor(
+        post_executor = self._ray_executor(
             post_graph,
             post_overrides,
             default_concurrency_node_names(None, self.embed_params, self.store_params, self.caption_params),
-        ).ingest(combined)
+        )
+        if hasattr(cluster_resources, "available_cpu_count"):
+            preflight_executors([*branch_executors, post_executor], cluster_resources)
+        return post_executor.ingest(combined)
 
     def _execute_inprocess(self) -> Any:
         frames = []

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -34,7 +34,9 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Self
 
 from nemo_retriever.graph import InprocessExecutor, RayDataExecutor
 from nemo_retriever.ingestor.branch_extraction import ExtractionBranchExecutor, merge_node_overrides
-from nemo_retriever.graph.ingestor_runtime import batch_tuning_to_node_overrides, build_graph
+from nemo_retriever.graph.ingestor_runtime import (
+    batch_tuning_to_node_overrides, build_graph, default_concurrency_node_names,
+)
 from nemo_retriever.ingestor.manifest import (
     ExtractionBranchPlan,
     ResolvedExtractionInputs,
@@ -851,6 +853,11 @@ class GraphIngestor(ingestor):
             num_cpus=self._num_cpus,
             num_gpus=self._num_gpus,
             node_overrides=merge_node_overrides(derived_overrides, self._node_overrides),
+            auto_concurrency_nodes=(
+                default_concurrency_node_names(
+                    effective_extraction.extract_params, self._embed_params, self._store_params, self._caption_params,
+                ) - set(self._node_overrides)
+            ),
         )
         executor_input = self._inline_text_dataset(ray.data) if self._inline_texts else self._documents
         result = executor.ingest(executor_input)

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -35,7 +35,9 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Self
 from nemo_retriever.graph import InprocessExecutor, RayDataExecutor
 from nemo_retriever.ingestor.branch_extraction import ExtractionBranchExecutor, merge_node_overrides
 from nemo_retriever.graph.ingestor_runtime import (
-    batch_tuning_to_node_overrides, build_graph, default_concurrency_node_names,
+    batch_tuning_to_node_overrides,
+    build_graph,
+    default_concurrency_node_names,
 )
 from nemo_retriever.ingestor.manifest import (
     ExtractionBranchPlan,
@@ -855,8 +857,12 @@ class GraphIngestor(ingestor):
             node_overrides=merge_node_overrides(derived_overrides, self._node_overrides),
             auto_concurrency_nodes=(
                 default_concurrency_node_names(
-                    effective_extraction.extract_params, self._embed_params, self._store_params, self._caption_params,
-                ) - set(self._node_overrides)
+                    effective_extraction.extract_params,
+                    self._embed_params,
+                    self._store_params,
+                    self._caption_params,
+                )
+                - set(self._node_overrides)
             ),
         )
         executor_input = self._inline_text_dataset(ray.data) if self._inline_texts else self._documents

--- a/nemo_retriever/tests/test_ingest_manifest.py
+++ b/nemo_retriever/tests/test_ingest_manifest.py
@@ -548,3 +548,50 @@ def test_batch_branch_preflight_precedes_dataset_construction(monkeypatch, tmp_p
     GraphIngestor(run_mode="batch").files([str(pdf), str(image)]).extract().ingest()
 
     assert calls == ["construct", "construct", "construct", "preflight", "build", "build", "ingest"]
+
+
+def test_batch_branch_preflight_counts_file_and_inline_datasets(monkeypatch, tmp_path) -> None:
+    document = tmp_path / "manual.txt"
+    document.write_text("from file")
+    datasets = [_FakeDataset(["path", "value"]), _FakeDataset(["path", "value"])]
+    calls: list[str] = []
+
+    class FakeCluster:
+        def available_cpu_count(self) -> int:
+            return 16
+
+        def available_gpu_count(self) -> int:
+            return 0
+
+        def total_cpu_count(self) -> int:
+            return 16
+
+    class FakeExecutor:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            calls.append("construct")
+
+        def build_dataset(self, data: Any, **kwargs: Any) -> Any:
+            calls.append("build")
+            return datasets.pop(0)
+
+        def ingest(self, data: Any, **kwargs: Any) -> Any:
+            calls.append("ingest")
+            return pd.DataFrame({"done": [True]})
+
+    def fake_preflight(executors: list[Any], resources: Any) -> None:
+        assert len(executors) == 3
+        calls.append("preflight")
+
+    monkeypatch.setattr(
+        GraphIngestor,
+        "_ensure_batch_runtime",
+        lambda self: (SimpleNamespace(data=SimpleNamespace(from_items=lambda rows: {"rows": rows})), FakeCluster()),
+    )
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.RayDataExecutor", FakeExecutor)
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.preflight_executors", fake_preflight)
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.build_graph", lambda **_kwargs: Graph())
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.build_post_extract_graph", lambda **_kwargs: Graph())
+
+    GraphIngestor(run_mode="batch").files([str(document)]).texts(["from inline"]).extract().ingest()
+
+    assert calls == ["construct", "construct", "construct", "preflight", "build", "build", "ingest"]

--- a/nemo_retriever/tests/test_ingest_manifest.py
+++ b/nemo_retriever/tests/test_ingest_manifest.py
@@ -502,3 +502,49 @@ def test_batch_branch_execution_uses_dataset_union(monkeypatch, tmp_path) -> Non
     assert len(combined.unioned) == 1
     assert combined.normalized_columns == ("path", "pdf_value", "image_value")
     assert result["done"].tolist() == [True]
+
+
+def test_batch_branch_preflight_precedes_dataset_construction(monkeypatch, tmp_path) -> None:
+    pdf = tmp_path / "manual.pdf"
+    image = tmp_path / "scan.png"
+    pdf.write_bytes(b"pdf")
+    image.write_bytes(b"png")
+    datasets = [_FakeDataset(["path", "pdf_value"]), _FakeDataset(["path", "image_value"])]
+    calls: list[str] = []
+
+    class FakeCluster:
+        def available_cpu_count(self) -> int:
+            return 16
+
+        def available_gpu_count(self) -> int:
+            return 0
+
+        def total_cpu_count(self) -> int:
+            return 16
+
+    class FakeExecutor:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            calls.append("construct")
+
+        def build_dataset(self, data: Any, **kwargs: Any) -> Any:
+            calls.append("build")
+            return datasets.pop(0)
+
+        def ingest(self, data: Any, **kwargs: Any) -> Any:
+            calls.append("ingest")
+            return pd.DataFrame({"done": [True]})
+
+    def fake_preflight(executors: list[Any], resources: Any) -> None:
+        assert len(executors) == 3
+        assert resources.available_cpu_count() == 16
+        calls.append("preflight")
+
+    monkeypatch.setattr(GraphIngestor, "_ensure_batch_runtime", lambda self: (None, FakeCluster()))
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.RayDataExecutor", FakeExecutor)
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.preflight_executors", fake_preflight)
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.build_graph", lambda **_kwargs: Graph())
+    monkeypatch.setattr("nemo_retriever.ingestor.branch_extraction.build_post_extract_graph", lambda **_kwargs: Graph())
+
+    GraphIngestor(run_mode="batch").files([str(pdf), str(image)]).extract().ingest()
+
+    assert calls == ["construct", "construct", "construct", "preflight", "build", "build", "ingest"]

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -369,8 +369,13 @@ def test_batch_preflight_reduces_default_pools_on_constrained_cluster() -> None:
         available_resources=Resources(cpu_count=16, gpu_count=8),
     )
     params = ExtractParams(
-        extract_text=True, extract_images=False, extract_tables=True, extract_charts=False,
-        extract_infographics=False, extract_page_as_image=False, use_page_elements=True,
+        extract_text=True,
+        extract_images=False,
+        extract_tables=True,
+        extract_charts=False,
+        extract_infographics=False,
+        extract_page_as_image=False,
+        use_page_elements=True,
         use_table_structure=True,
     )
     derived = batch_tuning_to_node_overrides(params, None, cluster_resources=cluster)
@@ -384,9 +389,14 @@ def test_batch_preflight_reduces_default_pools_on_constrained_cluster() -> None:
     assert derived["PageElementDetectionActor"]["concurrency"] < 24
     assert derived["TableStructureActor"]["concurrency"] < 16
     assert derived["OCRActor"]["concurrency"] < 24
-    assert all(derived[name]["concurrency"] >= 1 for name in (
-        "PageElementDetectionActor", "TableStructureActor", "OCRActor",
-    ))
+    assert all(
+        derived[name]["concurrency"] >= 1
+        for name in (
+            "PageElementDetectionActor",
+            "TableStructureActor",
+            "OCRActor",
+        )
+    )
 
 
 def test_batch_preflight_rejects_infeasible_explicit_tuning() -> None:
@@ -395,7 +405,8 @@ def test_batch_preflight_rejects_infeasible_explicit_tuning() -> None:
 
     params = ExtractParams(batch_tuning=BatchTuningParams(page_elements_workers=24))
     derived = batch_tuning_to_node_overrides(
-        params, None,
+        params,
+        None,
         cluster_resources=ClusterResources(
             total_resources=Resources(cpu_count=16, gpu_count=8),
             available_resources=Resources(cpu_count=16, gpu_count=8),
@@ -403,7 +414,8 @@ def test_batch_preflight_rejects_infeasible_explicit_tuning() -> None:
     )
     graph = build_graph(extract_params=params, stage_order=())
     executor = RayDataExecutor(
-        graph, node_overrides=derived,
+        graph,
+        node_overrides=derived,
         auto_concurrency_nodes=default_concurrency_node_names(params, None, None, None),
     )
     with pytest.raises(ValueError, match="Infeasible Ray CPU/GPU plan"):

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -464,6 +464,31 @@ def test_batch_tuning_to_node_overrides_adds_default_store_tuning() -> None:
     assert overrides["StoreOperator"] == {"concurrency": (1, 4, 1), "num_cpus": 0.1}
 
 
+def test_batch_preflight_preserves_default_store_actor_pool() -> None:
+    from nemo_retriever.graph.executor import RayDataExecutor
+    from nemo_retriever.graph.ingestor_runtime import build_post_extract_graph, default_concurrency_node_names
+
+    store_params = StoreParams(storage_uri="memory://stored")
+    resources = Resources(cpu_count=64, gpu_count=8)
+    cluster = ClusterResources(total_resources=resources, available_resources=resources)
+    overrides = batch_tuning_to_node_overrides(
+        extract_params=None,
+        embed_params=None,
+        store_params=store_params,
+        cluster_resources=cluster,
+    )
+    graph = build_post_extract_graph(store_params=store_params, stage_order=("store",))
+    executor = RayDataExecutor(
+        graph,
+        node_overrides=overrides,
+        auto_concurrency_nodes=default_concurrency_node_names(None, None, store_params, None),
+    )
+
+    executor._preflight_resources(executor._linearize(graph), available_cpus=64, available_gpus=8)
+
+    assert overrides["StoreOperator"] == {"concurrency": (1, 4, 1), "num_cpus": 0.1}
+
+
 def test_batch_tuning_to_node_overrides_honors_store_tuning() -> None:
     store_params = StoreParams(
         storage_uri="memory://stored",

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -361,6 +361,67 @@ def test_batch_tuning_to_node_overrides_keeps_default_pdf_pipeline_within_cpu_bu
     assert requested_cpu <= cluster.total_cpu_count()
 
 
+def test_batch_preflight_reduces_default_pools_on_constrained_cluster() -> None:
+    from nemo_retriever.graph.executor import RayDataExecutor
+
+    cluster = ClusterResources(
+        total_resources=Resources(cpu_count=16, gpu_count=8),
+        available_resources=Resources(cpu_count=16, gpu_count=8),
+    )
+    params = ExtractParams(
+        extract_text=True, extract_images=False, extract_tables=True, extract_charts=False,
+        extract_infographics=False, extract_page_as_image=False, use_page_elements=True,
+        use_table_structure=True,
+    )
+    derived = batch_tuning_to_node_overrides(params, None, cluster_resources=cluster)
+    executor = RayDataExecutor(
+        build_graph(extract_params=params, stage_order=()),
+        node_overrides=derived,
+        auto_concurrency_nodes={name for name, values in derived.items() if "concurrency" in values},
+    )
+    executor._preflight_resources(executor._linearize(executor.graph), 16, 8)
+
+    assert derived["PageElementDetectionActor"]["concurrency"] < 24
+    assert derived["TableStructureActor"]["concurrency"] < 16
+    assert derived["OCRActor"]["concurrency"] < 24
+    assert all(derived[name]["concurrency"] >= 1 for name in (
+        "PageElementDetectionActor", "TableStructureActor", "OCRActor",
+    ))
+
+
+def test_batch_preflight_rejects_infeasible_explicit_tuning() -> None:
+    from nemo_retriever.graph.executor import RayDataExecutor
+    from nemo_retriever.graph.ingestor_runtime import default_concurrency_node_names
+
+    params = ExtractParams(batch_tuning=BatchTuningParams(page_elements_workers=24))
+    derived = batch_tuning_to_node_overrides(
+        params, None,
+        cluster_resources=ClusterResources(
+            total_resources=Resources(cpu_count=16, gpu_count=8),
+            available_resources=Resources(cpu_count=16, gpu_count=8),
+        ),
+    )
+    graph = build_graph(extract_params=params, stage_order=())
+    executor = RayDataExecutor(
+        graph, node_overrides=derived,
+        auto_concurrency_nodes=default_concurrency_node_names(params, None, None, None),
+    )
+    with pytest.raises(ValueError, match="Infeasible Ray CPU/GPU plan"):
+        executor._preflight_resources(executor._linearize(graph), 16, 8)
+
+
+def test_batch_preflight_rejects_infeasible_direct_override() -> None:
+    from nemo_retriever.graph.executor import RayDataExecutor
+
+    graph = build_graph(extract_params=ExtractParams(), stage_order=())
+    executor = RayDataExecutor(
+        graph,
+        node_overrides={"PDFExtractionActor": {"concurrency": 17, "num_cpus": 1}},
+    )
+    with pytest.raises(ValueError, match="Infeasible Ray CPU/GPU plan"):
+        executor._preflight_resources(executor._linearize(graph), 16, 8)
+
+
 def test_batch_tuning_to_node_overrides_honors_table_structure_tuning() -> None:
     extract_params = ExtractParams(
         use_table_structure=True,

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1131,6 +1131,52 @@ class TestRayDataExecutor:
         assert ample._node_overrides["CPUAdaptiveAddOperator"]["concurrency"] == (1, 4, 1)
         assert constrained._node_overrides["CPUAdaptiveAddOperator"]["concurrency"] == (1, 1, 1)
 
+    def test_build_dataset_uses_shared_preflight_resource_snapshot(self, monkeypatch):
+        import sys
+        from types import SimpleNamespace
+
+        class _FakeDataset:
+            def map_batches(self, _operator_class, **kwargs):
+                captured.update(kwargs)
+                return self
+
+        class _FakeDataContext:
+            enable_rich_progress_bars = False
+            use_ray_tqdm = True
+
+            @classmethod
+            def get_current(cls):
+                return cls()
+
+        fake_dataset = _FakeDataset()
+        fake_ray_data = SimpleNamespace(Dataset=_FakeDataset, DataContext=_FakeDataContext)
+        fake_ray = SimpleNamespace(is_initialized=lambda: True, init=lambda **kwargs: None, data=fake_ray_data)
+        captured: dict[str, object] = {}
+        monkeypatch.setitem(sys.modules, "ray", fake_ray)
+        monkeypatch.setitem(sys.modules, "ray.data", fake_ray_data)
+        monkeypatch.setattr(
+            "nemo_retriever.graph.executor.gather_cluster_resources",
+            lambda _ray: (_ for _ in ()).throw(AssertionError("must retain the shared preflight snapshot")),
+        )
+
+        graph = Graph()
+        graph.add_root(GPUAdaptiveAddOperator())
+        executor = RayDataExecutor(
+            graph,
+            node_overrides={"GPUAdaptiveAddOperator": {"concurrency": 1}},
+            auto_concurrency_nodes={"GPUAdaptiveAddOperator"},
+        )
+        from nemo_retriever.common.ray_resource_hueristics import ClusterResources
+
+        resources = Resources(cpu_count=1, gpu_count=1)
+        preflight_executors([executor], ClusterResources(total_resources=resources, available_resources=resources))
+
+        executor.build_dataset(fake_dataset)
+
+        assert executor._preflight_cluster_resources is not None
+
+        assert captured["num_gpus"] == 0.1
+
     def test_node_overrides_stored(self):
         g = Graph()
         g.add_chain(AddOperator(1))

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1112,6 +1112,25 @@ class TestRayDataExecutor:
         with pytest.raises(ValueError, match="Infeasible Ray CPU/GPU plan"):
             executor._preflight_resources(executor._linearize(graph), available_cpus=11, available_gpus=1)
 
+    def test_preflight_preserves_and_caps_actor_pool_tuples(self):
+        def executor() -> RayDataExecutor:
+            graph = Graph()
+            graph.add_root(CPUAdaptiveAddOperator())
+            return RayDataExecutor(
+                graph,
+                node_overrides={"CPUAdaptiveAddOperator": {"concurrency": (1, 4, 1), "num_cpus": 1}},
+                auto_concurrency_nodes={"CPUAdaptiveAddOperator"},
+            )
+
+        ample = executor()
+        ample._preflight_resources(ample._linearize(ample.graph), available_cpus=4, available_gpus=0)
+
+        constrained = executor()
+        constrained._preflight_resources(constrained._linearize(constrained.graph), available_cpus=1, available_gpus=0)
+
+        assert ample._node_overrides["CPUAdaptiveAddOperator"]["concurrency"] == (1, 4, 1)
+        assert constrained._node_overrides["CPUAdaptiveAddOperator"]["concurrency"] == (1, 1, 1)
+
     def test_node_overrides_stored(self):
         g = Graph()
         g.add_chain(AddOperator(1))

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1074,6 +1074,17 @@ class TestRayDataExecutor:
         with pytest.raises(ValueError, match="fan-out"):
             RayDataExecutor._linearize(g)
 
+    def test_preflight_counts_implicit_gpu_operator_reservation(self):
+        graph = Graph()
+        graph.add_root(GPUAdaptiveAddOperator())
+        executor = RayDataExecutor(
+            graph,
+            node_overrides={"GPUAdaptiveAddOperator": {"concurrency": 11, "num_cpus": 1}},
+        )
+
+        with pytest.raises(ValueError, match="Infeasible Ray CPU/GPU plan"):
+            executor._preflight_resources(executor._linearize(graph), available_cpus=11, available_gpus=1)
+
     def test_node_overrides_stored(self):
         g = Graph()
         g.add_chain(AddOperator(1))

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -14,7 +14,7 @@ from nemo_retriever.operators.abstract_operator import AbstractOperator
 from nemo_retriever.operators.operator_archetype import ArchetypeOperator
 from nemo_retriever.graph import FileListLoaderOperator, MultiTypeExtractOperator, UDFOperator
 from nemo_retriever.operators.cpu_operator import CPUOperator
-from nemo_retriever.graph.executor import AbstractExecutor, InprocessExecutor, RayDataExecutor
+from nemo_retriever.graph.executor import AbstractExecutor, InprocessExecutor, RayDataExecutor, preflight_executors
 from nemo_retriever.graph.ingestor_runtime import build_graph, build_post_extract_graph
 from nemo_retriever.operators.graph_ops.multi_type_extract_operator import (
     AUDIO_EXTENSIONS,
@@ -1073,6 +1073,33 @@ class TestRayDataExecutor:
         g.add_root(root)
         with pytest.raises(ValueError, match="fan-out"):
             RayDataExecutor._linearize(g)
+
+    def test_shared_preflight_bounds_multiple_lazy_executors(self):
+        first_graph = Graph()
+        first_graph.add_root(CPUAdaptiveAddOperator())
+        second_graph = Graph()
+        second_graph.add_root(CPUAdaptiveAddOperator())
+        first = RayDataExecutor(
+            first_graph,
+            node_overrides={"CPUAdaptiveAddOperator": {"concurrency": 16, "num_cpus": 1}},
+            auto_concurrency_nodes={"CPUAdaptiveAddOperator"},
+        )
+        second = RayDataExecutor(
+            second_graph,
+            node_overrides={"CPUAdaptiveAddOperator": {"concurrency": 16, "num_cpus": 1}},
+            auto_concurrency_nodes={"CPUAdaptiveAddOperator"},
+        )
+
+        from nemo_retriever.common.ray_resource_hueristics import ClusterResources
+
+        resources = Resources(cpu_count=4, gpu_count=0)
+        preflight_executors([first, second], ClusterResources(total_resources=resources, available_resources=resources))
+
+        assert (
+            first._node_overrides["CPUAdaptiveAddOperator"]["concurrency"]
+            + second._node_overrides["CPUAdaptiveAddOperator"]["concurrency"]
+            <= 4
+        )
 
     def test_preflight_counts_implicit_gpu_operator_reservation(self):
         graph = Graph()


### PR DESCRIPTION
## Description

Prevent SDK batch extraction from stalling when the combined actor pools exceed Ray’s currently available CPU or GPU resources. Before submission, the batch executor preflights the complete plan, proportionally reduces unspecified default pools, and rejects infeasible explicit worker counts or direct node overrides.

Adds regression coverage for the 16 CPU / 8 GPU configuration and documents resource sizing and the preflight error.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

- `/tmp/nrl-resource-plan/bin/python -m pytest -q nemo_retriever/tests/test_ingest_plans.py nemo_retriever/tests/test_resource_heuristics.py nemo_retriever/tests/test_pipeline_graph.py`
- `/tmp/nrl-docs-venv/bin/python -m mkdocs build --strict --config-file mkdocs.yml`