### PR TITLE
feat(extraction): support Nemotron Parse 2.0

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -36,9 +36,9 @@ No. Chart-labeled PDF regions are not routed through Omni captioning. Refer to [
 ## When should I consider advanced visual parsing? { #advanced-visual-parsing }
 
 For scanned documents, or documents with complex layouts,
-you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `method="nemotron_parse"`.
-Nemotron Parse does not produce chart modality rows. For chart detection and chart-filtered retrieval, use the default **pdfium** layout path instead (refer to [Charts and infographics](multimodal-extraction.md#charts-and-infographics)).
-For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
+you can use [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `method="nemotron_parse"`.
+Local inference defaults to NVIDIA Nemotron Parse 2.0, which produces chart modality rows when `extract_charts=True`. Parse v1.2 does not include a dedicated `Chart` class. For details, refer to [Charts and infographics](multimodal-extraction.md#charts-and-infographics).
+For deployment options, refer to [Nemotron Parse deployment options](prerequisites-support-matrix.md#nemotron-parse-hosted-vs-self-hosted).
 
 ## Why are the environment variables different between library mode and self-hosted mode? { #library-vs-self-hosted-env-vars }
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -27,7 +27,7 @@ NeMo Retriever Library accepts multiple document and media types. A current list
 For PDFs, NeMo Retriever Library typically uses **pdfium**-based extraction with configurable depth and paths. Scanned or mixed pages may use hybrid, OCR-oriented, or Nemotron Parse methods. For `method` options such as `pdfium`, `pdfium_hybrid`, `ocr`, and `nemotron_parse`, refer to the [Python API reference](nemo-retriever-api-reference.md).
 
 !!! note
-    `method="nemotron_parse"` requires the Nemotron Parse NIM client dependencies. Install them with the `nemotron-parse` extra, for example `pip install "nemo-retriever[nemotron-parse]"`, before running PDF extraction through Nemotron Parse. This path does not produce chart modality rows; for chart detection, refer to [Charts and infographics](#charts-and-infographics).
+    `method="nemotron_parse"` requires the Nemotron Parse dependencies. For managed local inference, install `pip install "nemo-retriever[local,nemotron-parse]"`; for a remote endpoint, install `pip install "nemo-retriever[nemotron-parse]"`. When you do not configure an endpoint, NeMo Retriever Library manages local in-process inference and defaults to [NVIDIA Nemotron Parse 2.0](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-2.0). You do not need to start a separate model server for this local path.
 
 **Related**
 
@@ -49,16 +49,10 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 
 Charts and infographic regions are classified with other page layout elements (tables, text blocks, titles) and processed through layout detection and OCR. `extract_charts` and `extract_infographics` are enabled by default. Outputs use the same metadata schema as other extracted objects.
 
-!!! important "Chart modality requires the default layout path"
-    [Nemotron Parse v1.2](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) semantic classes do not include `Chart` or `Infographic`. The model labels regions as `Text`, `Table`, `Picture`, `Caption`, `List-item`, `Section-header`, and similar types instead.
+!!! note "Nemotron Parse chart classes vary by model version"
+    The default local [NVIDIA Nemotron Parse 2.0](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-2.0) model includes the `Chart` semantic class. With `method="nemotron_parse"` and `extract_charts=True`, NeMo Retriever Library routes these regions to chart modality rows.
 
-    When you set `method="nemotron_parse"`:
-
-    - The pipeline does not produce `chart` or `infographic` modality rows, even when `extract_charts=True` or `extract_infographics=True`.
-    - Chart- and infographic-filtered retrieval (for example, queries scoped to figure or chart content) returns no hits.
-    - Chart-heavy and infographic-heavy pages are typically emitted as `Picture` or other non-chart modalities.
-
-    For chart and infographic detection and modality-specific retrieval, use the default **pdfium** layout path (page-elements detection and OCR), not `method="nemotron_parse"`.
+    [Nemotron Parse v1.2](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) does not include the `Chart` or `Infographic` semantic class. It can label graphical regions as `Picture`; NeMo Retriever Library routes `Picture` regions to infographic rows when `extract_infographics=True`. Use the default **pdfium** layout path when you need dedicated chart detection with Parse v1.2.
 
 Chart-labeled PDF regions are **not** routed through the Omni caption stage; they remain on the layout-and-OCR path. For scope and validation guidance, refer to [Image captioning](#image-captioning).
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -26,7 +26,7 @@ NeMo Retriever Library does the following:
 - Apply pre- and post-processing: text splitting and chunking, transforms and filtering, embedding generation, and image offloading to storage
 
 !!! note
-    To use `method="nemotron_parse"` with PDFs, install the Nemotron Parse client dependencies with the `nemotron-parse` extra, for example `uv pip install "nemo-retriever[nemotron-parse]"`. You can use the equivalent `pip install` command if you do not use UV.
+    To use `method="nemotron_parse"` with PDFs, install `uv pip install "nemo-retriever[local,nemotron-parse]"` for managed local inference or `uv pip install "nemo-retriever[nemotron-parse]"` for a remote endpoint. You can use the equivalent `pip install` command if you do not use UV. Without a configured endpoint, NeMo Retriever Library manages local in-process inference and defaults to `nvidia/NVIDIA-Nemotron-Parse-2.0`.
 
 NeMo Retriever Library supports the following file types:
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -18,11 +18,12 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
   `sudo apt-get install -y --no-install-recommends ffmpeg` on Debian/Ubuntu).
   `ffmpeg-python` and `nemo-retriever[multimedia]` do not install these binaries.
   For container and Kubernetes guidance, refer to [Audio and video](audio-video.md).
-- For PDF extraction with `method="nemotron_parse"`, install the Nemotron Parse
-  client dependencies with `uv pip install "nemo-retriever[nemotron-parse]"` (pulls
-  `open-clip-torch`, which provides the `open_clip` module required by the Nemotron Parse
-  NIM client). The base `nemo-retriever` install and `[local]` extra do not include this
-  package. You can use the equivalent `pip install` command if you do not use UV.
+- For PDF extraction with `method="nemotron_parse"`, use
+  `uv pip install "nemo-retriever[local,nemotron-parse]"` for managed local inference or
+  `uv pip install "nemo-retriever[nemotron-parse]"` for a remote endpoint. The
+  `nemotron-parse` extra pulls `open-clip-torch`, which provides the `open_clip` module
+  required by the Nemotron Parse client. The base `nemo-retriever` install and `[local]`
+  extra do not include this package. You can use equivalent `pip install` commands.
 
 > **Note**
 >
@@ -106,21 +107,23 @@ When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-host
 | nemotron-ocr-v2 | `https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v2` | Chart default OCR SKU; library CPU actors default to this URL when no OCR invoke URL is set. **Local OCR language selectors (`--ocr-lang`, API `ocr_lang`) are not sent on remote requests** — hosted OCR v2 uses its own language behavior |
 | llama-nemotron-embed-vl-1b-v2 | `https://integrate.api.nvidia.com/v1/embeddings` with model ID `nvidia/llama-nemotron-embed-vl-1b-v2` | Core multimodal embedding |
 | llama-nemotron-rerank-vl-1b-v2 | `https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking` | Optional VL reranker |
-| nemotron-parse | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/nemotron-parse` | Optional `method="nemotron_parse"`. Hosted Build and self-hosted `nemotron-parse-v1.2` use different request contracts; the library selects the matching contract automatically. Refer to [Nemotron Parse: hosted Build endpoint vs self-hosted NIM](#nemotron-parse-hosted-vs-self-hosted) |
+| nemotron-parse | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/nemotron-parse` | Optional `method="nemotron_parse"`. Hosted Build uses a different request contract from versioned self-hosted models. Refer to [Nemotron Parse deployment options](#nemotron-parse-hosted-vs-self-hosted) |
 | nemotron-3-nano-omni-30b-a3b-reasoning | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Optional image captioning |
 | llama-3.3-nemotron-super-49b-v1.5 | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/llama-3.3-nemotron-super-49b-v1.5` | Optional `/v1/answer` (Helm `answer_llm`) and OpenAI-compatible agentic RAG endpoint mode; not part of the default extraction pipeline. Agentic query/harness runs default to local in-process vLLM instead. Helm auto-wires to the in-cluster NIM when `nimOperator.answer_llm` is enabled |
 | parakeet-1-1b-ctc-en-us | `grpc.nvcf.nvidia.com:443` (function ID from [build.nvidia.com](https://build.nvidia.com/)) | Optional ASR; refer to [Parakeet hosted inference](audio-video.md#parakeet-hosted-inference-build-nvidia) |
 
 <a id="nemotron-parse-hosted-vs-self-hosted"></a>
 
-!!! note "Nemotron Parse: hosted Build endpoint vs self-hosted NIM"
+!!! note "Nemotron Parse deployment options"
 
-    Hosted NVIDIA Build and self-hosted Nemotron Parse use **different request contracts**. The library selects the matching contract from the endpoint and model:
+    Nemotron Parse supports local managed inference and optional remote endpoints:
 
-    - **Hosted Build** (`https://integrate.api.nvidia.com/v1/chat/completions`) resolves to model ID `nvidia/nemotron-parse` and uses an image-only tool-call contract.
-    - **Self-hosted chat endpoints** default to model ID `nvidia/nemotron-parse-v1.2` and use the tagged text-prompt contract.
+    - **Local managed inference:** Set `method="nemotron_parse"` without `nemotron_parse_invoke_url`. NeMo Retriever Library loads `nvidia/NVIDIA-Nemotron-Parse-2.0` in process, applies the compatibility needed by its compact checkpoint, and uses up to 9,000 generation tokens. You do not need a separate endpoint or a `vllm serve` process. Set `nemotron_parse_model="nvidia/NVIDIA-Nemotron-Parse-v1.2"` to retain the earlier local model.
+    - **Hosted NVIDIA Build:** Set `nemotron_parse_invoke_url="https://integrate.api.nvidia.com/v1/chat/completions"`. The endpoint uses model ID `nvidia/nemotron-parse` and an image-only tool-call contract. You can normally omit `nemotron_parse_model` because the library selects the hosted model automatically.
+    - **Self-hosted NIM:** The shipped Compose and Helm defaults remain `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant`. To use Parse 2.0 explicitly, deploy `nvcr.io/nim/nvidia/nemotron-parse-v2.0:2.0.8-variant`, set the chat-completions endpoint, and set `nemotron_parse_model="nvidia/nemotron-parse-v2.0"`.
+    - **Self-hosted vLLM:** Set `nemotron_parse_model="nvidia/NVIDIA-Nemotron-Parse-2.0"` explicitly. When you serve the compact Hugging Face checkpoint outside NeMo Retriever Library, load the model-provided [`vllm_tied_patch/sitecustomize.py`](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-2.0/blob/main/vllm_tied_patch/sitecustomize.py) through `PYTHONPATH` before starting vLLM. The managed local path applies equivalent support automatically.
 
-    To use hosted Build, set `nemotron_parse_invoke_url` to the Build chat-completions URL (and set `method="nemotron_parse"`). You can normally omit `nemotron_parse_model` so the library selects the model automatically. If you set `nemotron_parse_model` explicitly, it must match the endpoint contract. Mixed Build and self-hosted endpoint lists require an explicit model.
+    Hosted NVIDIA Build and versioned self-hosted models use different request contracts. If you set `nemotron_parse_model`, match it to the endpoint. Mixed Build and self-hosted endpoint lists require an explicit model.
 
     For model/endpoint mismatch symptoms, refer to [Nemotron Parse model and endpoint mismatch](troubleshoot.md#nemotron-parse-model-endpoint-mismatch).
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -235,7 +235,7 @@ When you run PDF extraction with `method="nemotron_parse"`, you might see an err
 ModuleNotFoundError: No module named 'open_clip'
 ```
 
-The Nemotron Parse NIM client requires the `open_clip` Python module, provided by `open-clip-torch`. That package is not part of the default `nemo-retriever` install or the `[local]` extra.
+The Nemotron Parse client requires the `open_clip` Python module, provided by `open-clip-torch`. That package is not part of the default `nemo-retriever` install or the `[local]` extra.
 
 Install the dedicated PyPI extra before running Nemotron Parse extraction:
 
@@ -264,9 +264,17 @@ When you run PDF extraction with `method="nemotron_parse"`, a mismatched model a
 HTTP 400: Content cannot be a plain string. The model does not support text input.
 ```
 
-This can occur when you send a tagged or versioned `v1.2` model (for example `nvidia/nemotron-parse-v1.2`) to the NVIDIA-hosted Build endpoint, which expects the image-only `nvidia/nemotron-parse` contract. The library may replace the raw HTTP error with a targeted model/contract mismatch hint.
+This can occur when you send a tagged or versioned self-hosted model (for example, `nvidia/nemotron-parse-v1.2` or `nvidia/nemotron-parse-v2.0`) to the NVIDIA-hosted Build endpoint, which expects the image-only `nvidia/nemotron-parse` contract. The library can replace the raw HTTP error with a targeted model and contract mismatch hint.
 
-To use hosted Build, omit `nemotron_parse_model` so the library selects `nvidia/nemotron-parse` automatically, or set `nemotron_parse_model="nvidia/nemotron-parse"` explicitly. Send versioned `v1.2` models only to a compatible self-hosted chat endpoint. For more information, refer to [Nemotron Parse: hosted Build endpoint vs self-hosted NIM](prerequisites-support-matrix.md#nemotron-parse-hosted-vs-self-hosted).
+To use hosted Build, omit `nemotron_parse_model` so the library selects `nvidia/nemotron-parse` automatically, or set `nemotron_parse_model="nvidia/nemotron-parse"` explicitly. Send versioned models only to a compatible self-hosted chat endpoint. For local managed inference, omit `nemotron_parse_invoke_url`; the library defaults to `nvidia/NVIDIA-Nemotron-Parse-2.0` and does not require a separate server. For more information, refer to [Nemotron Parse deployment options](prerequisites-support-matrix.md#nemotron-parse-hosted-vs-self-hosted).
+
+## Self-hosted Nemotron Parse 2.0 returns empty output { #self-hosted-nemotron-parse-2-returns-empty-output }
+
+A self-hosted vLLM server can return an empty successful response when it loads the compact `nvidia/NVIDIA-Nemotron-Parse-2.0` checkpoint without restoring its tied language-model head.
+
+When you run `vllm serve` yourself, add the model repository's `vllm_tied_patch` directory to `PYTHONPATH` before starting the server. Follow the [NVIDIA Nemotron Parse 2.0 model card](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-2.0), and configure NeMo Retriever Library with the server's `/v1/chat/completions` URL and `nemotron_parse_model="nvidia/NVIDIA-Nemotron-Parse-2.0"`.
+
+This step does not apply to normal local extraction with `method="nemotron_parse"`. NeMo Retriever Library loads Parse 2.0 in process and applies the tied-weight support automatically.
 
 ## Hosted Page Elements NIM image size limits { #hosted-page-elements-nim-image-size-limits }
 

--- a/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
+++ b/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
@@ -28,6 +28,7 @@ HF_MODEL_REVISIONS: dict[str, str] = {
     "nvidia/llama-nemotron-embed-1b-v2": "b4caa8456edd360b3b4e938d94ed4398dd437fad",
     "nvidia/parakeet-ctc-1.1b": "a707e818195cb97c8f7da2fc36b221a29f69a5db",
     "nvidia/NVIDIA-Nemotron-Parse-v1.2": "f42c8040b12ee64370922d108778ab655b722c5d",
+    "nvidia/NVIDIA-Nemotron-Parse-2.0": "635b84d9b09bb9526b9a684d0b2c953d3cc3df05",
     "nvidia/llama-nemotron-embed-vl-1b-v2": "4ef1bfa6da3a909de6bd00611950b7ed99203117",
     "meta-llama/Llama-3.2-1B": "4e20de362430cd3b72f300e6b0f18e50e7166e08",
     "intfloat/e5-large-unsupervised": "15af9288f69a6291f37bfb89b47e71abc747b206",

--- a/nemo_retriever/src/nemo_retriever/models/local/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "NemotronOCRV1",
     "NemotronOCRV2",
     "NemotronTableStructureV1",
+    "NemotronParse",
     "NemotronParseV12",
     "NemotronRerankV2",
     "NemotronRerankVLV2",
@@ -41,10 +42,10 @@ def __getattr__(name: str):
         from nemo_retriever.models.local.nemotron_table_structure_v1 import NemotronTableStructureV1
 
         return NemotronTableStructureV1
-    if name == "NemotronParseV12":
-        from nemo_retriever.models.local.nemotron_parse_v1_2 import NemotronParseV12
+    if name in {"NemotronParse", "NemotronParseV12"}:
+        from nemo_retriever.models.local.nemotron_parse_v1_2 import NemotronParse, NemotronParseV12
 
-        return NemotronParseV12
+        return NemotronParse if name == "NemotronParse" else NemotronParseV12
     if name == "NemotronRerankV2":
         from nemo_retriever.models.local.nemotron_rerank_v2 import NemotronRerankV2
 

--- a/nemo_retriever/src/nemo_retriever/models/local/nemotron_parse_v1_2.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/nemotron_parse_v1_2.py
@@ -28,6 +28,7 @@ ImageInput = Union[torch.Tensor, np.ndarray, Image.Image, str, Path]
 # the processor class at import time to pop the conflicting kwarg.
 
 _VLLM_PROCESSOR_PATCHED = False
+_VLLM_TIED_LM_HEAD_PATCHED = False
 
 
 def _patch_vllm_nemotron_parse_processor() -> None:
@@ -51,16 +52,49 @@ def _patch_vllm_nemotron_parse_processor() -> None:
     _VLLM_PROCESSOR_PATCHED = True
 
 
+def _patch_vllm_nemotron_parse_tied_lm_head() -> None:
+    """Restore tied decoder weights omitted by compact Parse 2.0 checkpoints."""
+    global _VLLM_TIED_LM_HEAD_PATCHED
+    if _VLLM_TIED_LM_HEAD_PATCHED:
+        return
+
+    try:
+        from vllm.model_executor.models.nemotron_parse import (
+            NemotronParseForConditionalGeneration,
+        )
+    except ImportError:
+        return
+
+    original_load_weights = NemotronParseForConditionalGeneration.load_weights
+
+    def load_weights_with_tied_lm_head(self: Any, weights: Any) -> Any:
+        buffered_weights = list(weights)
+        has_lm_head = any(name.startswith("lm_head.") for name, _ in buffered_weights)
+        result = original_load_weights(self, buffered_weights)
+
+        decoder_config = getattr(getattr(self, "config", None), "decoder", None)
+        tie_word_embeddings = bool(
+            getattr(decoder_config, "tie_word_embeddings", False)
+            or getattr(getattr(self, "config", None), "tie_word_embeddings", False)
+        )
+        if tie_word_embeddings and not has_lm_head:
+            self.lm_head.weight = self.decoder.embed_tokens.weight
+        return result
+
+    NemotronParseForConditionalGeneration.load_weights = load_weights_with_tied_lm_head
+    _VLLM_TIED_LM_HEAD_PATCHED = True
+
+
 # ---------------------------------------------------------------------------
 # Model wrapper
 # ---------------------------------------------------------------------------
 
 
-class NemotronParseV12(BaseModel):
+class NemotronParse(BaseModel):
     """
-    NVIDIA Nemotron Parse v1.2 local wrapper backed by vLLM.
+    NVIDIA Nemotron Parse local wrapper backed by vLLM.
 
-    This wrapper loads ``nvidia/NVIDIA-Nemotron-Parse-v1.2`` via vLLM's offline
+    This wrapper loads ``nvidia/NVIDIA-Nemotron-Parse-2.0`` via vLLM's offline
     ``LLM`` engine for image-to-structured-text generation (document parsing).
     vLLM handles KV-cache management, continuous batching, and GPU scheduling
     internally, avoiding the transformers cache-API incompatibility that affects
@@ -71,7 +105,7 @@ class NemotronParseV12(BaseModel):
 
     def __init__(
         self,
-        model_path: str = "nvidia/NVIDIA-Nemotron-Parse-v1.2",
+        model_path: str = "nvidia/NVIDIA-Nemotron-Parse-2.0",
         device: Optional[str] = None,
         hf_cache_dir: Optional[str] = None,
         task_prompt: str = _DEFAULT_TASK_PROMPT,
@@ -92,6 +126,7 @@ class NemotronParseV12(BaseModel):
             ) from e
 
         _patch_vllm_nemotron_parse_processor()
+        _patch_vllm_nemotron_parse_tied_lm_head()
 
         self._model_path = model_path
         self._task_prompt = task_prompt
@@ -222,7 +257,7 @@ class NemotronParseV12(BaseModel):
 
     @property
     def model_name(self) -> str:
-        return "NVIDIA-Nemotron-Parse-v1.2"
+        return self._model_path.rsplit("/", 1)[-1]
 
     @property
     def model_type(self) -> str:
@@ -246,9 +281,13 @@ class NemotronParseV12(BaseModel):
         return {
             "type": "text",
             "format": "string",
-            "description": "Generated structured parse text from Nemotron Parse v1.2.",
+            "description": f"Generated structured parse text from {self.model_name}.",
         }
 
     @property
     def input_batch_size(self) -> int:
         return 64
+
+
+# Backward-compatible alias for callers that imported the versioned wrapper.
+NemotronParseV12 = NemotronParse

--- a/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Nemotron Parse v1.2 pipeline stage.
+Nemotron Parse pipeline stage.
 
 Runs the Nemotron Parse model on full page images to extract structured
 document content (text, tables, charts, infographics) in a single pass,
@@ -51,7 +51,7 @@ except Exception:  # pragma: no cover
 
 NEMOTRON_PARSE_REMOTE_DEFAULT_MODEL = "nvidia/nemotron-parse-v1.2"
 NEMOTRON_PARSE_HOSTED_MODEL = "nvidia/nemotron-parse"
-NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL = "nvidia/NVIDIA-Nemotron-Parse-v1.2"
+NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL = "nvidia/NVIDIA-Nemotron-Parse-2.0"
 NEMOTRON_PARSE_DEFAULT_TASK_PROMPT = "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>"
 
 # Map Nemotron Parse class labels to the pipeline content channels.
@@ -309,7 +309,7 @@ def nemotron_parse_pages(
     nim_client: NIMClient | None = None,
     **kwargs: Any,
 ) -> Any:
-    """Run Nemotron Parse v1.2 on full page images.
+    """Run Nemotron Parse on full page images.
 
     Each page is parsed in a single model call.  The structured output is
     split by element class (Text, Table, Chart, Picture, …) and routed to
@@ -419,7 +419,7 @@ def nemotron_parse_pages(
                         )
                     raw_texts = [_extract_parse_text(item) for item in response_items]
             else:
-                # Local vLLM model (v1.2): uses task_prompt, returns tagged text.
+                # Local vLLM model: uses task_prompt and returns tagged text.
                 invoke_batch = getattr(model, "invoke_batch", None)
                 if invoke_batch is not None:
                     raw_texts = [str(t or "").strip() for t in invoke_batch(batch_images, task_prompt=task_prompt)]
@@ -507,7 +507,7 @@ def nemotron_parse_pages(
 
 
 class NemotronParseGPUActor(AbstractOperator, GPUOperator):
-    """Ray-friendly callable that initialises Nemotron Parse v1.2 once per actor."""
+    """Ray-friendly callable that initialises Nemotron Parse once per actor."""
 
     def __init__(
         self,
@@ -554,9 +554,12 @@ class NemotronParseGPUActor(AbstractOperator, GPUOperator):
     def _ensure_model(self) -> None:
         """Load the local vLLM model on first use (i.e. on the worker, not the driver)."""
         if self._model is None and not self._invoke_url:
-            from nemo_retriever.models.local import NemotronParseV12
+            from nemo_retriever.models.local import NemotronParse
 
-            self._model = NemotronParseV12(task_prompt=self._task_prompt)
+            self._model = NemotronParse(
+                model_path=self._nemotron_parse_model or NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL,
+                task_prompt=self._task_prompt,
+            )
 
     def process(self, data: Any, **kwargs: Any) -> Any:
         self._ensure_model()

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -165,7 +165,8 @@ class NimEndpointsConfig(RichModel):
         description=(
             "Model identifier passed to the remote Nemotron Parse endpoint. "
             "Use nvidia/nemotron-parse for NVIDIA-hosted inference and "
-            "nvidia/nemotron-parse-v1.2 for a self-hosted NIM. "
+            "the deployed versioned model ID, such as nvidia/nemotron-parse-v1.2 "
+            "or nvidia/nemotron-parse-v2.0, for a self-hosted NIM. "
             "Server-owned — clients cannot override the deployed Parse SKU."
         ),
     )

--- a/nemo_retriever/tests/test_actor_operators.py
+++ b/nemo_retriever/tests/test_actor_operators.py
@@ -414,6 +414,36 @@ class TestNemotronParseActor:
         mock_fn.assert_called_once()
         pd.testing.assert_frame_equal(result, expected)
 
+    def test_local_gpu_actor_defaults_to_parse_2(self, monkeypatch):
+        import nemo_retriever.models.local as local_models
+        from nemo_retriever.operators.extract.parse.nemotron_parse import NemotronParseGPUActor
+
+        mock_parse = MagicMock()
+        monkeypatch.setitem(local_models.__dict__, "NemotronParse", mock_parse)
+        actor = NemotronParseGPUActor(extract_text=True)
+
+        assert actor._model is None
+        actor._ensure_model()
+
+        mock_parse.assert_called_once_with(
+            model_path="nvidia/NVIDIA-Nemotron-Parse-2.0",
+            task_prompt="</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>",
+        )
+
+    def test_local_gpu_actor_honors_explicit_model(self, monkeypatch):
+        import nemo_retriever.models.local as local_models
+        from nemo_retriever.operators.extract.parse.nemotron_parse import NemotronParseGPUActor
+
+        mock_parse = MagicMock()
+        monkeypatch.setitem(local_models.__dict__, "NemotronParse", mock_parse)
+        actor = NemotronParseGPUActor(nemotron_parse_model="org/custom-parse")
+        actor._ensure_model()
+
+        mock_parse.assert_called_once_with(
+            model_path="org/custom-parse",
+            task_prompt="</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>",
+
+        )
     def test_remote_chat_completions_uses_v1_2_protocol(self):
         from nemo_retriever.operators.extract.parse.nemotron_parse import (
             NEMOTRON_PARSE_DEFAULT_TASK_PROMPT,
@@ -444,6 +474,32 @@ class TestNemotronParseActor:
         assert client.kwargs["task_prompt"] == NEMOTRON_PARSE_DEFAULT_TASK_PROMPT
         assert client.kwargs["extra_body"] == {"max_tokens": 8192}
         assert client.kwargs["repetition_penalty"] == 1.1
+
+    def test_remote_chat_completions_supports_v2_0_nim(self):
+        from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
+
+        class _FakeNIMClient:
+            def __init__(self):
+                self.kwargs = None
+
+            def invoke_chat_completions_images(self, **kwargs):
+                self.kwargs = kwargs
+                return ["<x_0><y_0>Parse 2 text<x_1><y_1><class_Text>"]
+
+        client = _FakeNIMClient()
+        result = nemotron_parse_pages(
+            pd.DataFrame({"page_image": [{"image_b64": "aW1hZ2U="}]}),
+            invoke_url="http://nemotron-parse:8000/v1/chat/completions",
+            nemotron_parse_model="nvidia/nemotron-parse-v2.0",
+            extract_text=True,
+            nim_client=client,
+        )
+
+        assert result["text"].tolist() == ["Parse 2 text"]
+        assert client.kwargs["model"] == "nvidia/nemotron-parse-v2.0"
+        # The 9,000-token NIM context includes the control prompt, so requesting
+        # all 9,000 tokens for output is rejected by the 2.0.8 container.
+        assert client.kwargs["extra_body"] == {"max_tokens": 8192}
 
     def test_remote_chat_completions_supports_legacy_tool_call_protocol(self):
         from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages

--- a/nemo_retriever/tests/test_nemotron_parse_v1_2.py
+++ b/nemo_retriever/tests/test_nemotron_parse_v1_2.py
@@ -19,9 +19,70 @@ def test_applies_vllm_startup_defaults_before_constructing_llm(monkeypatch):
 
     with (
         patch.object(mod, "_patch_vllm_nemotron_parse_processor"),
+        patch.object(mod, "_patch_vllm_nemotron_parse_tied_lm_head"),
         patch.object(mod, "configure_global_hf_cache_base"),
         patch.object(mod, "get_hf_revision", return_value="test-revision"),
-        patch("vllm.LLM", side_effect=assert_startup_defaults),
+        patch("vllm.LLM", side_effect=assert_startup_defaults) as llm,
         patch("vllm.SamplingParams"),
     ):
-        mod.NemotronParseV12()
+        model = mod.NemotronParse()
+
+    assert mod.NemotronParseV12 is mod.NemotronParse
+    assert model.model_name == "NVIDIA-Nemotron-Parse-2.0"
+    assert llm.call_args.kwargs["model"] == "nvidia/NVIDIA-Nemotron-Parse-2.0"
+    assert llm.call_args.kwargs["revision"] == "test-revision"
+
+
+def test_tied_lm_head_patch_restores_compact_checkpoint_weight(monkeypatch):
+    from types import SimpleNamespace
+
+    from nemo_retriever.models.local import nemotron_parse_v1_2 as mod
+    from vllm.model_executor.models.nemotron_parse import NemotronParseForConditionalGeneration
+
+    loaded = []
+
+    def fake_load_weights(_self, weights):
+        loaded.extend(weights)
+        return {"decoder.embed_tokens.weight"}
+
+    monkeypatch.setattr(NemotronParseForConditionalGeneration, "load_weights", fake_load_weights)
+    monkeypatch.setattr(mod, "_VLLM_TIED_LM_HEAD_PATCHED", False)
+    mod._patch_vllm_nemotron_parse_tied_lm_head()
+
+    instance = SimpleNamespace(
+        config=SimpleNamespace(decoder=SimpleNamespace(tie_word_embeddings=True)),
+        decoder=SimpleNamespace(embed_tokens=SimpleNamespace(weight=object())),
+        lm_head=SimpleNamespace(weight=object()),
+    )
+    result = NemotronParseForConditionalGeneration.load_weights(
+        instance,
+        iter([("decoder.embed_tokens.weight", "decoder-weight")]),
+    )
+
+    assert loaded == [("decoder.embed_tokens.weight", "decoder-weight")]
+    assert result == {"decoder.embed_tokens.weight"}
+    assert instance.lm_head.weight is instance.decoder.embed_tokens.weight
+
+
+def test_tied_lm_head_patch_preserves_materialized_weight(monkeypatch):
+    from types import SimpleNamespace
+
+    from nemo_retriever.models.local import nemotron_parse_v1_2 as mod
+    from vllm.model_executor.models.nemotron_parse import NemotronParseForConditionalGeneration
+
+    def fake_load_weights(_self, _weights):
+        return set()
+
+    monkeypatch.setattr(NemotronParseForConditionalGeneration, "load_weights", fake_load_weights)
+    monkeypatch.setattr(mod, "_VLLM_TIED_LM_HEAD_PATCHED", False)
+    mod._patch_vllm_nemotron_parse_tied_lm_head()
+
+    original_head = object()
+    instance = SimpleNamespace(
+        config=SimpleNamespace(decoder=SimpleNamespace(tie_word_embeddings=True)),
+        decoder=SimpleNamespace(embed_tokens=SimpleNamespace(weight=object())),
+        lm_head=SimpleNamespace(weight=original_head),
+    )
+    NemotronParseForConditionalGeneration.load_weights(instance, [("lm_head.weight", "head-weight")])
+
+    assert instance.lm_head.weight is original_head


### PR DESCRIPTION
## Summary

- make `nvidia/NVIDIA-Nemotron-Parse-2.0` the Retriever-managed local default while preserving the `NemotronParseV12` compatibility alias
- restore the tied decoder output weight required by the compact Parse 2.0 checkpoint before vLLM loads it, and pin the tested Hugging Face revision
- honor explicit local `nemotron_parse_model` selection and document managed local, hosted Build, self-hosted NIM, and self-hosted vLLM contracts
- add regression coverage for local model selection, compact-checkpoint weight tying, and the Parse 2.0 NIM request contract

## Root cause

Latest main always instantiated the v1.2 local wrapper and ignored `nemotron_parse_model`. Loading the compact Parse 2.0 Hugging Face checkpoint with stock vLLM also left `lm_head` independent from the tied decoder embeddings, producing empty generations. The official Parse 2.0 NIM uses the tagged chat contract and its 9,000-token context includes the control prompt, so Retriever must retain an 8,192 output-token request rather than requesting the entire context for output.

## Validation

- `3126 passed, 118 skipped, 12 deselected` across `nemo_retriever/tests`
- core Ruff checks (`E4,E7,E9,F`) pass on all changed Python files
- Retriever-managed local actor, no endpoint and no manual server: first page of all 20 jp20 PDFs, 0 errors; 14 text pages, 2 tables, 7 charts, 1 infographic
- `nvcr.io/nim/nvidia/nemotron-parse-v2.0:2.0.8-variant` through Retriever HTTP integration: same 20 jp20 pages and routed counts, 0 errors
- `git diff --check` passes

Strict MkDocs rendering was not run because MkDocs is not installed in the available environments.