### PR TITLE
fix: use model-profile GPU memory defaults for local captioning

### DIFF
--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -88,7 +88,29 @@ Image captioning generates natural-language descriptions for unstructured image 
 
 **Captioning is optional** — enable it in your ingest configuration (for example, the `caption` API or pipeline flag) when you need natural-language descriptions of image content. Reasoning traces are disabled by default for captioning.
 
-Direct local captioning defaults to `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`. Its BF16 weights are approximately 62 GiB, so plan for a larger GPU footprint than the Nano caption profiles, which remain available through explicit model overrides. Hosted captioning defaults to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` at the NVIDIA API endpoint.
+Direct local Hugging Face captioning defaults to `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`. Its BF16 weights are approximately 62 GiB. For this local vLLM profile, NeMo Retriever Library reserves `0.95` of a dedicated GPU's memory for the model and KV cache. An NVIDIA H100 with 80 GB of memory meets this local profile's minimum capacity when it is dedicated to captioning. The Nano caption profiles retain their `0.5` memory-utilization default and remain available through explicit model overrides. Hosted captioning defaults to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` at the NVIDIA API endpoint.
+
+The 80 GB requirement for the self-hosted Omni NIM describes the NIM deployment. It does not by itself establish that local Hugging Face vLLM inference has enough memory for both weights and its KV cache. For local vLLM, use a dedicated GPU and retain the model-profile default unless you need to tune its memory reservation explicitly.
+
+For example, to override the local vLLM memory reservation from the SDK, pass `CaptionParams` to `caption`.
+
+```python
+from nemo_retriever import create_ingestor
+from nemo_retriever.common.params import CaptionParams, ExtractParams
+
+result = (
+    create_ingestor(run_mode="inprocess")
+    .files(["multimodal_test.png"])
+    .extract(ExtractParams(extract_images=True))
+    .caption(
+        CaptionParams(
+            model_name="nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+            gpu_memory_utilization=0.95,
+        )
+    )
+    .ingest()
+)
+```
 
 Chart-classified PDF regions stay on the layout/OCR path; only non-chart image regions and optional infographics (`caption_infographics=True`) receive Omni captions.
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -134,6 +134,8 @@ Optional features in the table above require GPU capacity **beyond the four defa
 
 For published NIM model IDs and deployment-specific constraints, use the product support matrices linked under [Related Topics](#related-topics) below.
 
+The Omni rows in the following table describe self-hosted NIM deployments. Direct local Hugging Face inference uses vLLM and also needs GPU memory for the KV cache and runtime allocations. For the local Omni BF16 profile, NeMo Retriever Library uses `gpu_memory_utilization=0.95` by default. On an 80 GB GPU, dedicate the GPU to local captioning. A checkpoint's approximately 62 GiB weight size alone does not establish local vLLM capacity.
+
 ## Model Hardware Requirements { #model-hardware-requirements }
 
 NeMo Retriever Library supports the following GPU hardware given system constraints in the table.
@@ -166,7 +168,7 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 
 ⁴ Self-hosted [audio/video extraction](audio-video.md) through Parakeet ASR (`parakeet-1-1b-ctc-en-us:1.5.0`, `nimOperator.audio`) is **not supported** on **B200**, other **Blackwell** GPUs (compute capability 12.0), including RTX PRO 6000 Blackwell and RTX PRO 4500 Blackwell, or **H200 NVL**. Core PDF and multimodal extraction on those GPUs is unchanged. Video workflows that depend on Parakeet for speech transcription are affected the same way. `NIMService` for `nimOperator.audio` may stay not Ready or enter `CrashLoopBackOff` while building the Riva/TensorRT engine (for example ONNX Runtime IR version, cuDNN visibility, or FP8 tactic errors). Use a supported dedicated GPU (for example H100 or A100), [hosted Parakeet on build.nvidia.com](audio-video.md#parakeet-hosted-inference-build-nvidia), or set `nimOperator.audio.enabled=false`.
 
-³ Opt-in Omni captioning uses the [nemotron-3-nano-omni-30b-a3b-reasoning](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) NIM (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant`). BF16 requires at least 80 GB total GPU memory; refer to the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
+³ Opt-in Omni captioning uses the [nemotron-3-nano-omni-30b-a3b-reasoning](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) NIM (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant`). BF16 requires at least 80 GB total GPU memory for this NIM deployment; refer to the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
 
 \* GPUs with less than 80GB VRAM cannot run the reranker concurrently with the core pipeline. 
 To perform recall testing with the reranker on these GPUs, shut down the core pipeline NIM microservices 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -265,7 +265,8 @@ These options apply to `retriever ingest`, `retriever ingest local`, and
 | `--ocr-version` | planner default | OCR engine version for local extraction. |
 | `--ocr-lang` | planner default | OCR v2 language selector for local extraction. |
 | `--caption` | off | Add a captioning stage. |
-| `--caption-model-name` | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | Local vLLM caption model. The default has approximately 62 GiB of BF16 weights and requires correspondingly larger GPU capacity; Nano models remain available as explicit overrides. For remote endpoints, pass the endpoint API model ID. |
+| `--caption-model-name` | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | Local vLLM caption model. The default has approximately 62 GiB of BF16 weights. On a dedicated 80 GB GPU, its local profile reserves `0.95` of GPU memory for vLLM model and KV-cache use. Nano models retain the `0.5` profile default and remain available as explicit overrides. For remote endpoints, pass the endpoint API model ID. |
+| `--caption-gpu-memory-utilization` | model profile | Fraction of a local caption GPU that vLLM can reserve. The Omni BF16 profile defaults to `0.95`; other local caption profiles default to `0.5`. Use this option only with `--caption` and local vLLM captioning. |
 | `--dedup` | off | Add image deduplication before captioning and embedding. |
 | `--text-chunk` | off | Enable token chunking during extraction. |
 | `--store-images-uri` | unset | Store extracted images at a local path or fsspec-compatible URI. |
@@ -407,6 +408,19 @@ retriever ingest ./data/test.pdf \
   --api-key "${NVIDIA_API_KEY}" \
   --store-images-uri ./processed_docs/images
 ```
+
+For local Hugging Face Omni BF16 captioning, use a dedicated GPU. The default
+profile reserves `0.95` of GPU memory so that vLLM can allocate both the model
+and its KV cache. Override that reservation when your deployment requires it:
+
+```bash
+retriever ingest ./data/test.png \
+  --caption \
+  --caption-gpu-memory-utilization 0.95
+```
+
+An 80 GB requirement for a self-hosted Omni NIM does not by itself establish
+that direct local Hugging Face vLLM inference has sufficient KV-cache capacity.
 
 ## Results and diagnostics
 

--- a/nemo_retriever/src/nemo_retriever/cli/ingest/graph_commands.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/graph_commands.py
@@ -216,6 +216,7 @@ def _graph_ingest_command(
     caption_invoke_url: opts.CaptionInvokeUrlOption = None,
     api_key: opts.ApiKeyOption = None,
     caption_model_name: opts.CaptionModelNameOption = None,
+    caption_gpu_memory_utilization: opts.CaptionGpuMemoryUtilizationOption = None,
     caption_context_text_max_chars: opts.CaptionContextTextMaxCharsOption = None,
     caption_infographics: opts.CaptionInfographicsOption = None,
     dedup: opts.DedupOption = False,

--- a/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
@@ -153,6 +153,18 @@ CaptionModelNameOption = Annotated[
         ),
     ),
 ]
+CaptionGpuMemoryUtilizationOption = Annotated[
+    float | None,
+    typer.Option(
+        "--caption-gpu-memory-utilization",
+        min=0.001,
+        max=1.0,
+        help=(
+            "Fraction of GPU memory reserved by local vLLM captioning. "
+            "Defaults to the selected local caption model profile."
+        ),
+    ),
+]
 CaptionContextTextMaxCharsOption = Annotated[
     int | None,
     typer.Option(

--- a/nemo_retriever/src/nemo_retriever/common/modality/caption/model_profiles.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/caption/model_profiles.py
@@ -60,8 +60,11 @@ class CaptionModelProfile:
     local_request_extras: Mapping[str, Any] = field(default_factory=dict)
     remote_request_extras: Mapping[str, Any] = field(default_factory=dict)
     local_engine_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    local_gpu_memory_utilization: float = 0.5
 
     def __post_init__(self) -> None:
+        if not 0 < self.local_gpu_memory_utilization <= 1:
+            raise ValueError("local_gpu_memory_utilization must be greater than 0 and no greater than 1")
         object.__setattr__(self, "local_request_extras", _freeze_metadata(self.local_request_extras))
         object.__setattr__(self, "remote_request_extras", _freeze_metadata(self.remote_request_extras))
         object.__setattr__(self, "local_engine_kwargs", _freeze_metadata(self.local_engine_kwargs))
@@ -274,6 +277,9 @@ _OMNI_BF16_PROFILE = CaptionModelProfile(
     local_request_extras=_OMNI_NO_THINK_EXTRAS,
     remote_request_extras=_OMNI_NO_THINK_EXTRAS,
     local_engine_kwargs=_BF16_ENGINE_KWARGS,
+    # The 62 GiB BF16 checkpoint needs a high vLLM reservation to leave KV
+    # cache capacity on the supported 80 GiB local GPU configuration.
+    local_gpu_memory_utilization=0.95,
 )
 _OMNI_FP8_PROFILE = CaptionModelProfile(
     family="nemotron-3-nano-omni",

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -989,7 +989,12 @@ class CaptionParams(LLMInferenceParams):
     hf_cache_dir: Optional[str] = None
     context_text_max_chars: int = 0
     tensor_parallel_size: int = 1
-    gpu_memory_utilization: Optional[float] = Field(default=None, gt=0, le=1)
+    gpu_memory_utilization: Optional[float] = Field(
+        default=None,
+        gt=0,
+        le=1,
+        description="Fraction of GPU memory reserved for local vLLM captioning; defaults to the model profile.",
+    )
     caption_infographics: bool = False
     extra_body: dict[str, Any] = Field(default_factory=dict)
 

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -24,7 +24,10 @@ from pydantic import (
     model_validator,
 )
 
-from nemo_retriever.common.modality.caption.model_profiles import DEFAULT_LOCAL_CAPTION_MODEL_ID
+from nemo_retriever.common.modality.caption.model_profiles import (
+    DEFAULT_LOCAL_CAPTION_MODEL_ID,
+    get_caption_model_profile,
+)
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 
 IngestorRunMode = Literal["inprocess", "batch", "service"]
@@ -989,7 +992,7 @@ class CaptionParams(LLMInferenceParams):
     hf_cache_dir: Optional[str] = None
     context_text_max_chars: int = 0
     tensor_parallel_size: int = 1
-    gpu_memory_utilization: float = 0.5
+    gpu_memory_utilization: Optional[float] = Field(default=None, gt=0, le=1)
     caption_infographics: bool = False
     extra_body: dict[str, Any] = Field(default_factory=dict)
 
@@ -999,6 +1002,15 @@ class CaptionParams(LLMInferenceParams):
         if value is None:
             raise ValueError("temperature cannot be None for captioning")
         return value
+
+    @model_validator(mode="after")
+    def _resolve_local_gpu_memory_utilization(self) -> "CaptionParams":
+        """Use the selected local caption profile's vLLM memory default."""
+        if self.gpu_memory_utilization is None:
+            profile = get_caption_model_profile(self.model_name, target="local", strict=False)
+            if profile is not None:
+                self.gpu_memory_utilization = profile.local_gpu_memory_utilization
+        return self
 
 
 class WebhookParams(_ParamsModel):

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -24,10 +24,7 @@ from pydantic import (
     model_validator,
 )
 
-from nemo_retriever.common.modality.caption.model_profiles import (
-    DEFAULT_LOCAL_CAPTION_MODEL_ID,
-    get_caption_model_profile,
-)
+from nemo_retriever.common.modality.caption.model_profiles import DEFAULT_LOCAL_CAPTION_MODEL_ID
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 
 IngestorRunMode = Literal["inprocess", "batch", "service"]
@@ -1002,15 +999,6 @@ class CaptionParams(LLMInferenceParams):
         if value is None:
             raise ValueError("temperature cannot be None for captioning")
         return value
-
-    @model_validator(mode="after")
-    def _resolve_local_gpu_memory_utilization(self) -> "CaptionParams":
-        """Use the selected local caption profile's vLLM memory default."""
-        if self.gpu_memory_utilization is None:
-            profile = get_caption_model_profile(self.model_name, target="local", strict=False)
-            if profile is not None:
-                self.gpu_memory_utilization = profile.local_gpu_memory_utilization
-        return self
 
 
 class WebhookParams(_ParamsModel):

--- a/nemo_retriever/src/nemo_retriever/models/local/nemotron_vlm_captioner.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/nemotron_vlm_captioner.py
@@ -80,12 +80,14 @@ class NemotronVLMCaptioner(BaseModel):
         hf_cache_dir: Optional[str] = None,
         max_new_tokens: int = 1024,
         tensor_parallel_size: int = 1,
-        gpu_memory_utilization: float = 0.5,
+        gpu_memory_utilization: float | None = None,
     ) -> None:
         super().__init__()
 
         profile = get_caption_model_profile(model_path, target="local")
         model_path = profile.local_model_id
+        if gpu_memory_utilization is None:
+            gpu_memory_utilization = profile.local_gpu_memory_utilization
 
         from nemo_retriever.models.inference.vllm import apply_vllm_startup_defaults
 
@@ -123,7 +125,7 @@ class NemotronVLMCaptioner(BaseModel):
             revision=revision,
             trust_remote_code=True,
             tensor_parallel_size=tensor_parallel_size,
-            gpu_memory_utilization=gpu_memory_utilization,
+            gpu_memory_utilization=float(gpu_memory_utilization),
             **engine_kwargs,
         )
 

--- a/nemo_retriever/tests/test_caption_model_profiles.py
+++ b/nemo_retriever/tests/test_caption_model_profiles.py
@@ -495,11 +495,10 @@ def test_local_captioner_uses_profile_gpu_memory_default(
     assert FakeLLM.instances[-1].kwargs["gpu_memory_utilization"] == expected_utilization
 
 
-def test_caption_params_resolves_profile_gpu_memory_default():
+def test_caption_params_preserves_an_omitted_gpu_memory_utilization():
     from nemo_retriever.common.params import CaptionParams
 
-    assert CaptionParams(model_name=NANO_BF16).gpu_memory_utilization == 0.5
-    assert CaptionParams(model_name=OMNI_BF16).gpu_memory_utilization == 0.95
+    assert CaptionParams(model_name=OMNI_BF16).gpu_memory_utilization is None
     assert CaptionParams(model_name=OMNI_BF16, gpu_memory_utilization=0.8).gpu_memory_utilization == 0.8
 
 

--- a/nemo_retriever/tests/test_caption_model_profiles.py
+++ b/nemo_retriever/tests/test_caption_model_profiles.py
@@ -473,6 +473,34 @@ def test_local_captioner_applies_vllm_startup_defaults_before_constructing_llm(
     NemotronVLMCaptioner(model_path=OMNI_BF16)
 
     assert FakeLLM.instances[-1].deep_gemm_warmup == "skip"
+    assert FakeLLM.instances[-1].kwargs["gpu_memory_utilization"] == 0.95
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_utilization"),
+    [
+        (NANO_BF16, 0.5),
+        (OMNI_BF16, 0.95),
+    ],
+)
+def test_local_captioner_uses_profile_gpu_memory_default(
+    isolated_local_captioner_imports, model_name, expected_utilization
+):
+    FakeLLM, _FakeSamplingParams = _install_fake_vllm()
+
+    from nemo_retriever.models.local.nemotron_vlm_captioner import NemotronVLMCaptioner
+
+    NemotronVLMCaptioner(model_path=model_name)
+
+    assert FakeLLM.instances[-1].kwargs["gpu_memory_utilization"] == expected_utilization
+
+
+def test_caption_params_resolves_profile_gpu_memory_default():
+    from nemo_retriever.common.params import CaptionParams
+
+    assert CaptionParams(model_name=NANO_BF16).gpu_memory_utilization == 0.5
+    assert CaptionParams(model_name=OMNI_BF16).gpu_memory_utilization == 0.95
+    assert CaptionParams(model_name=OMNI_BF16, gpu_memory_utilization=0.8).gpu_memory_utilization == 0.8
 
 
 def test_local_captioner_passes_omni_no_think_chat_kwargs(isolated_local_captioner_imports):

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -1327,6 +1327,8 @@ def test_root_ingest_caption_is_optional_and_passes_minimal_caption_params(monke
             "http://vlm:8000/v1/chat/completions",
             "--caption-model-name",
             "nvidia/test-vlm",
+            "--caption-gpu-memory-utilization",
+            "0.8",
             "--caption-context-text-max-chars",
             "512",
             "--caption-infographics",
@@ -1346,6 +1348,7 @@ def test_root_ingest_caption_is_optional_and_passes_minimal_caption_params(monke
     assert isinstance(caption_params, CaptionParams)
     assert caption_params.endpoint_url == "http://vlm:8000/v1/chat/completions"
     assert caption_params.model_name == "nvidia/test-vlm"
+    assert caption_params.gpu_memory_utilization == 0.8
     assert caption_params.context_text_max_chars == 512
     assert caption_params.caption_infographics is True
 
@@ -1364,6 +1367,8 @@ def test_root_ingest_rejects_caption_options_without_caption(monkeypatch, tmp_pa
             str(document),
             "--caption-invoke-url",
             "http://vlm:8000/v1/chat/completions",
+            "--caption-gpu-memory-utilization",
+            "0.8",
         ],
     )
 


### PR DESCRIPTION
## Description

Fix local vLLM startup for the Omni BF16 caption model on dedicated 80 GB GPUs.

- Default the Omni BF16 caption profile to `gpu_memory_utilization=0.95`; other local caption profiles remain at `0.5`.
- Add `--caption-gpu-memory-utilization` for explicit CLI tuning, while preserving explicit SDK overrides.
- Clarify the distinction between self-hosted NIM capacity guidance and local vLLM memory needed for model weights, KV cache, and runtime allocations.

## Validation

- `pytest tests/test_caption_model_profiles.py tests/test_root_cli_workflow.py -q`
- `pytest tests/test_caption.py tests/test_ingest_manifest.py -q`
- H100 NVL startup smoke test: `0.95` resolved to 18.19 GiB of available vLLM KV cache.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.