### PR TITLE
docs(extraction): fix broken links, heading permalinks, and API crosslinks

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -29,7 +29,7 @@ When you call hosted object-detection NIMs (Page Elements, Table Structure, Grap
 
     The `NVIDIA_API_KEY` from build.nvidia.com is not the same string as your NGC personal key used for Helm and `nvcr.io` access. Do not substitute one for the other unless your tooling explicitly documents that mapping.
 
-## Credential references in persisted graphs
+## Credential references in persisted graphs { #credential-references-in-persisted-graphs }
 
 Persisted pipeline graphs never contain literal API keys. Configure a graph with an explicit worker-side environment reference such as:
 
@@ -41,7 +41,9 @@ Use the provider's own variable name, for example `os.environ/OPENAI_API_KEY` fo
 
 Literal keys remain available for non-persisted local execution, but attempting to serialize one raises an error. This prevents graph persistence from silently substituting an NVIDIA credential for another provider's key.
 
-## NGC personal key (Helm and `nvcr.io`)
+For how persisted graphs store credential references, refer to [Persisted graphs are trusted configuration](nemo-retriever-api-reference.md#persisted-graphs-are-trusted-configuration) in the Python API guide.
+
+## NGC personal key (Helm and `nvcr.io`) { #ngc-personal-key }
 
 Many public assets on NGC can be used without authentication. For a Kubernetes deployment, the cluster must still pull NIM and microservice images from `nvcr.io` and may need NGC API access; the Helm chart expects credentials derived from an NGC personal key.
 
@@ -59,6 +61,6 @@ When you create an NGC key, select the following for **Services Included**.
 ![Generate Personal Key](images/generate_personal_key.png)
 
 
-## Using your NGC key with Helm
+## Using your NGC key with Helm { #using-your-ngc-key-with-helm }
 
 Configure your key through the chart values described in the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md): for example `imagePullSecret.create` / `imagePullSecret.password` for pulls from `nvcr.io`, `nimApiKey` (inline value or `existingSecret`) for the retriever service, and `nims.ngcApiKey` when `nims.enabled=true`. Exact paths are versioned—use the **Secrets** section in that README and [`values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/values.yaml) as the source of truth.

--- a/docs/docs/extraction/embedding.md
+++ b/docs/docs/extraction/embedding.md
@@ -12,14 +12,14 @@ The model can embed documents in the form of an image, text, or a combination of
 Documents can then be retrieved given a user query in text form. 
 The model supports images that contain text, tables, charts, and infographics.
 
-## Example with Default Text-Based Embedding
+## Example with Default Text-Based Embedding { #example-with-default-text-based-embedding }
 
 When you use the multimodal model, by default, all extracted content (text, tables, charts) is treated as plain text. 
 The following example provides a strong baseline for retrieval.
 
 - The `embed` method is called with no arguments.
 
-For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md) (`create_ingestor` and `.embed()`).
 
 ```python
 from nemo_retriever import create_ingestor
@@ -34,7 +34,7 @@ results = ingestor.ingest()
 ```
 
 
-## Example with Embedding Structured Elements as Text + Images
+## Example with Embedding Structured Elements as Text + Images { #example-with-embedding-structured-elements-as-text-images }
 
 It is common to process PDFs by embedding standard text as text and embed visual elements such as tables and charts as images. 
 The following example enables the multimodal model to capture the spatial and structural information of the visual content.
@@ -42,7 +42,7 @@ The following example enables the multimodal model to capture the spatial and st
 - The `embed` method is configured with `embed_modality="text_image"` to embed the extracted tables and charts as images.
 - This configuration is more accurate than text only, with a performance cost.
 
-For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md) (`create_ingestor` and `.embed()`).
 
 ```python
 from nemo_retriever import create_ingestor
@@ -59,7 +59,7 @@ results = ingestor.ingest()
 ```
 
 
-## Example with Embedding Entire PDF Pages as Images
+## Example with Embedding Entire PDF Pages as Images { #example-with-embedding-entire-pdf-pages-as-images }
 
 For documents where the entire page layout is important (such as infographics, complex diagrams, or forms), 
 you can configure NeMo Retriever Library to treat every page as a single image.
@@ -67,7 +67,7 @@ The following example extracts and embeds each page as an image.
 
 - The `embed` method processes the page images.
 
-For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md) (`create_ingestor` and `.embed()`).
 
 ```python
 from nemo_retriever import create_ingestor
@@ -84,7 +84,7 @@ ingestor = (
 results = ingestor.ingest()
 ```
 
-## Related Topics
+## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)

--- a/docs/docs/extraction/environment-config.md
+++ b/docs/docs/extraction/environment-config.md
@@ -4,7 +4,7 @@ The following are the environment variables that you can use to configure [NeMo 
 You can specify these in a .env file in your working directory or directly as shell environment variables.
 
 
-## General Environment Variables
+## General Environment Variables { #general-environment-variables }
 
 | Name                             | Example                        | Description                                                           |
 |----------------------------------|--------------------------------|-----------------------------------------------------------------------|
@@ -15,6 +15,8 @@ You can specify these in a .env file in your working directory or directly as sh
 | `OTEL_EXPORTER_OTLP_ENDPOINT`    | `http://otel-collector:4317` <br/>                       | The endpoint for the OpenTelemetry exporter, used for sending telemetry data. |
 
 
-## Related Topics
+## Related Topics { #related-topics }
 
-- [Configure Ray Logging](https://docs.nvidia.com/nemo/retriever/latest/extraction/ray-logging/)
+- [Configure Ray Logging](ray-logging.md)
+- [Authentication and API keys](api-keys.md)
+- [Python API guide](nemo-retriever-api-reference.md)

--- a/docs/docs/extraction/evaluate-on-your-data.md
+++ b/docs/docs/extraction/evaluate-on-your-data.md
@@ -2,15 +2,15 @@
 
 Retrieval and ingestion performance **depend on your documents**, hardware, and pipeline settings. Use the following when measuring quality and throughput on **your** datasets.
 
-## Benchmarking and baselines
+## Benchmarking and baselines { #benchmarking-and-baselines }
 
 Use this page as the baseline for methodology and expectations. Use [Operational tuning](#operational-tuning) below to observe production-like runs.
 
-## Throughput and dataset effects
+## Throughput and dataset effects { #throughput-and-dataset-effects }
 
 Read [Throughput is dataset-dependent](multimodal-extraction.md#extraction-limitations-and-quality) for why raw numbers from generic benchmarks may not match your corpus (layout complexity, file types, image density, and so on).
 
-## Operational tuning
+## Operational tuning { #operational-tuning }
 
 - [Ray and distributed ingest](ray-logging.md)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for supported configurations

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -2,52 +2,52 @@
 
 This documentation contains the Frequently Asked Questions (FAQ) for [NeMo Retriever Library](overview.md).
 
-## Is the NeMo Retriever Library supported under NVIDIA AI Enterprise (NVAIE)?
+## Is the NeMo Retriever Library supported under NVIDIA AI Enterprise (NVAIE)? { #nvaie-support }
 
 No. The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE).
 
 Some NIM microservices and models that the library calls may be individually covered by NVAIE. That coverage does not extend to the NeMo Retriever Library or its end-to-end extraction workflow. For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 
-## What if I already have a retrieval pipeline? Can I just use NeMo Retriever Library? 
+## What if I already have a retrieval pipeline? Can I just use NeMo Retriever Library? { #use-with-existing-retrieval-pipeline }
 
 You can use the CLI or Python APIs to perform extraction only, and then consume the results.
 Using the Python API, `results` is a list object with one entry.
 For code examples, refer to the Jupyter notebooks [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb) 
 and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb).
 
-## Where does NeMo Retriever Library ingest to?
+## Where does NeMo Retriever Library ingest to? { #where-does-nrl-ingest-to }
 
 NeMo Retriever Library supports extracting text representations of various forms of content,
 and ingesting to a vector database. **[LanceDB](https://lancedb.com/)** stores vectors as local Lance files on disk for the supported ingestion path.
 You can ingest to other data stores; however, you must configure other data stores yourself.
 For more information, refer to [Vector databases](vdbs.md).
 
-## How would I process unstructured images?
+## How would I process unstructured images? { #process-unstructured-images }
 
 For images that `nemoretriever-page-elements-v3` does not classify as tables, charts, or infographics,
 you can use our VLM caption task to create a dense caption of the detected image. 
 That caption is then embedded along with the rest of your content. 
 For chart-labeled PDF regions and other caption scope limits, refer to [Are PDF chart or figure regions captioned when Omni is enabled?](#are-pdf-chart-or-figure-regions-captioned-when-omni-is-enabled). For more information, refer to [Extract Captions from Images](nemo-retriever-api-reference.md).
 
-## Are PDF chart or figure regions captioned when Omni is enabled?
+## Are PDF chart or figure regions captioned when Omni is enabled? { #are-pdf-chart-or-figure-regions-captioned-when-omni-is-enabled }
 
 No. Chart-labeled PDF regions are not routed through Omni captioning. Refer to [Charts and infographics](multimodal-extraction.md#charts-and-infographics) and [Image captioning](multimodal-extraction.md#image-captioning) for caption scope and validation.
 
-## When should I consider advanced visual parsing?
+## When should I consider advanced visual parsing? { #advanced-visual-parsing }
 
 For scanned documents, or documents with complex layouts,
 you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `method="nemotron_parse"`.
 Nemotron Parse does not produce chart modality rows. For chart detection and chart-filtered retrieval, use the default **pdfium** layout path instead (refer to [Charts and infographics](multimodal-extraction.md#charts-and-infographics)).
 For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
 
-## Why are the environment variables different between library mode and self-hosted mode?
+## Why are the environment variables different between library mode and self-hosted mode? { #library-vs-self-hosted-env-vars }
 
-### Self-Hosted Deployments
+### Self-Hosted Deployments { #self-hosted-deployments }
 
 For [self-hosted deployments](deployment-options.md#when-to-self-host-nims), you should set the environment variables `NGC_API_KEY` and `NIM_NGC_API_KEY`.
 For more information, refer to [Authentication and API keys](api-keys.md).
 
-### Library Mode
+### Library Mode { #library-mode }
 
 For production environments, you should use the provided Helm charts. When you run the NeMo Retriever Library from Python without those charts, set `NVIDIA_API_KEY` only when you call [build.nvidia.com](https://build.nvidia.com/) hosted inference—it is not required for locally deployed Hugging Face models or self-hosted NIM endpoints. For more information, refer to [Deployment options](deployment-options.md) and [Authentication and API keys](api-keys.md).
 
@@ -57,7 +57,7 @@ For examples of `*_ENDPOINT` variables, refer to [Environment variables](environ
 
 When you explicitly configure remote NIM endpoints in Python library mode, graph ingestion raises a `GraphIngestionError` if a stage reports row-level connection or inference errors. This makes unreachable services visible to callers instead of returning a DataFrame that looks successful. To intentionally keep partial results with row-level error payloads, pass `error_policy="collect"` to `GraphIngestor` or `create_ingestor`. Refer to the [Python API error contract](nemo-retriever-api-reference.md#error-and-failure-contract) and [Python API error triage](troubleshoot.md#python-api-error-triage) for error signals, extraction-path mappings, and escalation criteria.
 
-## What parameters or settings can I adjust to optimize extraction from my documents or data? 
+## What parameters or settings can I adjust to optimize extraction from my documents or data? { #optimize-extraction-parameters }
 
 Refer to [Evaluate on your data](evaluate-on-your-data.md) for extraction tuning and optimization guidance.
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -146,7 +146,7 @@ To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray acto
 
 **Python client (`pdf_split_config`):** Only `create_ingestor(run_mode="service")` implements `.pdf_split_config(pages_per_chunk=...)`, which records page-chunking settings in the request pipeline spec for the remote gateway. Local graph ingest (`run_mode="inprocess"` or `"batch"`) raises `NotImplementedError` if you call this method; PDFs are split automatically on the default ingest path without client-side configuration.
 
-## One-shot text generation
+## One-shot text generation { #one-shot-text-generation }
 
 `TextGenerationOperator` is the reusable base for synchronous, one-request-per-row text generation. It is a provisional text-only API: it does not support tool calls, agent loops, streaming, multiple choices, or structured domain results.
 
@@ -192,7 +192,7 @@ To define another one-request/one-text-result task, subclass `TextGenerationTask
 
 Generation failures are collected per row using stable error codes: `empty_input`, `request_error`, `transport_error`, `unsupported_response`, `parse_error`, `empty_output`, and the RAG-specific `thinking_truncated`. Raw provider exceptions and credentials are not written to DataFrame outputs.
 
-## Persisted graphs are trusted configuration
+## Persisted graphs are trusted configuration { #persisted-graphs-are-trusted-configuration }
 
 Graph loading imports operator classes and invokes their constructors. Load graph JSON only from trusted sources; do not expose graph payloads, callable references, or class names as model- or user-controlled agent tools.
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -12,7 +12,7 @@ NeMo Retriever Library splits documents into pages, classifies sub-page content 
 
     Some individual NIM microservices and models that the library calls—for example, the default NIMs in the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#default-helm-nims)—may be covered by NVAIE on their own. That coverage applies only to those individual NIMs and models. It does **not** extend to the NeMo Retriever Library or its end-to-end extraction workflow. Using NVAIE-supported NIMs or models through the NeMo Retriever Library does not make the library, its container, or its chart NVAIE-supported.
 
-## What NeMo Retriever Library Is ✔️
+## What NeMo Retriever Library Is ✔️ { #what-nemo-retriever-library-is }
 
 The following diagram shows the retriever pipeline.
 
@@ -50,7 +50,7 @@ NeMo Retriever Library supports the following file types:
 - `txt`
 - `wav`
 
-## Related Topics
+## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Deployment options](deployment-options.md) — library, Helm, hosted vs self-hosted NIMs in one place

--- a/docs/docs/extraction/ray-logging.md
+++ b/docs/docs/extraction/ray-logging.md
@@ -11,7 +11,7 @@ In addition, NeMo Retriever Library provides preset configurations that you can 
 
 
 
-## Quick Start - Use Preset Configurations
+## Quick Start - Use Preset Configurations { #quick-start-use-preset-configurations }
 
 To get started quickly, use one of the NeMo Retriever Library package-level preset variables. 
 Run the code below that corresponds to your use case; production, development, or debugging. 
@@ -33,7 +33,7 @@ export INGEST_RAY_LOG_LEVEL=DEBUG
 ```
 
 
-### PRODUCTION Log Level
+### PRODUCTION Log Level { #production-log-level }
 
 The `PRODUCTION` log level is optimized for production deployments with minimal logging overhead. 
 
@@ -51,7 +51,7 @@ This log level uses the following settings:
 - **Encoding** – TEXT
 
 
-### DEVELOPMENT Log Level
+### DEVELOPMENT Log Level { #development-log-level }
 
 The `DEVELOPMENT` log level is a balanced configuration for development work, 
 and is the default log level.
@@ -70,7 +70,7 @@ This log level uses the following settings:
 - **Encoding** – TEXT
 
 
-### DEBUG Log Level
+### DEBUG Log Level { #debug-log-level }
 
 The `DEBUG` log level provides maximum visibility for troubleshooting issues. 
 
@@ -89,7 +89,7 @@ This log level uses the following settings:
 
 
 
-## Configuration Reference
+## Configuration Reference { #configuration-reference }
 
 The following are the environment variables that you can set to control Ray logging behavior. 
 If you specify an invalid value, the variable reverts to the default value with a warning message.
@@ -109,7 +109,7 @@ If you specify an invalid value, the variable reverts to the default value with 
 
 
 
-## Configuration Examples
+## Configuration Examples { #configuration-examples }
 
 ### Use a Preset With A Manual Override
 
@@ -174,7 +174,7 @@ export RAY_LOGGING_ROTATE_BACKUP_COUNT=9
 
 
 
-## Log Output Examples
+## Log Output Examples { #log-output-examples }
 
 ### INFO level (Default)
 
@@ -208,6 +208,6 @@ export RAY_LOGGING_ROTATE_BACKUP_COUNT=9
 ```
 
 
-## Related Topics
+## Related Topics { #related-topics }
 
-- [Environment Variables](https://docs.nvidia.com/nemo/retriever/latest/extraction/environment-config/)
+- [Environment Variables](environment-config.md)

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -6,7 +6,7 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 NVIDIA® NeMo Retriever Library version 26.08 builds on the 26.05 foundation with a graph-based ingest architecture, expanded multimodal and tabular capabilities, production-oriented service deployment, and documentation aligned to a Helm-first supported path.
 
-To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md).
+To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
 
 Highlights for the 26.08 release include:
 
@@ -73,7 +73,7 @@ Highlights for the 26.08 release include:
 ### Documentation
 
 - Documentation aligned to a Helm-first supported path for NIM and service deployment
-- Documentation consolidates extraction concepts, ingest workflow, embeddings, audio/video guides, prerequisites and support matrix, and UDF/custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)  
+- Documentation consolidates extraction concepts, ingest workflow, embeddings, audio/video guides, prerequisites and support matrix, and UDF/custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)  
 
 ## Release Notes for Previous Versions
 
@@ -93,4 +93,4 @@ Release notes for 24.12.1 and 24.12.0 are on the [25.3.0 archived release notes]
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Deployment options](deployment-options.md)
-- [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
+- [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -2,7 +2,7 @@
 
 This documentation contains the release notes for [NeMo Retriever Library](overview.md).
 
-## 26.08 Release Notes (26.8.0)
+## 26.08 Release Notes (26.8.0) { #release-2608 }
 
 NVIDIA® NeMo Retriever Library version 26.08 builds on the 26.05 foundation with a graph-based ingest architecture, expanded multimodal and tabular capabilities, production-oriented service deployment, and documentation aligned to a Helm-first supported path.
 
@@ -10,72 +10,72 @@ To upgrade the Helm charts for this release, refer to the [NeMo Retriever Librar
 
 Highlights for the 26.08 release include:
 
-### Upgrade notes
+### Upgrade notes { #upgrade-notes }
 
 - Text splitting for graph and library ingest moved into `.extract(split_config=...)` instead of standalone `.split()` on the graph ingest path (the service ingestor API may still expose `.split()` separately)  
 - Direct `Retriever(...)` construction uses `vdb_kwargs`, `embed_kwargs`, and `rerank` instead of flat `lancedb_uri`, `lancedb_table`, `embedder`, `embedding_endpoint`, `local_query_embed_backend`, and `reranker` arguments  
 - For Helm audio and video extraction, set `service.installFfmpeg: true` in `values.yaml` (or pass `--set service.installFfmpeg=true`) when images no longer bundle `ffmpeg` and `ffprobe` by default  
 - `nemo_retriever` requires Python 3.12  
 
-### Pipeline and ingestion
+### Pipeline and ingestion { #pipeline-and-ingestion }
 
 - Legacy `nv-ingest` and compatibility pipeline CLI code paths removed; `retriever ingest` and the graph stage registry are the canonical ingestion paths
 - Manifest-based ingest routing replaces input-type routing; `retriever ingest` is input-aware for PDF, image, audio, video, text, HTML, DOCX/PPTX, SVG, and related types  
 - `allow_no_gpu` option to skip GPU requirement during ingest for CPU-only experimentation  
 
-### CLI
+### CLI { #cli }
 
 - Root CLI adds first-class `retriever ingest` and `retriever query` commands with NIM URL flags, batch tuning, and LanceDB overwrite/append controls
 - `retriever ingest` and `retriever query` replace the retired compatibility pipeline command. Other top-level subcommands—including `eval`, `benchmark`, `harness`, and `skill-eval`—are development and experimental
 
-### Retriever Service and deployment
+### Retriever Service and deployment { #retriever-service-and-deployment }
 
 - Retriever Service v2 adds a scalable multi-pod architecture with gateway, process isolation, and VectorDB integration  
 - OpenTelemetry basic support for pipeline and service observability  
 - Expanded air-gapped deployment guidance in [deployment options](deployment-options.md) and the Helm chart README  
 
-### Models, OCR, and captioning
+### Models, OCR, and captioning { #models-ocr-and-captioning }
 
 - Nemotron OCR v2 is the default OCR engine for HuggingFace, with CLI language selectors and unified OCR actors. For Helm NIM deployments, Nemotron OCR v1 is the default.  
 - Nemotron Parse is available as an alternate PDF extraction method (v1.2 HTTP interface; optional Helm NIM; local inference via vLLM where configured)  
 - VLM image captioning via vLLM (including Omni caption model profiles) addresses the capability deferred in 26.03  
 - vLLM-backed text and vision-language embedders, multimodal VL reranker, and torch 2.11 for local GPU installs  
 
-### Multimodal extraction
+### Multimodal extraction { #multimodal-extraction }
 
 - Video retrieval pipeline with frame extraction, OCR, audio-visual fusion, and text deduplication  
 - Long-audio Parakeet chunking with time-aligned segments; punctuation-based audio segmenting; ASR batch/streaming improvements  
 
-### Retrieval and RAG
+### Retrieval and RAG { #retrieval-and-rag }
 
 - Live RAG SDK with `Retriever.retrieve()`,  reference answer generation `Retriever.answer()`, and optional batch operator graphs via LiteLLM (`[llm]` extra)  
 
-### Vector database
+### Vector database { #vector-database }
 
 - Vector database operators integrated directly in the pipeline; custom metadata support; LanceDB hybrid search guidance updated  
 - LanceDB is documented as the first-party vector path for new deployments; Milvus/MinIO guidance removed from the primary extraction doc set  
 
-### Evaluation
+### Evaluation { #evaluation }
 
 - BEIR-centric evaluation overhaul and `retriever skill-eval` benchmark CLI for the NeMo Retriever skill (experimental)  
 
 
 - Text-to-SQL agent graph and tabular tooling for structured data retrieval, including tabular data ingestion  
 
-### Packaging and platform
+### Packaging and platform { #packaging-and-platform }
 
 - Optional install extras (`[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and others), including slim remote/NIM-only installs on Mac and Windows  
 
-### Helm chart
+### Helm chart { #helm-chart }
 
 - Helm chart refresh under `nemo_retriever/helm/` with VL embedder defaults and optional Nemotron Parse and Omni caption NIMs  
 
-### Documentation
+### Documentation { #documentation }
 
 - Documentation aligned to a Helm-first supported path for NIM and service deployment
 - Documentation consolidates extraction concepts, ingest workflow, embeddings, audio/video guides, prerequisites and support matrix, and UDF/custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)  
 
-## Release Notes for Previous Versions
+## Release Notes for Previous Versions { #previous-versions }
 
 - [26.05](https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/releasenotes-nv-ingest/)
 - [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
@@ -89,7 +89,7 @@ Highlights for the 26.08 release include:
 
 Release notes for 24.12.1 and 24.12.0 are on the [25.3.0 archived release notes](https://archive.docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/).
 
-## Related Topics
+## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Deployment options](deployment-options.md)

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -125,13 +125,13 @@ is incorrect.
     shown in current NeMo Retriever Library output exists in `25.4.2`; include
     the exact old exception and logs when escalating.
 
-## Can't process long, non-language text strings
+## Can't process long, non-language text strings { #cant-process-long-non-language-text-strings }
 
 NeMo Retriever Library is designed to process language and language-length strings.
 If you submit a document that contains extremely long, or non-language text strings,
 such as a DNA sequence, errors or unexpected results occur.
 
-## Can't process malformed input files
+## Can't process malformed input files { #cant-process-malformed-input-files }
 
 When you run a job you might see errors similar to the following:
 
@@ -181,7 +181,7 @@ service:
 
 This path fails with `allowPrivilegeEscalation: false` or `readOnlyRootFilesystem: true`.
 
-## Can't start new thread error
+## Can't start new thread error { #cant-start-new-thread-error }
 
 In rare cases, when you run a job you might an see an error similar to `can't start new thread`.
 This error occurs when the maximum number of processes available to a single user is too low.
@@ -197,7 +197,7 @@ ulimit -u 10000
 
 
 
-## Out-of-Memory (OOM) Error when Processing Large Datasets
+## Out-of-Memory (OOM) Error when Processing Large Datasets { #out-of-memory-oom-error-when-processing-large-datasets }
 
 When you process a very large dataset with thousands of documents, you might encounter an Out-of-Memory (OOM) error.
 This happens because NeMo Retriever Library materializes extraction results in system memory (RAM) while the job runs.
@@ -212,7 +212,7 @@ To reduce memory pressure, try one or more of the following:
 
 
 
-## Embedding service fails to start with an unsupported batch size error
+## Embedding service fails to start with an unsupported batch size error { #embedding-service-fails-unsupported-batch-size }
 
 On certain hardware, for example RTX 6000,
 the embedding service might fail to start and you might see an error similar to the following.
@@ -251,7 +251,7 @@ pip install "nemo-retriever[local,nemotron-parse]"
 
 Also refer to [NeMo Retriever Library Overview](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
 
-## Extract method nemotron-parse doesn't support image files
+## Extract method nemotron-parse doesn't support image files { #extract-method-nemotron-parse-doesnt-support-image-files }
 
 Currently, extraction with Nemotron parse doesn't support image files, only scanned PDFs.
 To work around this issue, convert image files to PDFs before you use `method="nemotron_parse"`.
@@ -362,7 +362,7 @@ For the request schema, refer to the [Object Detection NIM API reference](https:
 
 Supported inline formats remain **PNG** and **JPEG**, encoded as `data:image/<format>;base64,<data>` or `data:image/<format>;asset_id,<uuid>`. OpenAPI specs for Page Elements v2 and v3 are linked from the [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html#openapi-reference-for-page-elements).
 
-## Too many open files error
+## Too many open files error { #too-many-open-files-error }
 
 In rare cases, when you run a job you might an see an error similar to `too many open files` or `max open file descriptor`.
 This error occurs when the open file descriptor limit for your service user account is too low.
@@ -378,7 +378,7 @@ ulimit -n 10000
 
 
 
-## Triton server INFO messages incorrectly logged as errors
+## Triton server INFO messages incorrectly logged as errors { #triton-server-info-messages-incorrectly-logged-as-errors }
 
 Sometimes messages are incorrectly logged as errors, when they are information.
 When this happens, you can ignore the errors, and treat the messages as information.
@@ -411,7 +411,7 @@ ERROR 2025-04-24 22:49:44.434 nimutils.py:68] }
 
 
 
-## Related Topics
+## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Deployment options](deployment-options.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -197,6 +197,8 @@ plugins:
 markdown_extensions:
   - attr_list
   - md_in_html
+  - toc:
+      permalink: true
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.snippets:


### PR DESCRIPTION
## Summary
- Fix release-notes GitHub links that pointed at a non-existent `26.08` branch (404) by using `main`, matching the rest of the extraction docs.
- Enable MkDocs `toc` permalinks so clicking a section heading appends `#section-name` to the URL.
- Add stable `{ #anchor }` IDs on high-traffic pages (overview, FAQ, embedding, troubleshoot, Ray logging, release notes, and related).
- Crosslink Python snippets / credential examples to the [Python API guide](docs/docs/extraction/nemo-retriever-api-reference.md), including the persisted-graphs credential section.
- Replace absolute `docs.nvidia.com/.../latest/...` related-topic links with in-tree relative paths on GitHub Pages (`environment-config.md`, `ray-logging.md`).

## Notes
- `custom-metadata.md` / `user-defined-stages.md` are already redirects on `main`, so their stale API targets are out of scope for this PR.
- Further deep-link anchors can continue in follow-up PRs as pages are edited.

## Test plan
- [ ] Confirm the three former `26.08` GitHub URLs now resolve via `main`
- [ ] After Pages publish: click an H2 on overview/FAQ and confirm `#…` appears in the URL (permalink)
- [ ] Spot-check API guide links from embedding, api-keys, FAQ, and audio/video pages
- [ ] Confirm `environment-config` / `ray-logging` Related Topics stay on the GitHub Pages site