### PR TITLE
fix(store): store batch image assets and return valid rows

### DIFF
--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
@@ -15,6 +15,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import fsspec
+import numpy as np
 import pandas as pd
 
 from nemo_retriever.operators.abstract_operator import AbstractOperator
@@ -106,6 +107,11 @@ def _store_nested_image_payloads(
     strip_base64: bool,
 ) -> Any:
     """Persist nested ``image_b64`` values and replace them with URIs."""
+    if isinstance(value, np.ndarray) and value.ndim == 1:
+        # Batch element cells arrive as NumPy arrays; ``DataFrame.at`` collapses
+        # those to a 0-d array, which breaks Arrow conversion of the result.
+        value = value.tolist()
+
     if isinstance(value, list):
         return [
             _store_nested_image_payloads(
@@ -178,12 +184,12 @@ def _row_image_represents_page(row: pd.Series, *, image_source: str | None) -> b
 
 
 def _ensure_object_column(df: pd.DataFrame, column: str) -> None:
-    """Convert Arrow-backed columns so dict/list payloads can be assigned.
+    """Convert Arrow-backed columns so Python payloads can be assigned.
 
     Pandas ArrowExtensionArray rejects ``DataFrame.at`` assignment of updated
-    Python dicts into struct/list columns (``cast_struct`` /
-    string-to-struct NotImplementedError). Object dtype preserves nested
-    payloads that add fields such as ``stored_image_uri``.
+    Python dicts into struct/list columns, and of a URI string into a
+    null-typed column that upstream stages left empty. Object dtype accepts
+    both.
     """
     if column not in df.columns:
         return
@@ -210,7 +216,7 @@ def _store_row_images(
         return df
 
     out = df.copy()
-    for column in (*image_columns, *row_image_columns):
+    for column in (*image_columns, *row_image_columns, "_stored_image_uri"):
         _ensure_object_column(out, column)
     fallback_format = _normalize_image_format(image_format)
     fsspec_options = dict(storage_options or {})

--- a/nemo_retriever/tests/test_store_pipeline_stages.py
+++ b/nemo_retriever/tests/test_store_pipeline_stages.py
@@ -12,6 +12,7 @@ import io
 from pathlib import Path
 from urllib.parse import urlparse
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -165,6 +166,55 @@ class TestStoreOperatorInGraph:
         assert files[0].read_bytes() == base64.b64decode(b64)
         assert result.iloc[0]["_stored_image_uri"].startswith("file://")
         assert result.iloc[0]["image_b64"] is None
+
+    def test_store_operator_writes_uri_into_null_typed_arrow_column(self, tmp_path: Path):
+        pa = pytest.importorskip("pyarrow")
+
+        b64 = _make_tiny_png_b64()
+        arrow_table = pa.table(
+            {
+                "page_image": pa.array([{"image_b64": b64}], type=pa.struct([("image_b64", pa.string())])),
+                "_content_type": pa.array(["text"], type=pa.string()),
+                # Upstream content transforms emit an all-None column, which Arrow types as null.
+                "_stored_image_uri": pa.array([None], type=pa.null()),
+            }
+        )
+        df = arrow_table.to_pandas(types_mapper=pd.ArrowDtype)
+        assert isinstance(df["_stored_image_uri"].dtype, pd.ArrowDtype)
+
+        result = StoreOperator(params=StoreParams(storage_uri=str(tmp_path))).process(df)
+
+        stored_uri = result.iloc[0]["_stored_image_uri"]
+        assert isinstance(stored_uri, str)
+        assert stored_uri.startswith("file://")
+        assert Path(urlparse(stored_uri).path).read_bytes() == base64.b64decode(b64)
+        assert result.iloc[0]["page_image"]["stored_image_uri"] == stored_uri
+        pa.Table.from_pandas(result)
+
+    def test_store_operator_stores_numpy_backed_element_images(self, tmp_path: Path):
+        pa = pytest.importorskip("pyarrow")
+
+        element_b64 = _make_tiny_png_b64(color=(0, 0, 255))
+        arrow_table = pa.table(
+            {
+                "images": pa.array(
+                    [[{"text": "fig", "image_b64": element_b64}]],
+                    type=pa.list_(pa.struct([("text", pa.string()), ("image_b64", pa.string())])),
+                ),
+                "_content_type": pa.array(["images"], type=pa.string()),
+            }
+        )
+        # Ray Data hands batches over with list columns converted to NumPy arrays.
+        df = arrow_table.to_pandas()
+        assert isinstance(df.iloc[0]["images"], np.ndarray)
+
+        result = StoreOperator(params=StoreParams(storage_uri=str(tmp_path))).process(df)
+
+        element = result.iloc[0]["images"][0]
+        assert element["image_b64"] is None
+        assert Path(urlparse(element["stored_image_uri"]).path).read_bytes() == base64.b64decode(element_b64)
+        # Ray Data re-serializes each returned batch through Arrow.
+        pa.Table.from_pandas(result)
 
     def test_store_operator_updates_arrow_backed_page_image_struct(self, tmp_path: Path):
         pa = pytest.importorskip("pyarrow")

--- a/nemo_retriever/tests/test_store_pipeline_stages.py
+++ b/nemo_retriever/tests/test_store_pipeline_stages.py
@@ -189,6 +189,7 @@ class TestStoreOperatorInGraph:
         assert stored_uri.startswith("file://")
         assert Path(urlparse(stored_uri).path).read_bytes() == base64.b64decode(b64)
         assert result.iloc[0]["page_image"]["stored_image_uri"] == stored_uri
+        list(result.iterrows())
         pa.Table.from_pandas(result)
 
     def test_store_operator_stores_numpy_backed_element_images(self, tmp_path: Path):
@@ -213,7 +214,7 @@ class TestStoreOperatorInGraph:
         element = result.iloc[0]["images"][0]
         assert element["image_b64"] is None
         assert Path(urlparse(element["stored_image_uri"]).path).read_bytes() == base64.b64decode(element_b64)
-        # Ray Data re-serializes each returned batch through Arrow.
+        list(result.iterrows())
         pa.Table.from_pandas(result)
 
     def test_store_operator_updates_arrow_backed_page_image_struct(self, tmp_path: Path):


### PR DESCRIPTION
## Description
 Fixes the two open items on the bug: the ArrowInvalid: Invalid null value crash at the _stored_image_uri assignment, and the malformed result frame that could not be consumed with standard pandas iteration.

**Root cause:** Two distinct issues. _stored_image_uri is created upstream in the UDF stage as None for every row, so Arrow types it null and rejects a string scalar. Separately, _store_nested_image_payloads only recursed into list, so NumPy-backed element cells were returned unstored, and writing a NumPy array back via DataFrame.at collapses it to a 0-d array, which is what breaks Arrow conversion of the returned batch.

**Fix:** Include _stored_image_uri in the object-dtype normalization, and convert one-dimensional NumPy element cells to lists before persisting nested payloads.

**Testing:** Two new cases in test_store_pipeline_stages.py for the null-typed Arrow column and for NumPy-backed element images, both asserting the result survives pa.Table.from_pandas. Verified end-to-end through a Ray Data UDFOperator(explode) → StoreOperator plan: 3 images written, URIs returned, base64 stripped, rows readable via iterrows; on main the same run writes 2 images and returns 0-d array cells. Full suite matches the main baseline.
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
