### PR TITLE
fix(helm): expose otel metrics through prometheus

### DIFF
--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -1165,6 +1165,24 @@ kubectl port-forward svc/tracing-smoke-nemo-retriever-zipkin 9411:9411
 curl "http://localhost:9411/api/v2/trace/${TRACE_ID}"
 ```
 
+### Prometheus metrics from the OpenTelemetry Collector
+
+When `topology.otel.enabled=true`, the chart-owned OpenTelemetry Collector
+exposes metrics received through OTLP in Prometheus format. The endpoint uses
+`topology.otel.ports.prometheus`, which defaults to port `8889`. The
+chart-owned OpenTelemetry Collector Service exposes the same port.
+
+After your workload sends telemetry, verify the endpoint by port-forwarding the
+Collector Service:
+
+```bash
+kubectl port-forward svc/<release>-nemo-retriever-otel 8889:8889
+curl -fsS http://127.0.0.1:8889/metrics
+```
+
+Set `topology.otel.ports.prometheus` to use a different port. The chart updates
+the Collector listener and Service port together.
+
 Common opt-out and override knobs:
 
 ```yaml

--- a/nemo_retriever/helm/templates/_helpers.tpl
+++ b/nemo_retriever/helm/templates/_helpers.tpl
@@ -329,6 +329,9 @@ Tracing helpers
 {{- $_ := set $exporters "prometheus" $prometheusExporter -}}
 {{- $_ := set $config "exporters" $exporters -}}
 {{- $metricExporters := get $metrics "exporters" | default list -}}
+{{- if not (kindIs "slice" $metricExporters) -}}
+{{- fail "topology.otel.config.service.pipelines.metrics.exporters must be a list when topology.otel.enabled=true" -}}
+{{- end -}}
 {{- if not (has "prometheus" $metricExporters) -}}
 {{- $metricExporters = append $metricExporters "prometheus" -}}
 {{- end -}}

--- a/nemo_retriever/helm/templates/_helpers.tpl
+++ b/nemo_retriever/helm/templates/_helpers.tpl
@@ -300,6 +300,42 @@ Tracing helpers
 {{- fail "topology.otel.config must be a map when topology.otel.enabled=true" -}}
 {{- end -}}
 {{- $config := deepCopy $configValue -}}
+{{- $otelPorts := include "nemo-retriever.otel.ports" . | fromYaml -}}
+{{- $service := get $config "service" | default dict -}}
+{{- if not (kindIs "map" $service) -}}
+{{- fail "topology.otel.config.service must be a map when topology.otel.enabled=true" -}}
+{{- end -}}
+{{- $pipelines := get $service "pipelines" | default dict -}}
+{{- if not (kindIs "map" $pipelines) -}}
+{{- fail "topology.otel.config.service.pipelines must be a map when topology.otel.enabled=true" -}}
+{{- end -}}
+{{- $metrics := get $pipelines "metrics" -}}
+{{- if not (kindIs "map" $metrics) -}}
+{{- fail "the chart-managed Prometheus exporter requires topology.otel.config.service.pipelines.metrics; provide a metrics pipeline with non-empty receivers" -}}
+{{- end -}}
+{{- $metricReceivers := get $metrics "receivers" -}}
+{{- if not $metricReceivers -}}
+{{- fail "the chart-managed Prometheus exporter requires topology.otel.config.service.pipelines.metrics with non-empty receivers; provide a metrics pipeline with non-empty receivers" -}}
+{{- end -}}
+{{- $exporters := get $config "exporters" | default dict -}}
+{{- if not (kindIs "map" $exporters) -}}
+{{- fail "topology.otel.config.exporters must be a map when topology.otel.enabled=true" -}}
+{{- end -}}
+{{- $prometheusExporter := get $exporters "prometheus" | default dict -}}
+{{- if not (kindIs "map" $prometheusExporter) -}}
+{{- fail "topology.otel.config.exporters.prometheus must be a map; the chart-managed Prometheus exporter controls its endpoint" -}}
+{{- end -}}
+{{- $prometheusExporter = mergeOverwrite (deepCopy $prometheusExporter) (dict "endpoint" (printf "0.0.0.0:%v" (get $otelPorts "prometheus"))) -}}
+{{- $_ := set $exporters "prometheus" $prometheusExporter -}}
+{{- $_ := set $config "exporters" $exporters -}}
+{{- $metricExporters := get $metrics "exporters" | default list -}}
+{{- if not (has "prometheus" $metricExporters) -}}
+{{- $metricExporters = append $metricExporters "prometheus" -}}
+{{- end -}}
+{{- $_ := set $metrics "exporters" $metricExporters -}}
+{{- $_ := set $pipelines "metrics" $metrics -}}
+{{- $_ := set $service "pipelines" $pipelines -}}
+{{- $_ := set $config "service" $service -}}
 {{- $zipkin := .Values.topology.zipkin | default dict -}}
 {{- if not (kindIs "map" $zipkin) -}}
 {{- fail "topology.zipkin must be a map" -}}

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -405,7 +405,9 @@ topology:
   # ---------------------------------------------------------------------------
   # Deploys an in-cluster OpenTelemetry Collector for traces, metrics, and logs.
   # Disable with `topology.otel.enabled: false`.  The collector exposes OTLP
-  # gRPC (4317) and OTLP HTTP (4318) receivers by default.
+  # gRPC (4317) and OTLP HTTP (4318) receivers, plus a Prometheus metrics
+  # endpoint (8889), by default. The chart-managed Prometheus exporter uses
+  # `ports.prometheus` and exports metrics received through the OTLP receiver.
   otel:
     enabled: true
     image:

--- a/nemo_retriever/tests/test_helm_tracing_zipkin.py
+++ b/nemo_retriever/tests/test_helm_tracing_zipkin.py
@@ -306,6 +306,17 @@ def test_otel_prometheus_exporter_requires_metrics_pipeline() -> None:
     )
 
 
+def test_otel_prometheus_exporter_requires_metric_exporter_list() -> None:
+    proc = _helm_template_process(
+        extra_args=["--set-string", "topology.otel.config.service.pipelines.metrics.exporters=debug"]
+    )
+
+    assert proc.returncode != 0
+    assert (
+        "topology.otel.config.service.pipelines.metrics.exporters must be a list " "when topology.otel.enabled=true"
+    ) in proc.stderr
+
+
 def test_default_injects_managed_service_and_nim_otel_env() -> None:
     docs = _helm_template()
     service_env = _deployment_env(_find(docs, "Deployment", FULLNAME))

--- a/nemo_retriever/tests/test_helm_tracing_zipkin.py
+++ b/nemo_retriever/tests/test_helm_tracing_zipkin.py
@@ -256,6 +256,56 @@ def test_default_renders_zipkin_deployment_and_service() -> None:
     assert service["spec"]["ports"] == [{"name": "http", "protocol": "TCP", "port": 9411, "targetPort": "http"}]
 
 
+def test_otel_prometheus_exporter_matches_advertised_port() -> None:
+    docs = _helm_template()
+    config = yaml.safe_load(_find(docs, "ConfigMap", OTEL_CONFIG_NAME)["data"]["config.yaml"])
+    otel_deployment = _find(docs, "Deployment", OTEL_NAME)
+    otel_service = _find(docs, "Service", OTEL_NAME)
+
+    assert config["exporters"]["prometheus"]["endpoint"] == "0.0.0.0:8889"
+    assert config["service"]["pipelines"]["metrics"]["exporters"].count("prometheus") == 1
+    assert {
+        port["name"]: port["containerPort"]
+        for port in otel_deployment["spec"]["template"]["spec"]["containers"][0]["ports"]
+    }["prometheus"] == 8889
+    assert {port["name"]: port["port"] for port in otel_service["spec"]["ports"]}["prometheus"] == 8889
+
+
+def test_otel_prometheus_exporter_follows_custom_port_and_preserves_settings() -> None:
+    docs = _helm_template(
+        extra_args=[
+            "--set",
+            "topology.otel.ports.prometheus=9999",
+            "--set-string",
+            "topology.otel.config.exporters.prometheus.endpoint=0.0.0.0:8889",
+            "--set-string",
+            "topology.otel.config.exporters.prometheus.namespace=nrl",
+            "--set-json",
+            'topology.otel.config.service.pipelines.metrics.exporters=["debug","prometheus"]',
+        ]
+    )
+    config = yaml.safe_load(_find(docs, "ConfigMap", OTEL_CONFIG_NAME)["data"]["config.yaml"])
+    otel_deployment = _find(docs, "Deployment", OTEL_NAME)
+    otel_service = _find(docs, "Service", OTEL_NAME)
+
+    assert config["exporters"]["prometheus"] == {"endpoint": "0.0.0.0:9999", "namespace": "nrl"}
+    assert config["service"]["pipelines"]["metrics"]["exporters"].count("prometheus") == 1
+    assert {
+        port["name"]: port["containerPort"]
+        for port in otel_deployment["spec"]["template"]["spec"]["containers"][0]["ports"]
+    }["prometheus"] == 9999
+    assert {port["name"]: port["port"] for port in otel_service["spec"]["ports"]}["prometheus"] == 9999
+
+
+def test_otel_prometheus_exporter_requires_metrics_pipeline() -> None:
+    proc = _helm_template_process(extra_args=["--set-json", "topology.otel.config.service.pipelines.metrics=null"])
+
+    assert proc.returncode != 0
+    assert (
+        "the chart-managed Prometheus exporter requires topology.otel.config.service.pipelines.metrics" in proc.stderr
+    )
+
+
 def test_default_injects_managed_service_and_nim_otel_env() -> None:
     docs = _helm_template()
     service_env = _deployment_env(_find(docs, "Deployment", FULLNAME))


### PR DESCRIPTION
## Description

Restore the Helm chart contract for the chart-owned OpenTelemetry Collector Prometheus endpoint.

- Inject a Prometheus exporter bound to `topology.otel.ports.prometheus` and route the metrics pipeline to it.
- Keep the rendered Collector configuration, Deployment port, and Service port synchronized, including custom port overrides.
- Add Helm render coverage and document the endpoint verification flow.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

- `pre-commit run --files nemo_retriever/helm/README.md nemo_retriever/helm/templates/_helpers.tpl nemo_retriever/helm/values.yaml nemo_retriever/tests/test_helm_tracing_zipkin.py`
- `helm lint nemo_retriever/helm`
- `flake8 nemo_retriever/tests/test_helm_tracing_zipkin.py`
- Minikube: chart-owned OTel Collector reached Ready and the Service `8889` port returned HTTP 200 from `/metrics`.
