### PR TITLE
Fix FFmpeg stdin inheritance in media extraction

### DIFF
--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -45,6 +45,7 @@ Highlights for the 26.05 release include:
 
 - Video retrieval pipeline with frame extraction, OCR, audio-visual fusion, and text deduplication  
 - Long-audio Parakeet chunking with time-aligned segments; punctuation-based audio segmenting; ASR batch/streaming improvements  
+- Fixed an issue that could cause local Hugging Face batch audio extraction to hang in interactive terminals when FFmpeg inherited the parent process's standard input.
 
 ### Retrieval and RAG
 

--- a/nemo_retriever/src/nemo_retriever/common/modality/audio/media_interface.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/audio/media_interface.py
@@ -148,13 +148,20 @@ def _run_ffmpeg(stream: Any, *, label: str, input_path: str) -> None:
     fills, ffmpeg's I/O thread blocks on ``write(2)``, and its ``-threads N``
     workers spin (=> 99% CPU, no progress, indefinite hang). Send stderr to a
     tempfile instead — file writes never block, so ffmpeg always makes progress
-    and the call returns. We only read stderr when ``returncode != 0``.
+    and the call returns. Disconnect stdin as well so ffmpeg cannot read from or
+    be stopped while accessing an interactive parent terminal. We only read
+    stderr when ``returncode != 0``.
     """
     if not is_ffmpeg_available():
         raise RuntimeError(media_dependency_error_message(f"FFmpeg operation '{label}'", required=FFMPEG_DEPENDENCIES))
     args = ffmpeg.compile(stream)
     with tempfile.TemporaryFile(mode="w+b") as stderr_buf:
-        result = subprocess.run(args, stdout=subprocess.DEVNULL, stderr=stderr_buf)
+        result = subprocess.run(
+            args,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_buf,
+        )
         if result.returncode != 0:
             stderr_buf.seek(0)
             err = stderr_buf.read()

--- a/nemo_retriever/tests/test_media_dependency_availability.py
+++ b/nemo_retriever/tests/test_media_dependency_availability.py
@@ -129,6 +129,23 @@ class MediaDependencyAvailabilityTests(TestCase):
                 self.assertIn("FFmpeg operation 'split' requires media dependencies", message)
                 self.assertNotIn("split requires media dependencies", message)
 
+    def test_run_ffmpeg_disables_stdin(self) -> None:
+        media_interface = _load_media_interface()
+        fake_ffmpeg = SimpleNamespace(compile=lambda _stream: ["ffmpeg"])
+
+        with (
+            patch.object(media_interface, "ffmpeg", fake_ffmpeg),
+            patch.object(media_interface.shutil, "which", return_value="/usr/bin/ffmpeg"),
+            patch.object(
+                media_interface.subprocess,
+                "run",
+                return_value=SimpleNamespace(returncode=0),
+            ) as run_ffmpeg,
+        ):
+            media_interface._run_ffmpeg(object(), label="split", input_path="/tmp/input.wav")
+
+        self.assertIs(run_ffmpeg.call_args.kwargs["stdin"], media_interface.subprocess.DEVNULL)
+
     def test_get_audio_from_video_does_not_require_ffprobe(self) -> None:
         media_interface = _load_media_interface()
 


### PR DESCRIPTION
## Summary

Fix the local Hugging Face batch audio workflow hanging when launched from an interactive terminal.

## Root cause

FFmpeg subprocesses launched by `MediaChunkActor` inherited stdin from the parent process. When the parent was attached to a terminal, FFmpeg could enter a stopped state and prevent audio chunks from reaching the ASR actor.

The same workflow completed successfully when stdin was redirected from `/dev/null`.

## Changes

- Disconnect FFmpeg stdin with `stdin=subprocess.DEVNULL`.
- Apply the behavior through the shared FFmpeg runner used by media extraction.
- Add a regression test verifying that FFmpeg is launched with stdin disabled.
- Add a release-note entry describing the fix.

## Validation

- `pre-commit run --all-files`
- Focused tests: `16 passed, 1 skipped, 2 subtests passed`
- GPG-signed commit verified successfully.