### PR TITLE
fix: avoid pandas reshape in batch error scan

### DIFF
--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -1199,7 +1199,11 @@ class GraphIngestor(ingestor):
                 if requested_columns is None
                 else [c for c in requested_columns if c in available_columns]
             )
-            for row_index, row in batch_df.iterrows():
+            # ``iterrows`` materializes the full frame through NumPy, which is
+            # unsafe for Ray pickled-object columns containing empty arrays.
+            row_values = batch_df.itertuples(index=False, name=None)
+            for row_index, values in zip(batch_df.index, row_values):
+                row = dict(zip(available_columns, values))
                 source_identifier = cls._source_identifier_from_row(row, row_index)
                 for column in target_columns:
                     for record in cls._iter_stage_errors_from_value(row[column]):

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pytest
 from PIL import Image
 from ray.data.block import BlockAccessor
+from ray.data.extensions import ArrowPythonObjectArray
 
 import nemo_retriever
 from nemo_retriever.graph.ingestor_runtime import build_graph
@@ -902,26 +903,54 @@ def test_get_error_rows_maps_batch_dataset_with_columns_property() -> None:
     assert errors.iloc[0]["text"] == "first page"
 
 
-def test_stage_error_records_normalizes_arrow_object_arrays_before_row_iteration() -> None:
-    table = BlockAccessor.batch_to_block(
-        pd.DataFrame(
-            {
-                "text": ["first page", "second page"],
-                "tables": [np.array([], dtype=object), np.array([], dtype=object)],
+@pytest.mark.parametrize("error_row", [None, 1])
+def test_batch_ingest_finalization_handles_ray_pickled_object_arrays(
+    error_row: int | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage_values = []
+    for row_index in range(3):
+        error = None
+        if row_index == error_row:
+            error = {
+                "stage": "remote_inference",
+                "type": "ConnectionError",
+                "message": "connection refused",
             }
-        )
+        stage_values.append({"timing": None, "error": error})
+
+    table = pa.Table.from_arrays(
+        [
+            pa.array(["first.pdf", "second.pdf", "third.pdf"]),
+            pa.array(stage_values),
+            ArrowPythonObjectArray.from_objects([np.array([], dtype=object) for _ in range(3)]),
+        ],
+        names=["path", "page_elements_v3", "images"],
+    )
+    batch_df = BlockAccessor.for_block(table).to_pandas()
+    assert str(batch_df["images"].dtype) == "python_object()"
+
+    ingestor = GraphIngestor(run_mode="batch").extract(
+        page_elements_invoke_url="http://remote.example/v1/page-elements",
+        extract_text=False,
+        extract_images=True,
+        extract_tables=False,
+        extract_charts=False,
+        extract_infographics=False,
     )
 
-    class RayLikeDataset:
-        columns = ["text", "tables"]
+    if error_row is None:
+        result = _run_graph_ingest_with_result(ingestor, batch_df, monkeypatch)
 
-        def iter_batches(self, *, batch_format: str):
-            if batch_format == "pandas":
-                yield BlockAccessor.for_block(table).to_pandas()
-            else:
-                assert batch_format == "pyarrow"
-                yield table
+        assert result is batch_df
+        assert len(result) == 3
+        assert str(result["images"].dtype) == "python_object()"
+    else:
+        with pytest.raises(GraphIngestionError) as exc_info:
+            _run_graph_ingest_with_result(ingestor, batch_df, monkeypatch)
 
-    records = GraphIngestor._stage_error_records(RayLikeDataset(), columns=[])
-
-    assert records == []
+        records = exc_info.value.records
+        assert len(records) == 1
+        assert records[0]["row_index"] == error_row
+        assert records[0]["source_identifier"] == "second.pdf"
+        assert records[0]["column"] == "page_elements_v3"
+        assert records[0]["path"] == "error"


### PR DESCRIPTION
## Description

Batch pipelines could complete successfully but fail during the final stage-error scan when Ray returned pickled object columns containing empty arrays. Pandas attempted to reshape these values while iterating over the result and raised a `ValueError`.

This change uses tuple-based row iteration for the final error scan, avoiding the faulty Pandas conversion while preserving the returned DataFrame and existing error-handling behavior.

Regression tests cover both a successful three-row batch result and detection of a genuine remote-stage error.

## Checklist

- [x] I am familiar with the [[Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.