### PR TITLE
fix(models): bump VL embed checkpoint for Transformers 5

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
+++ b/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
@@ -28,7 +28,7 @@ HF_MODEL_REVISIONS: dict[str, str] = {
     "nvidia/llama-nemotron-embed-1b-v2": "b4caa8456edd360b3b4e938d94ed4398dd437fad",
     "nvidia/parakeet-ctc-1.1b": "a707e818195cb97c8f7da2fc36b221a29f69a5db",
     "nvidia/NVIDIA-Nemotron-Parse-v1.2": "f42c8040b12ee64370922d108778ab655b722c5d",
-    "nvidia/llama-nemotron-embed-vl-1b-v2": "4ef1bfa6da3a909de6bd00611950b7ed99203117",
+    "nvidia/llama-nemotron-embed-vl-1b-v2": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
     "meta-llama/Llama-3.2-1B": "4e20de362430cd3b72f300e6b0f18e50e7166e08",
     "intfloat/e5-large-unsupervised": "15af9288f69a6291f37bfb89b47e71abc747b206",
     "nvidia/llama-nemotron-rerank-1b-v2": "8fd3e5d962d44cfe65d4ba0784eebed44cf136b0",

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -162,7 +162,7 @@ def test_root_ingest_runs_default_execution_chain(monkeypatch, tmp_path) -> None
         "table_name": "nemo-retriever",
         "overwrite": True,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "4ef1bfa6da3a909de6bd00611950b7ed99203117",
+        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
     }
     assert "Ingested 1 file(s) → 7 row(s) in LanceDB lancedb/nemo-retriever." in result.output
 
@@ -204,7 +204,7 @@ def test_root_ingest_without_mode_accepts_local_options_before_documents(monkeyp
         "table_name": "nemo-retriever",
         "overwrite": False,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "4ef1bfa6da3a909de6bd00611950b7ed99203117",
+        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
     }
 
 
@@ -401,7 +401,7 @@ def test_root_ingest_passes_vdb_options_and_run_mode(monkeypatch, tmp_path) -> N
         "table_name": "docs",
         "overwrite": True,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "4ef1bfa6da3a909de6bd00611950b7ed99203117",
+        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
     }
     assert "Ingested 2 file(s) → 12 row(s) in LanceDB /tmp/lancedb/docs." in result.output
 
@@ -421,7 +421,7 @@ def test_root_ingest_append_forwards_overwrite_false(monkeypatch, tmp_path) -> N
         "table_name": "nemo-retriever",
         "overwrite": False,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "4ef1bfa6da3a909de6bd00611950b7ed99203117",
+        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
     }
 
 
@@ -1715,7 +1715,7 @@ def test_root_ingest_index_mode_hybrid_passes_hybrid_into_vdb_kwargs(monkeypatch
         "overwrite": True,
         "hybrid": True,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "4ef1bfa6da3a909de6bd00611950b7ed99203117",
+        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
     }
 
 


### PR DESCRIPTION
## Description

Updates the pinned `llama-nemotron-embed-vl-1b-v2` revision to a Transformers 5-compatible checkpoint. This fixes local HF embedding failing with a `create_bidirectional_mask` argument mismatch.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.