### PR TITLE
fix: materialize caption actor preflight overrides

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -208,7 +208,9 @@ def preflight_executors(executors: list[Any], cluster_resources: ClusterResource
         used_cpu += selected[5]
         used_gpu += selected[6]
     for executor, name, concurrency, _target, _initial, _cpu, _gpu, _auto in auto:
-        executor._node_overrides[name]["concurrency"] = _planned_concurrency(concurrency, planned[(id(executor), name)])
+        executor._node_overrides.setdefault(name, {})["concurrency"] = _planned_concurrency(
+            concurrency, planned[(id(executor), name)]
+        )
     for executor in executors:
         executor._resources_preflight_complete = True
         executor._preflight_cluster_resources = cluster_resources
@@ -455,7 +457,7 @@ class RayDataExecutor(AbstractExecutor):
             used_cpu += cpu
             used_gpu += gpu
         for name, concurrency, _count, _initial, _cpu, _gpu in auto:
-            self._node_overrides[name]["concurrency"] = _planned_concurrency(concurrency, planned[name])
+            self._node_overrides.setdefault(name, {})["concurrency"] = _planned_concurrency(concurrency, planned[name])
 
     @staticmethod
     def _linearize(graph: Graph) -> List[Node]:

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -422,6 +422,48 @@ def test_batch_preflight_rejects_infeasible_explicit_tuning() -> None:
         executor._preflight_resources(executor._linearize(graph), 16, 8)
 
 
+@pytest.mark.parametrize("extraction_mode", ["image", "pdf"])
+def test_batch_preflight_remote_caption_materializes_missing_override(extraction_mode: str) -> None:
+    from nemo_retriever.graph.executor import RayDataExecutor
+    from nemo_retriever.graph.ingestor_runtime import default_concurrency_node_names
+    from nemo_retriever.operators.extract.caption.caption import CaptionCPUActor
+
+    cluster = ClusterResources(
+        total_resources=Resources(cpu_count=224, gpu_count=8),
+        available_resources=Resources(cpu_count=224, gpu_count=8),
+    )
+    extract_params = ExtractParams(extract_images=True)
+    caption_params = CaptionParams(
+        endpoint_url="http://omni-nim.example/v1/chat/completions",
+        model_name="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+    )
+    overrides = batch_tuning_to_node_overrides(
+        extract_params,
+        None,
+        cluster_resources=cluster,
+        caption_params=caption_params,
+    )
+    graph = build_graph(
+        extraction_mode=extraction_mode,
+        extract_params=extract_params,
+        caption_params=caption_params,
+        stage_order=(),
+    ).resolve(cluster.total_resources)
+    caption_node = next(node for node in _linear_nodes(graph) if node.name == "CaptionActor")
+    executor = RayDataExecutor(
+        graph,
+        node_overrides=overrides,
+        auto_concurrency_nodes=default_concurrency_node_names(extract_params, None, None, caption_params),
+    )
+
+    assert "CaptionActor" not in overrides
+    assert caption_node.operator_class is CaptionCPUActor
+
+    executor._preflight_resources(executor._linearize(graph), available_cpus=224, available_gpus=8)
+
+    assert overrides["CaptionActor"]["concurrency"] == 1
+
+
 def test_batch_preflight_rejects_infeasible_direct_override() -> None:
     from nemo_retriever.graph.executor import RayDataExecutor
 

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1112,6 +1112,18 @@ class TestRayDataExecutor:
         with pytest.raises(ValueError, match="Infeasible Ray CPU/GPU plan"):
             executor._preflight_resources(executor._linearize(graph), available_cpus=11, available_gpus=1)
 
+    def test_shared_preflight_materializes_missing_auto_override(self):
+        graph = Graph()
+        graph.add_root(CPUAdaptiveAddOperator())
+        executor = RayDataExecutor(graph, auto_concurrency_nodes={"CPUAdaptiveAddOperator"})
+
+        from nemo_retriever.common.ray_resource_hueristics import ClusterResources
+
+        resources = Resources(cpu_count=4, gpu_count=0)
+        preflight_executors([executor], ClusterResources(total_resources=resources, available_resources=resources))
+
+        assert executor._node_overrides["CPUAdaptiveAddOperator"]["concurrency"] == 1
+
     def test_preflight_preserves_and_caps_actor_pool_tuples(self):
         def executor() -> RayDataExecutor:
             graph = Graph()


### PR DESCRIPTION
## What changed

- Materialize missing node override dictionaries before Ray resource preflight writes planned auto-concurrency.
- Apply the safeguard to both single-executor and shared-executor preflight paths.
- Add regression coverage for remote caption endpoints in direct-image and PDF pipelines, plus the shared planner.

## Why

Remote VLM/Omni captioning adds `CaptionActor` to the auto-concurrency set but intentionally does not create a GPU or concurrency override. Preflight treated the implicit concurrency as valid during planning, then directly indexed the absent override entry while saving the plan, raising `KeyError: CaptionActor` before any endpoint request was sent.

## Impact

SDK batch caption pipelines using remote NIM endpoints can now complete resource preflight. Caption resolution remains CPU-based for remote endpoints, without reserving local GPUs.

## Validation

- `python -m pytest nemo_retriever/tests/test_ingest_plans.py nemo_retriever/tests/test_pipeline_graph.py` — 144 passed
- `git diff --check`
- Signed commit verified with `git verify-commit HEAD`