### PR TITLE
fix(resources): don't treat fractional/busy GPUs as no-GPU and remoting local HF

### DIFF
--- a/nemo_retriever/src/nemo_retriever/common/ray_resource_hueristics.py
+++ b/nemo_retriever/src/nemo_retriever/common/ray_resource_hueristics.py
@@ -216,7 +216,10 @@ def gather_cluster_resources(ray: object) -> ClusterResources:
             return 0
         if parsed <= 0:
             return 0
-        return int(parsed)
+        # Truncation alone turns e.g. 0.9 available GPUs into 0, which incorrectly
+        # signals "no GPU" and can flip local HF actors to remote/NVCF CPU variants.
+        floored = int(parsed)
+        return floored if floored > 0 else 1
 
     total_resources: dict[str, object] = ray.cluster_resources()
     available_resources: dict[str, object] = ray.available_resources()
@@ -521,9 +524,15 @@ def resolve_requested_plan(
     override_caption_gpus_per_actor: Optional[float] = None,
 ) -> RequestedPlan:
     available_gpu_count = max(0, int(cluster_resources.available_gpu_count()))
-
-    if available_gpu_count == 0 and not allow_no_gpu:
+    total_gpu_count = max(0, int(cluster_resources.total_gpu_count()))
+    # Capability comes from total cluster GPUs. Transient available==0 (or a
+    # fractional value previously truncated to 0) must not abort local HF plans.
+    if total_gpu_count == 0 and not allow_no_gpu:
         raise ValueError("No GPUs available")
+    # Scale actor pools from currently free GPUs when possible; fall back to
+    # total so a fully reserved cluster still requests GPU actors (Ray waits).
+    if available_gpu_count == 0 and total_gpu_count > 0:
+        available_gpu_count = total_gpu_count
 
     def _resolve_int_actors(override: Optional[int], default: int, multiply_by_available_num_gpu: bool) -> int:
         if override is not None and override > 0:

--- a/nemo_retriever/src/nemo_retriever/common/ray_resource_hueristics.py
+++ b/nemo_retriever/src/nemo_retriever/common/ray_resource_hueristics.py
@@ -216,8 +216,7 @@ def gather_cluster_resources(ray: object) -> ClusterResources:
             return 0
         if parsed <= 0:
             return 0
-        # Truncation alone turns e.g. 0.9 available GPUs into 0, which incorrectly
-        # signals "no GPU" and can flip local HF actors to remote/NVCF CPU variants.
+        # Keep a positive fractional Ray count (e.g. 0.9 GPU) as present (1).
         floored = int(parsed)
         return floored if floored > 0 else 1
 
@@ -525,12 +524,10 @@ def resolve_requested_plan(
 ) -> RequestedPlan:
     available_gpu_count = max(0, int(cluster_resources.available_gpu_count()))
     total_gpu_count = max(0, int(cluster_resources.total_gpu_count()))
-    # Capability comes from total cluster GPUs. Transient available==0 (or a
-    # fractional value previously truncated to 0) must not abort local HF plans.
+    # Plan against total cluster GPU capacity; Ray waits if GPUs are busy.
     if total_gpu_count == 0 and not allow_no_gpu:
         raise ValueError("No GPUs available")
-    # Scale actor pools from currently free GPUs when possible; fall back to
-    # total so a fully reserved cluster still requests GPU actors (Ray waits).
+    # Prefer free GPUs for sizing; if none are free, size from total capacity.
     if available_gpu_count == 0 and total_gpu_count > 0:
         available_gpu_count = total_gpu_count
 

--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -90,7 +90,7 @@ def batch_tuning_to_node_overrides(
     PDF extract concurrency is capped so that it cannot exhaust the cluster CPU
     budget when all other persistent actors are running simultaneously.
     """
-    auto_allow_no_gpu = bool(cluster_resources is not None and cluster_resources.available_gpu_count() == 0)
+    auto_allow_no_gpu = bool(cluster_resources is not None and cluster_resources.total_gpu_count() == 0)
     effective_allow_no_gpu = allow_no_gpu if allow_no_gpu is not None else auto_allow_no_gpu
     plan = (
         resolve_requested_plan(

--- a/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
@@ -79,7 +79,7 @@ class ExtractionBranchExecutor:
 
     def _execute_batch(self) -> Any:
         ray_module, cluster_resources = self.ensure_batch_runtime()
-        effective_allow_no_gpu = self.allow_no_gpu or cluster_resources.available_gpu_count() == 0
+        effective_allow_no_gpu = self.allow_no_gpu or cluster_resources.total_gpu_count() == 0
         branch_datasets: list[Any] = []
         for branch in self.branches:
             effective_extraction = self._resolve_branch(branch)

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -834,7 +834,7 @@ class GraphIngestor(ingestor):
             webhook_params=self._webhook_params,
             stage_order=post_extract_order,
         )
-        effective_allow_no_gpu = self._allow_no_gpu or cluster_resources.available_gpu_count() == 0
+        effective_allow_no_gpu = self._allow_no_gpu or cluster_resources.total_gpu_count() == 0
         derived_overrides = batch_tuning_to_node_overrides(
             effective_extraction.extract_params,
             self._embed_params,

--- a/nemo_retriever/src/nemo_retriever/operators/operator_archetype.py
+++ b/nemo_retriever/src/nemo_retriever/operators/operator_archetype.py
@@ -12,8 +12,14 @@ from nemo_retriever.common.ray_resource_hueristics import ClusterResources, Reso
 
 
 def _available_gpu_count(resources: ClusterResources | Resources) -> int:
+    """Return GPU *capability* used for local-vs-remote operator selection.
+
+    For cluster resources this is total GPU count, not transient available
+    GPUs. Fractional available values (e.g. 0.9) were previously truncated
+    to 0 and silently selected remote/NVCF CPU actors for local HF workflows.
+    """
     if isinstance(resources, ClusterResources):
-        return int(resources.available_gpu_count())
+        return int(resources.total_gpu_count())
     return int(resources.gpu_count)
 
 
@@ -108,7 +114,7 @@ class ArchetypeOperator(AbstractOperator):
 def _delegate_cache_key(resources: ClusterResources | Resources) -> tuple[int, int]:
     if isinstance(resources, ClusterResources):
         return (
-            int(resources.available_cpu_count()),
-            int(resources.available_gpu_count()),
+            int(resources.total_cpu_count()),
+            int(resources.total_gpu_count()),
         )
     return (int(resources.cpu_count), int(resources.gpu_count))

--- a/nemo_retriever/src/nemo_retriever/operators/operator_archetype.py
+++ b/nemo_retriever/src/nemo_retriever/operators/operator_archetype.py
@@ -12,11 +12,11 @@ from nemo_retriever.common.ray_resource_hueristics import ClusterResources, Reso
 
 
 def _available_gpu_count(resources: ClusterResources | Resources) -> int:
-    """Return GPU *capability* used for local-vs-remote operator selection.
+    """Return GPU capability used for local-vs-remote operator selection.
 
-    For cluster resources this is total GPU count, not transient available
-    GPUs. Fractional available values (e.g. 0.9) were previously truncated
-    to 0 and silently selected remote/NVCF CPU actors for local HF workflows.
+    For cluster resources this is total GPU count so selection does not
+    depend on transient free capacity; Ray schedules the actor when a
+    fractional share becomes free.
     """
     if isinstance(resources, ClusterResources):
         return int(resources.total_gpu_count())

--- a/nemo_retriever/tests/test_asr_actor.py
+++ b/nemo_retriever/tests/test_asr_actor.py
@@ -336,3 +336,42 @@ def test_local_asr_apply_asr_to_df():
             sys.modules.pop("nemo_retriever.models.local", None)
         else:
             sys.modules["nemo_retriever.models.local"] = prev_local
+
+
+def test_asr_actor_resolves_gpu_when_fractional_gpu_available():
+    """Local HF ASR must not flip to NVCF CPU when Ray reports 0.9 GPU free."""
+    from nemo_retriever.common.ray_resource_hueristics import ClusterResources, Resources, gather_cluster_resources
+    from nemo_retriever.operators.extract.audio.gpu_actor import ASRGPUActor
+
+    mock_ray = type(
+        "Ray",
+        (),
+        {
+            "is_initialized": staticmethod(lambda: True),
+            "cluster_resources": staticmethod(lambda: {"CPU": 4.0, "GPU": 1.0}),
+            "available_resources": staticmethod(lambda: {"CPU": 3.9, "GPU": 0.9}),
+        },
+    )()
+
+    resources = gather_cluster_resources(mock_ray)
+    assert resources.total_gpu_count() == 1
+    assert resources.available_gpu_count() == 1
+
+    resolved = ASRActor.resolve_operator_class(
+        resources,
+        operator_kwargs={"params": ASRParams(audio_endpoints=(None, None))},
+    )
+    assert resolved is ASRGPUActor
+
+    # Even if available GPUs are fully reserved, capability comes from total.
+    fully_reserved = ClusterResources(
+        total_resources=Resources(cpu_count=4, gpu_count=1),
+        available_resources=Resources(cpu_count=4, gpu_count=0),
+    )
+    assert (
+        ASRActor.resolve_operator_class(
+            fully_reserved,
+            operator_kwargs={"params": ASRParams(audio_endpoints=(None, None))},
+        )
+        is ASRGPUActor
+    )

--- a/nemo_retriever/tests/test_asr_actor.py
+++ b/nemo_retriever/tests/test_asr_actor.py
@@ -339,7 +339,7 @@ def test_local_asr_apply_asr_to_df():
 
 
 def test_asr_actor_resolves_gpu_when_fractional_gpu_available():
-    """Local HF ASR must not flip to NVCF CPU when Ray reports 0.9 GPU free."""
+    """Local HF ASR resolves to the GPU actor when fractional GPU is free."""
     from nemo_retriever.common.ray_resource_hueristics import ClusterResources, Resources, gather_cluster_resources
     from nemo_retriever.operators.extract.audio.gpu_actor import ASRGPUActor
 

--- a/nemo_retriever/tests/test_ingest_manifest.py
+++ b/nemo_retriever/tests/test_ingest_manifest.py
@@ -474,6 +474,9 @@ def test_batch_branch_execution_uses_dataset_union(monkeypatch, tmp_path) -> Non
         def available_gpu_count(self) -> int:
             return 0
 
+        def total_gpu_count(self) -> int:
+            return 0
+
         def total_cpu_count(self) -> int:
             return 64
 

--- a/nemo_retriever/tests/test_resource_heuristics.py
+++ b/nemo_retriever/tests/test_resource_heuristics.py
@@ -121,7 +121,7 @@ def test_gather_cluster_resources_coerces_fractional_values() -> None:
 
 
 def test_gather_cluster_resources_preserves_fractional_available_gpu() -> None:
-    """Ray can report e.g. 0.9 GPU free; truncating that to 0 is a silent GPU miss."""
+    """Positive fractional available GPUs remain a non-zero count."""
     mock_ray = types.SimpleNamespace(
         is_initialized=lambda: True,
         cluster_resources=lambda: {"CPU": 4.0, "GPU": 1.0},

--- a/nemo_retriever/tests/test_resource_heuristics.py
+++ b/nemo_retriever/tests/test_resource_heuristics.py
@@ -120,6 +120,32 @@ def test_gather_cluster_resources_coerces_fractional_values() -> None:
     assert cr.available_gpu_count() == 1
 
 
+def test_gather_cluster_resources_preserves_fractional_available_gpu() -> None:
+    """Ray can report e.g. 0.9 GPU free; truncating that to 0 is a silent GPU miss."""
+    mock_ray = types.SimpleNamespace(
+        is_initialized=lambda: True,
+        cluster_resources=lambda: {"CPU": 4.0, "GPU": 1.0},
+        available_resources=lambda: {"CPU": 3.9, "GPU": 0.9},
+    )
+
+    cr = rh.gather_cluster_resources(mock_ray)
+
+    assert cr.total_gpu_count() == 1
+    assert cr.available_gpu_count() == 1
+
+
+def test_resolve_requested_plan_uses_total_when_available_gpus_are_zero() -> None:
+    cr = rh.ClusterResources(
+        total_resources=rh.Resources(cpu_count=4, gpu_count=1),
+        available_resources=rh.Resources(cpu_count=4, gpu_count=0),
+    )
+
+    plan = rh.resolve_requested_plan(cluster_resources=cr)
+
+    assert plan.embed_gpus_per_actor == rh.EMBED_SINGLE_GPU_GPUS_PER_ACTOR
+    assert plan.ocr_gpus_per_actor == rh.OCR_GPUS_PER_ACTOR
+
+
 # ---------------------------------------------------------------------------
 # resolve_requested_plan — defaults
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


## Description
- Stop coercing fractional Ray available GPUs (e.g. `0.9`) to `0`
- Select local HF GPU actors from **total** cluster GPU capability, not transient availability
- When GPUs exist but are fully reserved (`available == 0`), keep the GPU actor and let Ray wait — do **not** fall back to CPU/remote/NVCF

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
