### PR TITLE
fix(ray): reserve CPU for file-backed source reads

### DIFF
--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -16,6 +16,8 @@ Use this guide to document practical recommendations for:
 
 In batch mode, NeMo Retriever Library sizes unspecified Ray actor pools from the CPU and GPU resources that Ray reports as available immediately before the pipeline is submitted. This prevents default extraction, OCR, and embedding pools from reserving more resources than the cluster can schedule.
 
-If you set `BatchTuningParams` worker counts or direct `node_overrides`, those requests must fit the available Ray CPU and GPU budget. The library validates the final plan before submitting work and raises an error when it is infeasible. Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity before retrying.
+For filesystem inputs, the library reserves CPU capacity for each Ray Data `ReadBinary` source task before it sizes actor pools. This reservation lets the input stage start instead of being blocked by persistent extraction actors. Inputs that are already Ray datasets, such as inline text rows, do not require this reservation.
+
+If you set `BatchTuningParams` worker counts or direct `node_overrides`, those requests and required source-task reservations must fit the available Ray CPU and GPU budget. The library validates the final plan before submitting work and raises an error when it is infeasible. Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity before retrying.
 
 Use the Ray dashboard to verify the available-resource snapshot and the planned worker allocation when you tune throughput.

--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -24,7 +24,7 @@ Use the Ray dashboard to verify the available-resource snapshot and the planned 
 
 ## Shared preflight for custom Ray Data graphs
 
-`GraphIngestor` reserves source capacity automatically. For custom graphs, declare source capacity before calling `preflight_executors(...)`. Set `source_cpu_reservation=1` on each `RayDataExecutor` that will receive a filesystem path or glob. An executor that only receives an existing Ray dataset can omit the reservation.
+`GraphIngestor` reserves source capacity automatically. For custom graphs, declare source capacity before calling `preflight_executors(...)`. Set `source_cpu_reservation=1` on each `RayDataExecutor` that will receive a filesystem path or glob. `source_cpu_reservation` must be a finite, non-negative CPU value. An executor that only receives an existing Ray dataset can omit the reservation.
 
 ```python
 file_executor = RayDataExecutor(graph, source_cpu_reservation=1)

--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -21,3 +21,15 @@ For filesystem inputs, the library reserves CPU capacity for each Ray Data `Read
 If you set `BatchTuningParams` worker counts or direct `node_overrides`, those requests and required source-task reservations must fit the available Ray CPU and GPU budget. The library validates the final plan before submitting work and raises an error when it is infeasible. Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity before retrying.
 
 Use the Ray dashboard to verify the available-resource snapshot and the planned worker allocation when you tune throughput.
+
+## Shared preflight for custom Ray Data graphs
+
+`GraphIngestor` reserves source capacity automatically. For custom graphs, declare source capacity before calling `preflight_executors(...)`. Set `source_cpu_reservation=1` on each `RayDataExecutor` that will receive a filesystem path or glob. An executor that only receives an existing Ray dataset can omit the reservation.
+
+```python
+file_executor = RayDataExecutor(graph, source_cpu_reservation=1)
+inline_executor = RayDataExecutor(graph)
+preflight_executors([file_executor, inline_executor], cluster_resources)
+```
+
+The shared preflight records these reservations. NeMo Retriever Library rejects a later filesystem input when its executor lacks the required reservation. It rejects the input before it starts Ray work. Construct a new executor with `source_cpu_reservation=1`, and include it in a new shared preflight instead.

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -64,7 +64,7 @@ inspect row columns and service logs directly.
 | A per-document entry in `ServiceIngestResult.failures` | Upload or pipeline processing failed after a service job was created | Correlate the document ID with the job ID and service logs. Other documents in the same result can still have succeeded. |
 | Successful ingest with fewer rows than inputs (caption or ASR enabled) | Caption inference failed before row collection, or ASR dropped failed rows and logged warnings | Re-run with logging enabled. For caption, verify endpoint credentials and payload limits. For ASR, verify gRPC endpoint, `function_id`, and `NVIDIA_API_KEY`. |
 | OOM, worker exit, or pod restart | Host or GPU resources were exhausted, or an orchestrator terminated the worker | Reduce batch size or concurrency, use smaller document groups, and inspect host, Ray, Kubernetes, and NIM resource telemetry. |
-| `Infeasible Ray CPU/GPU plan` | Explicit worker counts or node overrides exceed resources currently available to Ray. | Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity. Refer to the [performance guide](performance_guide.md). |
+| `Infeasible Ray CPU/GPU plan` | Explicit worker counts or node overrides, including required Ray Data source capacity for filesystem inputs, exceed resources currently available to Ray. | Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity. Refer to the [performance guide](performance_guide.md). |
 
 The service can retry some transient transport, `429`, and `5xx` failures.
 Report the final status returned after retries, not an intermediate warning.

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import math
 from typing import Any, Dict, List, Optional, Set
 import pandas as pd
 
@@ -367,6 +368,9 @@ class RayDataExecutor(AbstractExecutor):
         source_cpu_reservation: float = 0,
     ) -> None:
         super().__init__(graph)
+        source_cpu_reservation = float(source_cpu_reservation)
+        if not math.isfinite(source_cpu_reservation) or source_cpu_reservation < 0:
+            raise ValueError("source_cpu_reservation must be a finite, non-negative CPU value.")
         self._preflight_cluster_resources: ClusterResources | None = None
         self._ray_address = ray_address
         self._source_cpu_reservation = source_cpu_reservation

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -214,6 +214,7 @@ def preflight_executors(executors: list[Any], cluster_resources: ClusterResource
         executor._node_overrides[name]["concurrency"] = _planned_concurrency(concurrency, planned[(id(executor), name)])
     for executor in executors:
         executor._resources_preflight_complete = True
+        executor._preflight_source_cpu_reservation = executor._source_cpu_reservation
         executor._preflight_cluster_resources = cluster_resources
 
 
@@ -369,6 +370,10 @@ class RayDataExecutor(AbstractExecutor):
         self._preflight_cluster_resources: ClusterResources | None = None
         self._ray_address = ray_address
         self._source_cpu_reservation = source_cpu_reservation
+        # ``preflight_executors`` records the source reservation it budgeted.
+        # A filesystem input supplied later must not silently increase that
+        # shared plan: re-planning this executor alone would ignore its peers.
+        self._preflight_source_cpu_reservation: float | None = None
         self._default_batch_size = batch_size
         self._default_batch_format = batch_format
         self._default_num_cpus = num_cpus
@@ -517,8 +522,22 @@ class RayDataExecutor(AbstractExecutor):
         ctx = rd.DataContext.get_current()
         ctx.enable_rich_progress_bars = True
         ctx.use_ray_tqdm = False
-        if not isinstance(data, rd.Dataset):
-            self._source_cpu_reservation = 1
+        is_filesystem_source = not isinstance(data, rd.Dataset)
+        if is_filesystem_source:
+            required_source_cpu_reservation = 1
+            if self._resources_preflight_complete:
+                planned_source_cpu_reservation = self._preflight_source_cpu_reservation
+                if (
+                    planned_source_cpu_reservation is None
+                    or planned_source_cpu_reservation < required_source_cpu_reservation
+                ):
+                    raise ValueError(
+                        "Filesystem inputs require 1 CPU for Ray Data source reads, but shared Ray resource "
+                        "preflight completed without that reservation. Construct RayDataExecutor with "
+                        "source_cpu_reservation=1 before calling preflight_executors."
+                    )
+            else:
+                self._source_cpu_reservation = required_source_cpu_reservation
 
         cluster = self._preflight_cluster_resources or gather_cluster_resources(ray)
         available_gpus = cluster.available_gpu_count()

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -177,17 +177,20 @@ def preflight_executors(executors: list[Any], cluster_resources: ClusterResource
     fixed = [item for item in entries if not item[7]]
     auto = [item for item in entries if item[7]]
     fixed_cpu = sum(item[3] * item[5] for item in fixed)
+    source_cpu_reservation = sum(executor._source_cpu_reservation for executor in executors)
     fixed_gpu = sum(item[3] * item[6] for item in fixed)
     min_cpu = sum(item[4] * item[5] for item in auto)
     min_gpu = sum(item[4] * item[6] for item in auto)
-    if fixed_cpu + min_cpu > available_cpus or fixed_gpu + min_gpu > available_gpus:
+    requested_cpu = source_cpu_reservation + fixed_cpu + min_cpu
+    if requested_cpu > available_cpus or fixed_gpu + min_gpu > available_gpus:
         raise ValueError(
             "Infeasible Ray CPU/GPU plan: requested at least "
-            f"{fixed_cpu + min_cpu:g} CPUs and {fixed_gpu + min_gpu:g} GPUs, but Ray reports "
+            f"{requested_cpu:g} CPUs (including {source_cpu_reservation:g} for source reads) "
+            f"and {fixed_gpu + min_gpu:g} GPUs, but Ray reports "
             f"{available_cpus} CPUs and {available_gpus} GPUs available. "
             "Reduce explicit *_workers or node_overrides concurrency, or wait for cluster capacity."
         )
-    used_cpu, used_gpu = fixed_cpu + min_cpu, fixed_gpu + min_gpu
+    used_cpu, used_gpu = source_cpu_reservation + fixed_cpu + min_cpu, fixed_gpu + min_gpu
     planned = {(id(item[0]), item[1]): item[4] for item in auto}
     while True:
         candidates = sorted(
@@ -360,10 +363,12 @@ class RayDataExecutor(AbstractExecutor):
         num_gpus: float = 0,
         node_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         auto_concurrency_nodes: Optional[Set[str]] = None,
+        source_cpu_reservation: float = 0,
     ) -> None:
         super().__init__(graph)
         self._preflight_cluster_resources: ClusterResources | None = None
         self._ray_address = ray_address
+        self._source_cpu_reservation = source_cpu_reservation
         self._default_batch_size = batch_size
         self._default_batch_format = batch_format
         self._default_num_cpus = num_cpus
@@ -425,15 +430,17 @@ class RayDataExecutor(AbstractExecutor):
         fixed_cpu = sum(count * cpu for _name, _concurrency, count, _initial, cpu, _gpu in fixed)
         fixed_gpu = sum(count * gpu for _name, _concurrency, count, _initial, _cpu, gpu in fixed)
         minimum_cpu = sum(initial * cpu for _name, _concurrency, _count, initial, cpu, _gpu in auto)
+        requested_cpu = self._source_cpu_reservation + fixed_cpu + minimum_cpu
         minimum_gpu = sum(initial * gpu for _name, _concurrency, _count, initial, _cpu, gpu in auto)
-        if fixed_cpu + minimum_cpu > available_cpus or fixed_gpu + minimum_gpu > available_gpus:
+        if requested_cpu > available_cpus or fixed_gpu + minimum_gpu > available_gpus:
             raise ValueError(
                 "Infeasible Ray CPU/GPU plan: requested at least "
-                f"{fixed_cpu + minimum_cpu:g} CPUs and {fixed_gpu + minimum_gpu:g} GPUs, but Ray reports "
+                f"{requested_cpu:g} CPUs (including {self._source_cpu_reservation:g} for source reads) "
+                f"and {fixed_gpu + minimum_gpu:g} GPUs, but Ray reports "
                 f"{available_cpus} CPUs and {available_gpus} GPUs available. "
                 "Reduce explicit *_workers or node_overrides concurrency, or wait for cluster capacity."
             )
-        used_cpu, used_gpu = fixed_cpu + minimum_cpu, fixed_gpu + minimum_gpu
+        used_cpu, used_gpu = self._source_cpu_reservation + fixed_cpu + minimum_cpu, fixed_gpu + minimum_gpu
         planned = {name: initial for name, _concurrency, _count, initial, _cpu, _gpu in auto}
         while True:
             candidates = sorted(
@@ -510,6 +517,8 @@ class RayDataExecutor(AbstractExecutor):
         ctx = rd.DataContext.get_current()
         ctx.enable_rich_progress_bars = True
         ctx.use_ray_tqdm = False
+        if not isinstance(data, rd.Dataset):
+            self._source_cpu_reservation = 1
 
         cluster = self._preflight_cluster_resources or gather_cluster_resources(ray)
         available_gpus = cluster.available_gpu_count()

--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -363,28 +363,6 @@ def batch_tuning_to_node_overrides(
             plan.pdf_extract_tasks if plan else None,
         )
 
-        # Cap PDF extract concurrency so persistent actors for page-elements,
-        # table structure, OCR, embed, and caption plus fixed pipeline tasks (DocToPdf,
-        # PDFSplit, UDFOperator(s), ReadBinary) cannot exhaust the cluster
-        # CPU budget.
-        if pdf_extract_tasks is not None and cluster_resources is not None:
-            # Conservative fixed overhead for the documented PDF flow:
-            # ReadBinary + DocToPdf + PDFSplit + TextChunk + DedupImages +
-            # the content-reshape UDF before embedding. Caption adds its actor
-            # and one additional UDF.
-            fixed_cpu_overhead = 6 + (2 if caption_params is not None else 0)
-            non_pdf_cpu_overhead = (
-                fixed_cpu_overhead
-                + page_elements_concurrency * page_elements_cpus
-                + ocr_concurrency * ocr_cpus
-                + embed_concurrency * embed_cpus
-                + ts_concurrency * ts_cpus
-            )
-            pdf_extract_tasks = min(
-                pdf_extract_tasks,
-                max(1, int((cluster_resources.total_cpu_count() - non_pdf_cpu_overhead) // pdf_extract_cpus)),
-            )
-
         _set(PDFExtractionActor.__name__, "batch_size", pdf_bs)
         _set(PDFExtractionActor.__name__, "concurrency", pdf_extract_tasks)
         _set(PDFExtractionActor.__name__, "num_cpus", pdf_extract_cpus if pdf_extract_cpus != 1.0 else None)

--- a/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py
@@ -118,6 +118,7 @@ class ExtractionBranchExecutor:
                     graph,
                     derived_overrides,
                     default_concurrency_node_names(effective_extraction.extract_params, None, None, None),
+                    source_cpu_reservation=1 if isinstance(input_data, list) else 0,
                 )
                 branch_executors.append(executor)
                 branch_inputs.append((executor, input_data))
@@ -146,6 +147,7 @@ class ExtractionBranchExecutor:
             post_graph,
             post_overrides,
             default_concurrency_node_names(None, self.embed_params, self.store_params, self.caption_params),
+            source_cpu_reservation=0,
         )
         if hasattr(cluster_resources, "available_cpu_count"):
             preflight_executors([*branch_executors, post_executor], cluster_resources)
@@ -222,6 +224,7 @@ class ExtractionBranchExecutor:
         graph: Any,
         derived_overrides: dict[str, dict[str, Any]],
         auto_concurrency_nodes: set[str],
+        source_cpu_reservation: float,
     ) -> RayDataExecutor:
         return RayDataExecutor(
             graph,
@@ -231,6 +234,7 @@ class ExtractionBranchExecutor:
             num_gpus=self.num_gpus,
             node_overrides=merge_node_overrides(derived_overrides, self.node_overrides),
             auto_concurrency_nodes=auto_concurrency_nodes - set(self.node_overrides),
+            source_cpu_reservation=source_cpu_reservation,
         )
 
     def _inprocess_branch_input(self, branch: ExtractionBranchPlan) -> Any:

--- a/nemo_retriever/tests/test_ingest_manifest.py
+++ b/nemo_retriever/tests/test_ingest_manifest.py
@@ -569,7 +569,8 @@ def test_batch_branch_preflight_precedes_dataset_construction(monkeypatch, tmp_p
 
     class FakeExecutor:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
-            calls.append("construct")
+            calls.append(f"construct:{kwargs['source_cpu_reservation']}")
+            self._source_cpu_reservation = kwargs["source_cpu_reservation"]
 
         def build_dataset(self, data: Any, **kwargs: Any) -> Any:
             calls.append("build")
@@ -580,7 +581,7 @@ def test_batch_branch_preflight_precedes_dataset_construction(monkeypatch, tmp_p
             return pd.DataFrame({"done": [True]})
 
     def fake_preflight(executors: list[Any], resources: Any) -> None:
-        assert len(executors) == 3
+        assert [executor._source_cpu_reservation for executor in executors] == [1, 1, 0]
         assert resources.available_cpu_count() == 16
         calls.append("preflight")
 
@@ -592,7 +593,7 @@ def test_batch_branch_preflight_precedes_dataset_construction(monkeypatch, tmp_p
 
     GraphIngestor(run_mode="batch").files([str(pdf), str(image)]).extract().ingest()
 
-    assert calls == ["construct", "construct", "construct", "preflight", "build", "build", "ingest"]
+    assert calls == ["construct:1", "construct:1", "construct:0", "preflight", "build", "build", "ingest"]
 
 
 def test_batch_branch_preflight_counts_file_and_inline_datasets(monkeypatch, tmp_path) -> None:
@@ -616,7 +617,8 @@ def test_batch_branch_preflight_counts_file_and_inline_datasets(monkeypatch, tmp
 
     class FakeExecutor:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
-            calls.append("construct")
+            self._source_cpu_reservation = kwargs["source_cpu_reservation"]
+            calls.append(f"construct:{kwargs['source_cpu_reservation']}")
 
         def build_dataset(self, data: Any, **kwargs: Any) -> Any:
             calls.append("build")
@@ -627,7 +629,7 @@ def test_batch_branch_preflight_counts_file_and_inline_datasets(monkeypatch, tmp
             return pd.DataFrame({"done": [True]})
 
     def fake_preflight(executors: list[Any], resources: Any) -> None:
-        assert len(executors) == 3
+        assert [executor._source_cpu_reservation for executor in executors] == [1, 0, 0]
         calls.append("preflight")
 
     monkeypatch.setattr(
@@ -642,4 +644,4 @@ def test_batch_branch_preflight_counts_file_and_inline_datasets(monkeypatch, tmp
 
     GraphIngestor(run_mode="batch").files([str(document)]).texts(["from inline"]).extract().ingest()
 
-    assert calls == ["construct", "construct", "construct", "preflight", "build", "build", "ingest"]
+    assert calls == ["construct:1", "construct:0", "construct:0", "preflight", "build", "build", "ingest"]

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -463,6 +463,7 @@ def test_batch_preflight_remote_caption_materializes_missing_override(extraction
 
     assert overrides["CaptionActor"]["concurrency"] == 1
 
+
 def test_batch_preflight_rejects_infeasible_direct_override() -> None:
     from nemo_retriever.graph.executor import RayDataExecutor
 

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -333,34 +333,6 @@ def test_batch_tuning_to_node_overrides_scales_local_caption_on_multi_gpu() -> N
     assert overrides["_BatchEmbedActor"]["num_gpus"] == 0.5
 
 
-def test_batch_tuning_to_node_overrides_keeps_default_pdf_pipeline_within_cpu_budget() -> None:
-    cluster = ClusterResources(
-        total_resources=Resources(cpu_count=224, gpu_count=8),
-        available_resources=Resources(cpu_count=224, gpu_count=8),
-    )
-
-    overrides = batch_tuning_to_node_overrides(
-        extract_params=ExtractParams(extract_tables=True, use_table_structure=True),
-        embed_params=EmbedParams(model_name="nvidia/llama-nemotron-embed-1b-v2"),
-        cluster_resources=cluster,
-    )
-
-    # The documented extract -> chunk -> dedup -> reshape -> embed pipeline
-    # has six additional one-CPU tasks alongside these persistent actor pools.
-    requested_cpu = 6 + sum(
-        overrides[actor]["concurrency"] * overrides[actor].get("num_cpus", 1)
-        for actor in (
-            "PDFExtractionActor",
-            "PageElementDetectionActor",
-            "TableStructureActor",
-            "OCRActor",
-            "_BatchEmbedActor",
-        )
-    )
-
-    assert requested_cpu <= cluster.total_cpu_count()
-
-
 def test_batch_preflight_reduces_default_pools_on_constrained_cluster() -> None:
     from nemo_retriever.graph.executor import RayDataExecutor
 
@@ -383,6 +355,7 @@ def test_batch_preflight_reduces_default_pools_on_constrained_cluster() -> None:
         build_graph(extract_params=params, stage_order=()),
         node_overrides=derived,
         auto_concurrency_nodes={name for name, values in derived.items() if "concurrency" in values},
+        source_cpu_reservation=1,
     )
     executor._preflight_resources(executor._linearize(executor.graph), 16, 8)
 
@@ -397,6 +370,12 @@ def test_batch_preflight_reduces_default_pools_on_constrained_cluster() -> None:
             "OCRActor",
         )
     )
+    actor_cpu = sum(
+        derived[name]["concurrency"] * derived[name].get("num_cpus", 1)
+        for name in ("PDFExtractionActor", "PageElementDetectionActor", "TableStructureActor", "OCRActor")
+    )
+    # DocToPdf and PDFSplit use one CPU each; ReadBinary needs the reserved CPU.
+    assert actor_cpu + 2 + executor._source_cpu_reservation <= 16
 
 
 def test_batch_preflight_rejects_infeasible_explicit_tuning() -> None:
@@ -420,6 +399,27 @@ def test_batch_preflight_rejects_infeasible_explicit_tuning() -> None:
     )
     with pytest.raises(ValueError, match="Infeasible Ray CPU/GPU plan"):
         executor._preflight_resources(executor._linearize(graph), 16, 8)
+
+
+def test_batch_preflight_reserves_cpu_for_file_sources() -> None:
+    from nemo_retriever.graph.executor import RayDataExecutor
+    from nemo_retriever.graph import UDFOperator
+
+    graph = Graph()
+    graph.add_root(UDFOperator(lambda data: data))
+    file_executor = RayDataExecutor(
+        graph,
+        node_overrides={"UDFOperator": {"concurrency": 16, "num_cpus": 1}},
+        source_cpu_reservation=1,
+    )
+    inline_executor = RayDataExecutor(
+        graph,
+        node_overrides={"UDFOperator": {"concurrency": 16, "num_cpus": 1}},
+    )
+
+    with pytest.raises(ValueError, match="including 1 for source reads"):
+        file_executor._preflight_resources(file_executor._linearize(graph), 16, 0)
+    inline_executor._preflight_resources(inline_executor._linearize(graph), 16, 0)
 
 
 def test_batch_preflight_rejects_infeasible_direct_override() -> None:

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1289,6 +1289,11 @@ class TestRayDataExecutor:
 
         assert executor.build_dataset(fake_dataset) is fake_dataset
 
+    @pytest.mark.parametrize("source_cpu_reservation", [-1, float("nan"), float("inf")])
+    def test_rejects_invalid_source_cpu_reservation(self, source_cpu_reservation):
+        with pytest.raises(ValueError, match="finite, non-negative"):
+            RayDataExecutor(Graph(), source_cpu_reservation=source_cpu_reservation)
+
     def test_node_overrides_stored(self):
 
         g = Graph()

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1177,7 +1177,120 @@ class TestRayDataExecutor:
 
         assert captured["num_gpus"] == 0.1
 
+    def test_shared_preflight_rejects_late_filesystem_source_without_reservation(self, tmp_path, monkeypatch):
+        import sys
+        from types import SimpleNamespace
+
+        source = tmp_path / "sample.pdf"
+        source.write_bytes(b"pdf")
+
+        class _FakeDataset:
+            pass
+
+        class _FakeDataContext:
+            enable_rich_progress_bars = False
+            use_ray_tqdm = True
+
+            @classmethod
+            def get_current(cls):
+                return cls()
+
+        def _unexpected_read_binary_files(*_args, **_kwargs):
+            raise AssertionError("late filesystem source must fail before read_binary_files")
+
+        fake_ray_data = SimpleNamespace(
+            Dataset=_FakeDataset,
+            DataContext=_FakeDataContext,
+            read_binary_files=_unexpected_read_binary_files,
+        )
+        fake_ray = SimpleNamespace(is_initialized=lambda: True, init=lambda **kwargs: None, data=fake_ray_data)
+        monkeypatch.setitem(sys.modules, "ray", fake_ray)
+        monkeypatch.setitem(sys.modules, "ray.data", fake_ray_data)
+
+        executor = RayDataExecutor(Graph())
+        from nemo_retriever.common.ray_resource_hueristics import ClusterResources
+
+        resources = Resources(cpu_count=1, gpu_count=0)
+        preflight_executors([executor], ClusterResources(total_resources=resources, available_resources=resources))
+
+        with pytest.raises(ValueError, match="source_cpu_reservation=1"):
+            executor.build_dataset(str(source))
+
+    def test_shared_preflight_allows_filesystem_source_with_reservation(self, tmp_path, monkeypatch):
+        import sys
+        from types import SimpleNamespace
+
+        source = tmp_path / "sample.pdf"
+        source.write_bytes(b"pdf")
+
+        class _FakeDataset:
+            pass
+
+        class _FakeDataContext:
+            enable_rich_progress_bars = False
+            use_ray_tqdm = True
+
+            @classmethod
+            def get_current(cls):
+                return cls()
+
+        fake_dataset = _FakeDataset()
+        captured: dict[str, object] = {}
+
+        def _read_binary_files(paths, include_paths=True):
+            captured["paths"] = list(paths)
+            captured["include_paths"] = include_paths
+            return fake_dataset
+
+        fake_ray_data = SimpleNamespace(
+            Dataset=_FakeDataset,
+            DataContext=_FakeDataContext,
+            read_binary_files=_read_binary_files,
+        )
+        fake_ray = SimpleNamespace(is_initialized=lambda: True, init=lambda **kwargs: None, data=fake_ray_data)
+        monkeypatch.setitem(sys.modules, "ray", fake_ray)
+        monkeypatch.setitem(sys.modules, "ray.data", fake_ray_data)
+
+        executor = RayDataExecutor(Graph(), source_cpu_reservation=1)
+        from nemo_retriever.common.ray_resource_hueristics import ClusterResources
+
+        resources = Resources(cpu_count=1, gpu_count=0)
+        preflight_executors([executor], ClusterResources(total_resources=resources, available_resources=resources))
+
+        assert executor.build_dataset(str(source)) is fake_dataset
+        assert captured == {"paths": [str(source)], "include_paths": True}
+
+    def test_shared_preflight_allows_dataset_after_conservative_source_reservation(self, monkeypatch):
+        import sys
+        from types import SimpleNamespace
+
+        class _FakeDataset:
+            pass
+
+        class _FakeDataContext:
+            enable_rich_progress_bars = False
+            use_ray_tqdm = True
+
+            @classmethod
+            def get_current(cls):
+                return cls()
+
+        fake_dataset = _FakeDataset()
+        fake_ray_data = SimpleNamespace(Dataset=_FakeDataset, DataContext=_FakeDataContext)
+        fake_ray = SimpleNamespace(is_initialized=lambda: True, init=lambda **kwargs: None, data=fake_ray_data)
+        monkeypatch.setitem(sys.modules, "ray", fake_ray)
+        monkeypatch.setitem(sys.modules, "ray.data", fake_ray_data)
+
+        executor = RayDataExecutor(Graph(), source_cpu_reservation=1)
+        from nemo_retriever.common.ray_resource_hueristics import ClusterResources
+
+        resources = Resources(cpu_count=1, gpu_count=0)
+        preflight_executors([executor], ClusterResources(total_resources=resources, available_resources=resources))
+
+        assert executor.build_dataset(fake_dataset) is fake_dataset
+
     def test_node_overrides_stored(self):
+
         g = Graph()
         g.add_chain(AddOperator(1))
         overrides = {"AddOperator": {"batch_size": 16, "num_gpus": 0.5}}


### PR DESCRIPTION
## Description

Reserve 1 CPU for each file-backed Ray Data `read_binary_files` source before shared resource preflight sizes extraction actors. This applies to direct executors and manifest-based ingestion, so extraction pools use only the remaining CPU capacity. A filesystem input introduced after shared preflight now fails when no source CPU was reserved.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

- `uv run --directory nemo_retriever pytest -q tests/test_ingest_plans.py tests/test_ingest_manifest.py tests/test_pipeline_graph.py`
- `uvx pre-commit run --files nemo_retriever/src/nemo_retriever/graph/executor.py nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py nemo_retriever/src/nemo_retriever/ingestor/branch_extraction.py nemo_retriever/tests/test_ingest_plans.py nemo_retriever/tests/test_ingest_manifest.py docs/docs/extraction/performance_guide.md docs/docs/extraction/troubleshoot.md`
- `cd docs && uv run --with-requirements requirements.txt --with-editable ../nemo_retriever mkdocs build --strict --config-file mkdocs.yml`