### PR TITLE
Validate extraction method values

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -23,6 +23,17 @@ not parse them as stable codes. The stable text-generation codes documented in
 [One-shot text generation](#one-shot-text-generation) apply to generation
 operator output columns, not to document extraction.
 
+### Select a supported extraction method
+
+`ExtractParams` validates `method` when you construct the model. For PDF
+extraction, use `pdfium`, `pdfium_hybrid`, `ocr`, or `nemotron_parse`. The
+`audio` value remains available for the legacy params-driven audio path. For
+new audio pipelines, use `GraphIngestor.extract_audio()` instead.
+
+Any other value raises a Pydantic `ValidationError` before pipeline setup. The
+error lists the supported values, so spelling and configuration errors do not
+silently select another extraction path.
+
 ### Choose raise or collect behavior
 
 For graph run modes, `error_policy="raise"` raises `GraphIngestionError` when

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -516,7 +516,13 @@ class ExtractParams(_ParamsModel):
     extract_page_as_image: Optional[bool] = True
 
     # Extraction options
-    method: str = "pdfium"
+    method: Literal["pdfium", "pdfium_hybrid", "ocr", "nemotron_parse", "audio"] = Field(
+        default="pdfium",
+        description=(
+            "Extraction method. PDF extraction supports 'pdfium', 'pdfium_hybrid', 'ocr', and "
+            "'nemotron_parse'; 'audio' is retained for the legacy params-driven audio path."
+        ),
+    )
     # Run PageElementDetection (layout/yolox). Required by TableStructure and
     # OCR. Safe to disable for text-only ingests.
     use_page_elements: bool = True

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -65,6 +65,7 @@ from nemo_retriever.common.params import (
     ExtractParams,
     HtmlChunkParams,
     IngestExecuteParams,
+    NO_API_KEY,
     StoreParams,
     TextChunkParams,
     VideoFrameParams,
@@ -382,6 +383,9 @@ def _resolve_api_key(params: Any) -> Any:
     """Auto-resolve api_key from NVIDIA_API_KEY / NGC_API_KEY if not explicitly set."""
     if params is None:
         return params
+    uses_no_api_key = getattr(params, "_uses_no_api_key", None)
+    if callable(uses_no_api_key) and uses_no_api_key("api_key"):
+        return params
     if not getattr(params, "api_key", None) and hasattr(params, "model_copy"):
         key = resolve_remote_api_key()
         if key:
@@ -400,7 +404,20 @@ def _coerce(params: Any, kwargs: dict[str, Any], *, default_factory: Callable[[]
     if not kwargs:
         return params
     if hasattr(params, "model_copy"):
-        return params.model_copy(update=kwargs)
+        values = params.model_dump()
+        uses_no_api_key = getattr(params, "_uses_no_api_key", None)
+        api_key_env_reference = getattr(params, "_api_key_env_reference", None)
+        for field_name in type(params).model_fields:
+            if field_name in kwargs:
+                continue
+            if callable(uses_no_api_key) and uses_no_api_key(field_name):
+                values[field_name] = NO_API_KEY
+                continue
+            if callable(api_key_env_reference):
+                reference = api_key_env_reference(field_name)
+                if reference is not None:
+                    values[field_name] = reference
+        return type(params).model_validate(values | kwargs)
     return params
 
 

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -22,6 +22,7 @@ from nemo_retriever.common.params import (
     ExtractParams,
     HtmlChunkParams,
     IngestExecuteParams,
+    NO_API_KEY,
     RemoteRetryParams,
     TextChunkParams,
 )
@@ -361,6 +362,28 @@ def test_extract_rejects_unknown_kwargs() -> None:
     expected_rejected = repr(sorted(["document_type", "extract_method", "extract_audio_params"]))
     assert expected_rejected in message
     assert "asr_params" in message
+
+
+@pytest.mark.parametrize("run_mode", ["inprocess", "batch"])
+def test_extract_validates_overrides_to_existing_params(run_mode: str) -> None:
+    params = ExtractParams()
+
+    with pytest.raises(ValueError, match="pdfium_hybrid"):
+        GraphIngestor(run_mode=run_mode).extract(params, method="unsupported")
+
+
+@pytest.mark.parametrize("run_mode", ["inprocess", "batch"])
+@pytest.mark.parametrize("overrides", [{}, {"dpi": 300}])
+def test_extract_preserves_explicit_api_key_suppression(
+    monkeypatch: pytest.MonkeyPatch, run_mode: str, overrides: dict[str, int]
+) -> None:
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-review-secret")
+    params = ExtractParams(api_key=NO_API_KEY)
+
+    resolved = GraphIngestor(run_mode=run_mode).extract(params, **overrides)._extract_params
+
+    assert resolved.api_key is None
+    assert resolved._uses_no_api_key("api_key")
 
 
 def test_extract_default_pdf_only_builds_dedicated_pdf_graph(tmp_path) -> None:

--- a/nemo_retriever/tests/test_params_models.py
+++ b/nemo_retriever/tests/test_params_models.py
@@ -18,6 +18,24 @@ class TestVideoFrameParams:
 
 
 class TestExtractParams:
+    @pytest.mark.parametrize("method", ["pdfium", "pdfium_hybrid", "ocr", "nemotron_parse", "audio"])
+    def test_supported_extraction_methods_are_valid(self, method: str) -> None:
+        assert ExtractParams(method=method).method == method
+
+    def test_unsupported_extraction_method_is_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ExtractParams(method="unsupported")
+
+        error = str(exc_info.value)
+        for method in ("pdfium", "pdfium_hybrid", "ocr", "nemotron_parse", "audio"):
+            assert method in error
+
+    def test_extraction_method_schema_describes_supported_and_legacy_values(self) -> None:
+        schema = ExtractParams.model_json_schema()["properties"]["method"]
+
+        assert "PDF extraction supports" in schema["description"]
+        assert "legacy params-driven audio path" in schema["description"]
+
     def test_parse_specific_configuration_requires_parse_method(self) -> None:
         for field, value in (
             ("nemotron_parse_invoke_url", "http://parse:8000/v1/chat/completions"),


### PR DESCRIPTION
## Summary

- Validate `ExtractParams.method` at model construction and when keyword overrides are merged into an existing params model.
- Accept the four documented PDF extraction methods and the existing legacy `audio` route.
- Preserve explicit API-key suppression and environment-reference provenance while revalidating merged params.
- Describe supported choices in generated Pydantic schemas and the API documentation.
- Add regression coverage for both `inprocess` and `batch` override paths.

## Root cause

`ExtractParams.method` was typed as an unconstrained `str`. Downstream extraction routing only recognized specific values, so an unsupported value bypassed the specialized branches and silently behaved like the default PDFium path.

The fluent builder also merged overrides with `model_copy(update=...)`, which does not validate updates. Reconstructing solely from `model_dump()` fixed field validation but discarded private API-key provenance, including the `NO_API_KEY` suppression marker. The builder now reconstructs and validates the merged model while carrying forward credential provenance unless that field is explicitly overridden.

## User impact

Misspelled or unsupported extraction methods now raise a Pydantic `ValidationError` before pipeline setup, including when overriding an existing `ExtractParams` instance. Explicit `NO_API_KEY` remains effective even when environment credentials are present, preventing unintended credential forwarding. The error and generated schema expose every supported method.

## Validation

- `pytest nemo_retriever/tests/test_params_models.py nemo_retriever/tests/test_ingest_interface.py nemo_retriever/tests/test_ingest_plans.py nemo_retriever/tests/test_split_config_integration.py -q` — 107 passed, 2 deselected.
- `git diff --check`.

Strict MkDocs and Ruff checks were unavailable because those tools are not installed in the available environments.
