### PR TITLE
Enable performance mode for extraction NIMs

### DIFF
--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -1083,7 +1083,7 @@ nimOperator:
       - name: NIM_SERVER_BIND_ADDR
         value: "0.0.0.0:8000"
       - name: NIM_PERFORMANCE_MODE
-        value: "0"
+        value: "1"
       - name: NIM_SERVER_MODE
         value: latency
       - name: NIM_SERVER_MAX_WAIT_MS
@@ -1139,7 +1139,7 @@ nimOperator:
       - name: NIM_SERVER_BIND_ADDR
         value: "0.0.0.0:8000"
       - name: NIM_PERFORMANCE_MODE
-        value: "0"
+        value: "1"
       - name: NIM_SERVER_MODE
         value: latency
       - name: NIM_SERVER_MAX_WAIT_MS
@@ -1196,7 +1196,7 @@ nimOperator:
       - name: NIM_SERVER_BIND_ADDR
         value: "0.0.0.0:8000"
       - name: NIM_PERFORMANCE_MODE
-        value: "0"
+        value: "1"
       - name: NIM_SERVER_MODE
         value: latency
       - name: NIM_SERVER_MAX_WAIT_MS

--- a/nemo_retriever/tests/test_helm_nim_2_contracts.py
+++ b/nemo_retriever/tests/test_helm_nim_2_contracts.py
@@ -64,7 +64,8 @@ def test_extraction_nims_select_distinct_native_models() -> None:
         assert env["NIM_ENGINE_MODEL_DOWNLOAD_PROVIDER"] == "ngc"
         assert env["NIM_ENGINE_MODEL_NAME"] == model_name
         assert env["NIM_ENGINE_MODEL_PATH"] == model_path
-        assert env["NIM_PERFORMANCE_MODE"] == "0"
+        assert env["NIM_PERFORMANCE_MODE"] == "1"
+        assert env["NIM_ENGINE_COUNT"] == "1"
         assert env["NIM_PIPELINE_MAX_BATCH_SIZE"] == "1"
         assert "NIM_TRITON_MAX_BATCH_SIZE" not in env
 


### PR DESCRIPTION
## Summary

- enable `NIM_PERFORMANCE_MODE=1` for both object-detection services and OCR
- leave the VL embed NIM environment without this override

## Why

The extraction NIM 2.0 services should run with the requested performance-mode and single-engine Helm defaults while the VL embed service keeps its native environment configuration.

## Validation

- `8 passed, 13 skipped, 17 subtests passed` in the focused Helm tests
- `git diff --check`
- Helm-render tests were skipped because the `helm` binary is unavailable in this environment
