### PR TITLE
Avoid arrow crashes during text chunking

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -258,6 +258,10 @@ class RayDataExecutor(AbstractExecutor):
         nodes = self._linearize(resolved_graph)
         for node in nodes:
             overrides = dict(self._node_overrides.get(node.name, {}))
+            from nemo_retriever.operators.extract.txt.ray_data import TextChunkCPUActor
+
+            if issubclass(node.operator_class, TextChunkCPUActor):
+                overrides.setdefault("batch_size", None)
             target_num_rows_per_block = overrides.pop("target_num_rows_per_block", None)
             batch_size = overrides.pop("batch_size", self._default_batch_size)
             batch_format = overrides.pop("batch_format", self._default_batch_format)


### PR DESCRIPTION
## Description
RayDataExecutor normally uses batch_size=1. After PDF extraction produces three page rows, Ray creates three separate pandas batches by slicing the underlying Arrow block:

Page 1: offset 0, length 1
Page 2: offset 1, length 1
Page 3: offset 2, length 1

The PDF rows contain nested Arrow columns such as images, even when image extraction is disabled. With the affected Ray/PyArrow versions, these one-row slices can retain the parent array’s nonzero offset while exposing only the sliced child data.

When TextChunkCPUActor calls DataFrame.iterrows(), pandas materializes all columns, including images. On the third page, Arrow sees an offset of 2 against an array of length 1 and aborts:

Slice offset (2) greater than array length (1)

Setting batch_size=None tells Ray Data to pass each complete upstream block to the text chunk actor instead of slicing it into one-row batches. The nested arrays retain a valid zero-based relationship between their offsets and buffers, so pandas can iterate over the rows safely.

This does not combine the entire dataset into one batch. Ray still processes separate blocks independently; it simply stops subdividing each block at this stage. The text chunk actor can already expand multiple input rows into multiple chunk rows, so whole-block input is compatible with its behavior.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
