### PR TITLE
fix(store): stop StoreOperator crash on Arrow-backed page_image assets

### DIFF
--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
@@ -177,6 +177,21 @@ def _row_image_represents_page(row: pd.Series, *, image_source: str | None) -> b
     return content_type == "text"
 
 
+def _ensure_object_column(df: pd.DataFrame, column: str) -> None:
+    """Convert Arrow-backed columns so dict/list payloads can be assigned.
+
+    Pandas ArrowExtensionArray rejects ``DataFrame.at`` assignment of updated
+    Python dicts into struct/list columns (``cast_struct`` /
+    string-to-struct NotImplementedError). Object dtype preserves nested
+    payloads that add fields such as ``stored_image_uri``.
+    """
+    if column not in df.columns:
+        return
+    dtype = df[column].dtype
+    if isinstance(dtype, pd.ArrowDtype):
+        df[column] = df[column].astype(object)
+
+
 def _store_row_images(
     df: pd.DataFrame,
     *,
@@ -195,6 +210,8 @@ def _store_row_images(
         return df
 
     out = df.copy()
+    for column in (*image_columns, *row_image_columns):
+        _ensure_object_column(out, column)
     fallback_format = _normalize_image_format(image_format)
     fsspec_options = dict(storage_options or {})
 

--- a/nemo_retriever/tests/test_store_pipeline_stages.py
+++ b/nemo_retriever/tests/test_store_pipeline_stages.py
@@ -166,6 +166,37 @@ class TestStoreOperatorInGraph:
         assert result.iloc[0]["_stored_image_uri"].startswith("file://")
         assert result.iloc[0]["image_b64"] is None
 
+    def test_store_operator_updates_arrow_backed_page_image_struct(self, tmp_path: Path):
+        pa = pytest.importorskip("pyarrow")
+
+        b64 = _make_tiny_png_b64()
+        struct_type = pa.struct(
+            [
+                ("image_b64", pa.string()),
+                ("encoding", pa.string()),
+                ("orig_shape_hw", pa.list_(pa.int64())),
+            ]
+        )
+        page_image = {"image_b64": b64, "encoding": "png", "orig_shape_hw": [4, 4]}
+        arr = pa.array([page_image], type=struct_type)
+        df = pd.DataFrame(
+            {
+                "page_image": pd.arrays.ArrowExtensionArray(arr),
+                "_content_type": ["text"],
+            }
+        )
+
+        result = StoreOperator(
+            params=StoreParams(storage_uri=str(tmp_path), strip_base64=True, storage_options={"auto_mkdir": True})
+        ).process(df)
+
+        files = list(tmp_path.rglob("*.png"))
+        assert len(files) == 1
+        assert files[0].read_bytes() == base64.b64decode(b64)
+        assert result.iloc[0]["page_image"]["image_b64"] is None
+        assert result.iloc[0]["page_image"]["stored_image_uri"] == result.iloc[0]["_stored_image_uri"]
+        assert result.iloc[0]["page_image"]["encoding"] == "png"
+
     def test_store_operator_does_not_rewrite_page_image_when_strip_false(self, monkeypatch):
         b64 = _make_tiny_png_b64()
         df = _make_embedded_df(b64).drop(columns=["_image_b64"])


### PR DESCRIPTION
## Description
- Convert Arrow-backed image columns to object dtype before StoreOperator mutates nested payloads
- Fixes batch HF extract→store crashes when `page_image` is a PyArrow struct (`cast_struct` / string-to-struct)

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
