### PR TITLE
fix(embedding): honor normalize=False for VL vLLM embeddings

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/models/__init__.py
@@ -129,6 +129,7 @@ def create_local_embedder(
             revision=spec.revision,
             gpu_memory_utilization=gpu_memory_utilization,
             enforce_eager=enforce_eager,
+            normalize=normalize,
             output_dimension=spec.output_dimension,
             query_prefix=spec.query_prefix,
             document_prefix=spec.document_prefix,

--- a/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
+++ b/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
@@ -99,6 +99,22 @@ def create_vllm_llm(
     return LLM(**kwargs)
 
 
+def _pooling_params_for_normalize(normalize: Optional[bool]) -> Any:
+    """Create per-request vLLM pooling parameters when normalization is disabled."""
+    if normalize is not False:
+        return None
+    try:
+        from vllm.pooling_params import PoolingParams
+
+        return PoolingParams(use_activation=False)
+    except (ImportError, TypeError) as e:
+        raise RuntimeError(
+            f"Failed to create PoolingParams for normalize=False: {e}. "
+            "Ensure your vLLM installation supports PoolingParams "
+            "(install with: uv pip install -e '.[local]')."
+        ) from e
+
+
 def embed_with_vllm_llm(
     prompts: List[str],
     llm: Any,
@@ -121,18 +137,7 @@ def embed_with_vllm_llm(
             pooler activation, such as L2 normalization. ``True`` and ``None``
             omit ``PoolingParams`` and preserve vLLM's compiled defaults.
     """
-    pooling_params = None
-    if normalize is False:
-        try:
-            from vllm.pooling_params import PoolingParams
-
-            pooling_params = PoolingParams(use_activation=False)
-        except (ImportError, TypeError) as e:
-            raise RuntimeError(
-                f"Failed to create PoolingParams for normalize=False: {e}. "
-                "Ensure your vLLM installation supports PoolingParams "
-                "(install with: uv pip install -e '.[local]')."
-            ) from e
+    pooling_params = _pooling_params_for_normalize(normalize)
 
     if prefix:
         prompts = [str(prefix) + p for p in prompts]
@@ -165,6 +170,7 @@ def embed_multimodal_with_vllm_llm(
     llm: Any,
     *,
     batch_size: int = 64,
+    normalize: Optional[bool] = None,
 ) -> List[List[float]]:
     """
     Compute embeddings for multimodal prompts using an existing vLLM LLM instance.
@@ -174,15 +180,20 @@ def embed_multimodal_with_vllm_llm(
       - ``"multi_modal_data"``: ``{"image": PIL.Image.Image}``
 
     The LLM must have been created with ``limit_mm_per_prompt={"image": 1}``.
+    ``normalize=False`` disables the model pooler's normalization activation.
     Returns one embedding vector (list of floats) per input; ``[]`` for failures.
     """
     if not prompt_dicts:
         return []
 
+    pooling_params = _pooling_params_for_normalize(normalize)
     all_embeddings: List[List[float]] = []
     for i in range(0, len(prompt_dicts), max(1, batch_size)):
         batch = prompt_dicts[i : i + max(1, batch_size)]
-        outputs = llm.embed(batch)
+        if pooling_params is None:
+            outputs = llm.embed(batch)
+        else:
+            outputs = llm.embed(batch, pooling_params=pooling_params)
         for out in outputs:
             emb = getattr(getattr(out, "outputs", None), "embedding", None)
             if emb is not None:

--- a/nemo_retriever/src/nemo_retriever/models/local/llama_nemotron_embed_vl_1b_v2_embedder.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/llama_nemotron_embed_vl_1b_v2_embedder.py
@@ -197,6 +197,7 @@ class LlamaNemotronEmbedVL1BV2VLLMEmbedder:
     output_dimension: int = 2048
     query_prefix: str = "query: "
     document_prefix: str = "passage: "
+    normalize: bool = True
 
     _llm: Any = field(default=None, init=False, repr=False)
 
@@ -248,13 +249,14 @@ class LlamaNemotronEmbedVL1BV2VLLMEmbedder:
         return False
 
     def _finalize_vectors(self, vectors: Sequence[Sequence[float]]) -> torch.Tensor:
-        """Zero-pad rows vLLM failed to embed to the returned width, then normalize."""
+        """Zero-pad rows vLLM failed to embed, then optionally normalize."""
         valid = [v for v in vectors if v]
         if not valid:
             return torch.empty((0, self.output_dimension), dtype=torch.float32)
         dim = len(valid[0])
         padded = [v if v else [0.0] * dim for v in vectors]
-        return _l2_normalize(torch.tensor(padded, dtype=torch.float32))
+        tensor = torch.tensor(padded, dtype=torch.float32)
+        return _l2_normalize(tensor) if self.normalize else tensor
 
     def embed(self, texts: Sequence[str], *, batch_size: int = 64) -> torch.Tensor:
         """Embed document texts. Returns CPU tensor ``[N, D]``."""
@@ -269,6 +271,7 @@ class LlamaNemotronEmbedVL1BV2VLLMEmbedder:
             self._llm,
             batch_size=max(1, int(batch_size)),
             prefix=self.document_prefix,
+            normalize=self.normalize,
         )
         return self._finalize_vectors(vectors)
 
@@ -285,6 +288,7 @@ class LlamaNemotronEmbedVL1BV2VLLMEmbedder:
             self._llm,
             batch_size=max(1, int(batch_size)),
             prefix=self.query_prefix,
+            normalize=self.normalize,
         )
         return self._finalize_vectors(vectors)
 
@@ -301,7 +305,12 @@ class LlamaNemotronEmbedVL1BV2VLLMEmbedder:
             {"prompt": f"{self.document_prefix}<image> ", "multi_modal_data": {"image": _b64_to_pil(b64)}}
             for b64 in valid_b64
         ]
-        vectors = embed_multimodal_with_vllm_llm(prompt_dicts, self._llm, batch_size=max(1, int(batch_size)))
+        vectors = embed_multimodal_with_vllm_llm(
+            prompt_dicts,
+            self._llm,
+            batch_size=max(1, int(batch_size)),
+            normalize=self.normalize,
+        )
         return self._finalize_vectors(vectors)
 
     def embed_text_image(
@@ -325,7 +334,12 @@ class LlamaNemotronEmbedVL1BV2VLLMEmbedder:
             {"prompt": f"{self.document_prefix}<image> {text}", "multi_modal_data": {"image": _b64_to_pil(b64)}}
             for text, b64 in zip(paired_texts, paired_b64)
         ]
-        vectors = embed_multimodal_with_vllm_llm(prompt_dicts, self._llm, batch_size=max(1, int(batch_size)))
+        vectors = embed_multimodal_with_vllm_llm(
+            prompt_dicts,
+            self._llm,
+            batch_size=max(1, int(batch_size)),
+            normalize=self.normalize,
+        )
         return self._finalize_vectors(vectors)
 
     def unload(self) -> None:

--- a/nemo_retriever/tests/test_create_local_embedder.py
+++ b/nemo_retriever/tests/test_create_local_embedder.py
@@ -161,11 +161,13 @@ def test_kwargs_forwarded_to_default_vllm_embedder(_patch_embedders):
         device="cuda:1",
         hf_cache_dir="/tmp/cache",
         gpu_memory_utilization=0.6,
+        normalize=False,
     )
     kw = fake_vl_vllm.call_args.kwargs
     assert kw["device"] == "cuda:1"
     assert kw["hf_cache_dir"] == "/tmp/cache"
     assert kw["gpu_memory_utilization"] == 0.6
+    assert kw["normalize"] is False
 
 
 def test_kwargs_forwarded_to_default_hf_embedder(_patch_embedders):

--- a/nemo_retriever/tests/test_vllm_embed.py
+++ b/nemo_retriever/tests/test_vllm_embed.py
@@ -173,6 +173,24 @@ class TestEmbedMultimodalWithVllmLlm:
         assert len(result) == 1
         assert len(result[0]) == 2
 
+    def test_normalize_false_translates_to_pooling_params(self, monkeypatch):
+        class FakePoolingParams:
+            def __init__(self, *, use_activation):
+                self.use_activation = use_activation
+
+        fake_vllm = ModuleType("vllm")
+        fake_vllm.__path__ = []
+        fake_pooling_params = ModuleType("vllm.pooling_params")
+        fake_pooling_params.PoolingParams = FakePoolingParams
+        monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+        monkeypatch.setitem(sys.modules, "vllm.pooling_params", fake_pooling_params)
+
+        llm = MagicMock()
+        llm.embed.return_value = [_make_output([0.0])]
+        embed_multimodal_with_vllm_llm([{"prompt": "<image>"}], llm, normalize=False)
+        pooling_params = llm.embed.call_args.kwargs["pooling_params"]
+        assert pooling_params.use_activation is False
+
 
 class TestCreateVllmLlm:
     def setup_method(self):
@@ -270,6 +288,17 @@ class TestVLLMEmbedderImages:
         assert result.shape == (1, 2)
         assert abs(float(torch.norm(result, dim=-1).item()) - 1.0) < 1e-5
 
+    def test_output_is_unnormalized_when_normalize_false(self):
+        self.embedder.normalize = False
+        b64 = _make_minimal_b64()
+        with patch(
+            "nemo_retriever.models.inference.vllm.embed_multimodal_with_vllm_llm",
+            return_value=[[3.0, 4.0]],
+        ) as mock_mm:
+            result = self.embedder.embed_images([b64])
+        assert mock_mm.call_args.kwargs["normalize"] is False
+        assert result.tolist() == [[3.0, 4.0]]
+
     def test_no_valid_embeddings_returns_empty_tensor(self):
         b64 = _make_minimal_b64()
         with patch(
@@ -349,6 +378,24 @@ class TestLlamaNemotronEmbed1BV2EmbedderNormalization:
         assert abs(float(result[0][0].item()) - 3.0) < 1e-5
 
 
+class TestLlamaNemotronEmbedVL1BV2VLLMEmbedderNormalization:
+    def test_text_output_unnormalized_when_normalize_false(self):
+        embedder = _make_vllm_vl_embedder()
+        embedder.normalize = False
+        with patch("nemo_retriever.models.inference.vllm.embed_with_vllm_llm", return_value=[[3.0, 4.0]]) as mock_fn:
+            result = embedder.embed(["text"])
+        assert mock_fn.call_args.kwargs["normalize"] is False
+        assert result.tolist() == [[3.0, 4.0]]
+
+    def test_query_output_unnormalized_when_normalize_false(self):
+        embedder = _make_vllm_vl_embedder()
+        embedder.normalize = False
+        with patch("nemo_retriever.models.inference.vllm.embed_with_vllm_llm", return_value=[[3.0, 4.0]]) as mock_fn:
+            result = embedder.embed_queries(["text"])
+        assert mock_fn.call_args.kwargs["normalize"] is False
+        assert result.tolist() == [[3.0, 4.0]]
+
+
 class TestVLLMEmbedderTextImage:
     def setup_method(self):
         self.embedder = _make_vllm_vl_embedder()
@@ -400,3 +447,14 @@ class TestVLLMEmbedderTextImage:
             result = self.embedder.embed_text_image(["text"], [b64])
         assert result.shape == (1, 2)
         assert abs(float(torch.norm(result, dim=-1).item()) - 1.0) < 1e-5
+
+    def test_output_is_unnormalized_when_normalize_false(self):
+        self.embedder.normalize = False
+        b64 = _make_minimal_b64()
+        with patch(
+            "nemo_retriever.models.inference.vllm.embed_multimodal_with_vllm_llm",
+            return_value=[[3.0, 4.0]],
+        ) as mock_mm:
+            result = self.embedder.embed_text_image(["text"], [b64])
+        assert mock_mm.call_args.kwargs["normalize"] is False
+        assert result.tolist() == [[3.0, 4.0]]


### PR DESCRIPTION
## Description

Propagate `ModelRuntimeParams.normalize` through the local VL vLLM embedding path. When `normalize=False`, text and multimodal embeddings now return raw vectors instead of unit-normalized vectors.

Adds regression coverage for text, query, image, and text-image embeddings.

## Checklist

- [x] I am familiar with the [[Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.