### PR TITLE
Preserve unfused video OCR results

### DIFF
--- a/nemo_retriever/src/nemo_retriever/operators/extract/video/audio_visual_fuser.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/video/audio_visual_fuser.py
@@ -13,9 +13,9 @@ the visual portion capped at :data:`FRAME_TEXT_MAX_CHARS`. The source
 audio row is dropped whenever a fused row was produced for its window
 so retrieval doesn't see two near-identical embeddings (audio-only and
 audio+visual) for the same utterance; audio rows whose window has no
-concurrent frame are preserved. ``video_frame`` rows are consumed by
-the fusion and not passed through downstream — every visual moment that
-mattered is already represented inside an ``audio_visual`` row.
+concurrent frame are preserved. A ``video_frame`` row is consumed only
+when it supplied the visual text for a fused row. Other frame-OCR rows
+remain visible downstream instead of being silently discarded.
 
 Set :attr:`AudioVisualFuseParams.enabled` to ``False`` to skip fusion.
 """
@@ -66,11 +66,20 @@ def _row_segment_window(row: Any) -> tuple[float, float] | None:
     return start, end
 
 
-def _keep_upstream(row: Any, fused_window_keys: set[tuple[str, float, float]]) -> bool:
-    """Drop ``video_frame`` rows and audio rows whose window already fused."""
+def _keep_upstream(
+    row: Any,
+    fused_window_keys: set[tuple[str, float, float]],
+    fused_frame_keys: set[tuple[str, float, float, str]],
+) -> bool:
+    """Drop rows represented by a fused result and preserve all others."""
     kind = _row_content_type(row)
     if kind == _CT.VIDEO_FRAME:
-        return False
+        window = _row_segment_window(row)
+        source = getattr(row, "source_path", None)
+        text = getattr(row, "text", None)
+        if window is None or not isinstance(source, str) or not isinstance(text, str):
+            return True
+        return (source, float(window[0]), float(window[1]), text.strip()) not in fused_frame_keys
     if kind != _CT.AUDIO:
         return True
     window = _row_segment_window(row)
@@ -82,8 +91,12 @@ def _keep_upstream(row: Any, fused_window_keys: set[tuple[str, float, float]]) -
     return (source, float(window[0]), float(window[1])) not in fused_window_keys
 
 
-def _filter_upstream(batch_df: pd.DataFrame, fused_window_keys: set[tuple[str, float, float]]) -> pd.DataFrame:
-    mask = [_keep_upstream(row, fused_window_keys) for row in batch_df.itertuples(index=False)]
+def _filter_upstream(
+    batch_df: pd.DataFrame,
+    fused_window_keys: set[tuple[str, float, float]],
+    fused_frame_keys: set[tuple[str, float, float, str]],
+) -> pd.DataFrame:
+    mask = [_keep_upstream(row, fused_window_keys, fused_frame_keys) for row in batch_df.itertuples(index=False)]
     return batch_df[mask].reset_index(drop=True)
 
 
@@ -140,9 +153,10 @@ class AudioVisualFuser(AbstractOperator, CPUOperator):
             frames_by_source.setdefault(source, []).append((float(f_start), float(f_end), text.strip()))
 
         if not frames_by_source:
-            return _filter_upstream(batch_df, set())
+            return _filter_upstream(batch_df, set(), set())
 
         fused_rows: List[Dict[str, Any]] = []
+        fused_frame_keys: set[tuple[str, float, float, str]] = set()
         for row in batch_df.itertuples(index=False):
             if _row_content_type(row) != _CT.AUDIO:
                 continue
@@ -176,6 +190,7 @@ class AudioVisualFuser(AbstractOperator, CPUOperator):
                 concurrent_entries,
                 key=lambda fe: (abs((fe[0] + fe[1]) / 2.0 - u_mid), -len(fe[2])),
             )
+            fused_frame_keys.add((source, float(best[0]), float(best[1]), best[2]))
             visual_text = best[2]
             if len(visual_text) > FRAME_TEXT_MAX_CHARS:
                 visual_text = visual_text[:FRAME_TEXT_MAX_CHARS].rstrip()
@@ -199,7 +214,7 @@ class AudioVisualFuser(AbstractOperator, CPUOperator):
             fused_rows.append(fused_row)
 
         if not fused_rows:
-            return _filter_upstream(batch_df, set())
+            return _filter_upstream(batch_df, set(), set())
 
         fused_window_keys = {
             (
@@ -211,7 +226,7 @@ class AudioVisualFuser(AbstractOperator, CPUOperator):
         }
         return concat_with_passthrough(
             pd.DataFrame(fused_rows),
-            _filter_upstream(batch_df, fused_window_keys),
+            _filter_upstream(batch_df, fused_window_keys, fused_frame_keys),
         )
 
     def postprocess(self, data: Any, **kwargs: Any) -> Any:

--- a/nemo_retriever/tests/test_audio_visual_fuser.py
+++ b/nemo_retriever/tests/test_audio_visual_fuser.py
@@ -10,7 +10,7 @@ The fuser's behaviour is fixed (no per-call knobs beyond ``enabled``):
   * visual capped at ``FRAME_TEXT_MAX_CHARS`` characters,
   * fused text rendered as ``"[AUDIO] <audio> | [VISUAL] <visual>"``,
   * source audio rows whose window produced a fused row are dropped,
-  * ``video_frame`` rows are not passed through downstream.
+  * only the ``video_frame`` rows selected for fusion are consumed.
 """
 
 from __future__ import annotations
@@ -63,12 +63,12 @@ def test_fuser_emits_one_fused_row_per_overlapping_utterance() -> None:
     # Top-level _content_type set so the LanceDB sink picks it up.
     assert fused[0]["_content_type"] == "audio_visual"
     # Audio row whose window produced the fused row is dropped; the orphan
-    # audio utterance (no concurrent frame) is preserved. All ``video_frame``
-    # rows are dropped — paired ones are folded into the fused row, orphan
-    # ones were shown to be net-noise in retrieval.
+    # audio utterance (no concurrent frame) is preserved. The selected frame
+    # is folded into the fused row, while unselected and orphan OCR frames
+    # remain independently retrievable.
     kinds = [r["metadata"]["_content_type"] for _, r in out.iterrows()]
     assert kinds.count("audio") == 1  # only the second utterance
-    assert kinds.count("video_frame") == 0
+    assert kinds.count("video_frame") == 2
     assert kinds.count("audio_visual") == 1
 
 
@@ -79,10 +79,28 @@ def test_fuser_skips_when_no_concurrent_frame_text() -> None:
     ]
     df = pd.DataFrame(rows)
     out = AudioVisualFuser(AudioVisualFuseParams()).run(df)
-    # No fused row is appended (no overlap), the audio row is preserved,
-    # and the orphan ``video_frame`` row is dropped.
+    # No fused row is appended (no overlap), so neither source row may be
+    # discarded from the public result.
     kinds = [r["metadata"]["_content_type"] for _, r in out.iterrows()]
-    assert kinds == ["audio"]
+    assert kinds == ["audio", "video_frame"]
+
+
+def test_fuser_preserves_all_visual_rows_when_no_audio_window_fuses() -> None:
+    rows = [
+        _audio_row("/v.mp4", "speech after the title", 5.0, 8.0),
+        _frame_row("/v.mp4", "TITLE ONLY VISIBLE ON SCREEN", 1.0),
+        _frame_row("/v.mp4", "SECOND VISUAL", 3.0),
+    ]
+
+    out = AudioVisualFuser(AudioVisualFuseParams()).run(pd.DataFrame(rows))
+
+    kinds = [r["metadata"]["_content_type"] for _, r in out.iterrows()]
+    assert kinds == ["audio", "video_frame", "video_frame"]
+    assert out["text"].tolist() == [
+        "speech after the title",
+        "TITLE ONLY VISIBLE ON SCREEN",
+        "SECOND VISUAL",
+    ]
 
 
 def test_fuser_preserves_segment_window_from_audio_row() -> None:

--- a/nemo_retriever/tests/test_video_pipeline_batch.py
+++ b/nemo_retriever/tests/test_video_pipeline_batch.py
@@ -135,12 +135,11 @@ def test_run_video_pipeline_emits_audio_frame_and_scene_rows(tmp_path: Path) -> 
     assert isinstance(out, pd.DataFrame)
     content_types = out["metadata"].apply(lambda md: md.get("_content_type")).tolist()
     # The baked-in fuser drops audio rows whose windows match a fused row
-    # AND drops every ``video_frame`` row from the output (paired frames
-    # are folded into the audio_visual rows; orphan frames are net-noise).
-    # Both utterances here have concurrent frames so only audio_visual
-    # rows appear.
-    assert "video_frame" not in content_types
-    assert "audio_visual" in content_types
+    # and consumes the one representative frame selected for each fused row.
+    # Other OCR frames remain visible in the public output.
+    assert "audio" not in content_types
+    assert content_types.count("video_frame") == 3
+    assert content_types.count("audio_visual") == 2
 
     # Each scene row covers an audio utterance and pairs it with the most
     # representative concurrent frame in labelled "[AUDIO] <a> | [VISUAL] <v>"


### PR DESCRIPTION
## Summary

- preserve video frame OCR rows that were not selected for audio-visual fusion
- continue consuming the specific frame represented by each fused row
- add unit and batch-video regression coverage for visual-only evidence

## Root cause

`AudioVisualFuser` unconditionally filtered every `video_frame` row from its output. When no frame overlapped an ASR window, the fuser produced no `audio_visual` rows but still removed all frame OCR results, leaving an audio-only public result.

## Impact

Enabled frame processing now keeps visible OCR evidence in the ingest result when that evidence was not incorporated into a fused row.

## Validation

- `pre-commit run --all-files`
- `pytest nemo_retriever/tests/test_audio_visual_fuser.py nemo_retriever/tests/test_video_pipeline_batch.py -q` — 10 passed
- surrounding video and graph suites — 124 passed