### PR TITLE
fix(dedup): deduplicate NumPy/Arrow-backed image cells in batch mode

### DIFF
--- a/nemo_retriever/src/nemo_retriever/operators/dedup.py
+++ b/nemo_retriever/src/nemo_retriever/operators/dedup.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
+import numpy as np
 import pandas as pd
 
 from nemo_retriever.common.api.internal.mutate.deduplicate import calculate_iou
@@ -15,19 +16,44 @@ from nemo_retriever.common.params import DedupParams
 _STRUCTURED_COLUMNS = ("table", "chart", "infographic")
 
 
+def _as_element_list(value: Any) -> Optional[List[Any]]:
+    """Return an extracted-element cell as a plain list, or ``None`` if unsupported.
+
+    Batch mode delivers structural-element cells as one-dimensional NumPy
+    object arrays (Arrow list columns converted to pandas), while inprocess
+    mode uses Python lists.
+    """
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, np.ndarray) and value.ndim == 1:
+        return value.tolist()
+    return None
+
+
+def _as_bbox(value: Any) -> Optional[Tuple[float, ...]]:
+    """Return the first four bbox coordinates as a plain tuple."""
+    if isinstance(value, np.ndarray):
+        value = value.tolist()
+    if not isinstance(value, (list, tuple)) or len(value) < 4:
+        return None
+    return tuple(value[:4])
+
+
 def _collect_structured_bboxes(row: pd.Series) -> List[Tuple[float, ...]]:
     """Gather all bounding boxes from tables, charts, and infographics columns."""
     bboxes: List[Tuple[float, ...]] = []
     for col in _STRUCTURED_COLUMNS:
-        items = row.get(col)
-        if not isinstance(items, list):
+        items = _as_element_list(row.get(col))
+        if items is None:
             continue
         for item in items:
             if not isinstance(item, dict):
                 continue
-            bbox = item.get("bbox_xyxy_norm")
-            if bbox and len(bbox) >= 4:
-                bboxes.append(tuple(bbox[:4]))
+            bbox = _as_bbox(item.get("bbox_xyxy_norm"))
+            if bbox is not None:
+                bboxes.append(bbox)
     return bboxes
 
 
@@ -54,9 +80,13 @@ def dedup_images(
     if "images" not in batch_df.columns:
         return batch_df
 
+    # Arrow-backed columns reject assignment of a filtered Python list.
+    if isinstance(batch_df["images"].dtype, pd.ArrowDtype):
+        batch_df["images"] = batch_df["images"].astype(object)
+
     for row_idx, row in batch_df.iterrows():
-        images = row.get("images")
-        if not isinstance(images, list) or not images:
+        images = _as_element_list(row.get("images"))
+        if not images:
             continue
 
         filtered = list(images)
@@ -88,11 +118,10 @@ def dedup_images(
                     if not isinstance(item, dict):
                         surviving.append(item)
                         continue
-                    img_bbox = item.get("bbox_xyxy_norm")
-                    if not img_bbox or len(img_bbox) < 4:
+                    img_bbox_t = _as_bbox(item.get("bbox_xyxy_norm"))
+                    if img_bbox_t is None:
                         surviving.append(item)
                         continue
-                    img_bbox_t = tuple(img_bbox[:4])
                     overlaps = any(calculate_iou(img_bbox_t, sb) >= iou_threshold for sb in structured_bboxes)
                     if not overlaps:
                         surviving.append(item)

--- a/nemo_retriever/tests/test_dedup.py
+++ b/nemo_retriever/tests/test_dedup.py
@@ -4,7 +4,9 @@
 
 """Unit tests for nemo_retriever.operators.dedup."""
 
+import numpy as np
 import pandas as pd
+import pytest
 
 from nemo_retriever.common.api.internal.mutate.deduplicate import calculate_iou
 from nemo_retriever.operators.dedup import dedup_images
@@ -144,4 +146,60 @@ class TestEdgeCases:
     def test_empty_images_list(self):
         df = _make_df([{"images": []}])
         result = dedup_images(df)
+        assert len(result.iloc[0]["images"]) == 0
+
+
+# ── batch-mode cell representations ────────────────────────────────────────
+
+
+class TestListLikeImageCells:
+    """Batch mode delivers element cells as NumPy object arrays or Arrow lists."""
+
+    def test_content_hash_dedup_on_numpy_images_cell(self):
+        images = np.array([_make_image("AAA"), _make_image("AAA"), _make_image("BBB")], dtype=object)
+        df = pd.DataFrame({"images": [images], "table": [[]], "chart": [[]], "infographic": [[]]})
+
+        result = dedup_images(df, content_hash=True, bbox_iou=False)
+
+        assert len(result.iloc[0]["images"]) == 2
+
+    def test_bbox_iou_dedup_with_numpy_bbox_values(self):
+        images = np.array(
+            [_make_image("X", bbox=np.array([0.0, 0.0, 1.0, 1.0]))],
+            dtype=object,
+        )
+        tables = np.array([{"text": "t", "bbox_xyxy_norm": np.array([0.0, 0.0, 1.0, 1.0])}], dtype=object)
+        df = pd.DataFrame({"images": [images], "table": [tables], "chart": [[]], "infographic": [[]]})
+
+        result = dedup_images(df, content_hash=False, bbox_iou=True, iou_threshold=0.45)
+
+        assert len(result.iloc[0]["images"]) == 0
+
+    def test_numpy_bbox_below_threshold_is_kept(self):
+        images = [_make_image("X", bbox=np.array([0.0, 0.0, 0.1, 0.1]))]
+        tables = [{"text": "t", "bbox_xyxy_norm": np.array([0.9, 0.9, 1.0, 1.0])}]
+        df = pd.DataFrame({"images": [images], "table": [tables], "chart": [[]], "infographic": [[]]})
+
+        result = dedup_images(df, content_hash=False, bbox_iou=True, iou_threshold=0.45)
+
+        assert len(result.iloc[0]["images"]) == 1
+
+    def test_content_hash_dedup_on_arrow_backed_images_cell(self):
+        pa = pytest.importorskip("pyarrow")
+
+        element_struct = pa.struct([("image_b64", pa.string())])
+        arrow_table = pa.table(
+            {"images": pa.array([[{"image_b64": "AAA"}, {"image_b64": "AAA"}]], type=pa.list_(element_struct))}
+        )
+        df = arrow_table.to_pandas(types_mapper=pd.ArrowDtype)
+
+        result = dedup_images(df, content_hash=True, bbox_iou=False)
+
+        assert len(result.iloc[0]["images"]) == 1
+
+    def test_empty_numpy_images_cell_is_left_alone(self):
+        df = pd.DataFrame({"images": [np.array([], dtype=object)]})
+
+        result = dedup_images(df)
+
         assert len(result.iloc[0]["images"]) == 0


### PR DESCRIPTION
## Description
dedup() appears to succeed in batch mode but has no effect on image elements, so duplicates continue into captioning, embedding, storage, and VDB upload. Inprocess mode is unaffected because it uses Python lists.

**Root cause:** dedup_images and _collect_structured_bboxes only processed cells passing isinstance(value, list). Batch cells are one-dimensional NumPy object arrays or Arrow list values. NumPy bbox_xyxy_norm values also fail the if bbox and len(bbox) >= 4 truthiness check.

**Fix:** Normalize element cells and bbox coordinates to plain Python containers before the content-hash and IoU passes, and convert Arrow-backed images columns to object dtype so the filtered list is assignable.

**Testing:** Five new cases in test_dedup.py covering NumPy cells, NumPy bboxes (dropped and kept), Arrow-backed cells, and empty NumPy cells. Verified end-to-end through a Ray Data DedupImages stage: 4 images in, 2 out; the same run leaves all 4 on main. Full suite matches the main baseline.
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
