### PR TITLE
Persist direct image captions in ray batch mode

### DIFF
--- a/nemo_retriever/src/nemo_retriever/operators/extract/caption/caption.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/caption/caption.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 import base64
 from io import BytesIO
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+import numpy as np
 import pandas as pd
 from PIL import Image
 
@@ -17,6 +19,7 @@ from nemo_retriever.common.modality.caption.model_profiles import (
     merge_request_extras,
     resolve_caption_model_name,
 )
+from nemo_retriever.common.modality.image.load import SUPPORTED_IMAGE_EXTENSIONS
 from nemo_retriever.operators.abstract_operator import AbstractOperator
 from nemo_retriever.operators.cpu_operator import CPUOperator
 from nemo_retriever.graph.designer import designer_component
@@ -48,6 +51,49 @@ def _image_meets_min_size(b64: str) -> bool:
         return w >= _MIN_IMAGE_DIMENSION and h >= _MIN_IMAGE_DIMENSION
     except Exception:
         return False
+
+
+def _is_direct_image_row(row: pd.Series) -> bool:
+    """Return whether a pipeline row originated from a standalone image file."""
+    metadata = row.get("metadata")
+    source_path = metadata.get("source_path") if isinstance(metadata, dict) else None
+    for candidate in (row.get("path"), source_path):
+        if isinstance(candidate, str) and Path(candidate).suffix.lower() in SUPPORTED_IMAGE_EXTENSIONS:
+            return True
+    return False
+
+
+def _as_image_list(value: Any) -> List[Any] | None:
+    """Normalize image collections materialized by pandas or Ray."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, np.ndarray) and value.ndim == 1 and value.dtype == object:
+        return value.tolist()
+    return None
+
+
+def _ensure_object_column(batch_df: pd.DataFrame, column: str) -> None:
+    """Make a nested Arrow column accept complete Python collection replacements."""
+    if column in batch_df.columns and isinstance(batch_df[column].dtype, pd.ArrowDtype):
+        batch_df[column] = batch_df[column].astype(object)
+
+
+def _write_caption(
+    batch_df: pd.DataFrame,
+    *,
+    row_idx: Any,
+    column: str,
+    item_idx: int,
+    field: str,
+    caption: str,
+) -> None:
+    """Persist a caption by replacing the complete nested collection cell."""
+    items = _as_image_list(batch_df.at[row_idx, column])
+    if items is None or item_idx >= len(items) or not isinstance(items[item_idx], dict):
+        return
+    updated_items = [dict(item) if isinstance(item, dict) else item for item in items]
+    updated_items[item_idx][field] = caption
+    batch_df.at[row_idx, column] = updated_items
 
 
 def _create_local_model(kwargs: dict) -> "Any":
@@ -326,6 +372,9 @@ def caption_images(
     empty will be captioned.  The returned caption is written back into
     ``images[i]["text"]``.
 
+    For a standalone image row with an empty ``images`` list, the full
+    ``page_image`` is materialized as an image entry before captioning.
+
     When ``caption_infographics`` is True, infographic entries are cropped
     from the page image and captioned.  The VLM caption is written to the
     ``caption`` field, preserving the existing OCR ``text``.
@@ -334,9 +383,18 @@ def caption_images(
         return batch_df
 
     has_images = "images" in batch_df.columns
+    has_page_image = "page_image" in batch_df.columns
+    has_direct_page_image = has_page_image and any(_is_direct_image_row(row) for _, row in batch_df.iterrows())
     has_infographics = caption_infographics and "infographic" in batch_df.columns
-    if not has_images and not has_infographics:
+    if not has_images and not has_direct_page_image and not has_infographics:
         return batch_df
+    if not has_images and has_direct_page_image:
+        batch_df["images"] = [[] for _ in range(len(batch_df))]
+        has_images = True
+    if has_images:
+        _ensure_object_column(batch_df, "images")
+    if has_infographics:
+        _ensure_object_column(batch_df, "infographic")
 
     request_extras: Dict[str, Any] = {}
     if endpoint_url:
@@ -372,8 +430,20 @@ def caption_images(
     for row_idx, row in batch_df.iterrows():
         # Unstructured images.
         if has_images:
-            images = row.get("images")
-            if isinstance(images, list):
+            images = _as_image_list(row.get("images"))
+            if images is not None:
+                if not images and _is_direct_image_row(row):
+                    page_image = row.get("page_image")
+                    page_b64 = page_image.get("image_b64") if isinstance(page_image, dict) else None
+                    if page_b64 and _image_meets_min_size(page_b64):
+                        image_entry = {
+                            "image_b64": page_b64,
+                            "text": "",
+                            "bbox_xyxy_norm": [0.0, 0.0, 1.0, 1.0],
+                        }
+                        batch_df.at[row_idx, "images"] = [image_entry]
+                        pending.append((row_idx, "images", 0, page_b64))
+                    continue
                 for item_idx, item in enumerate(images):
                     if not isinstance(item, dict):
                         continue
@@ -425,7 +495,14 @@ def caption_images(
             )
             # Infographics keep OCR text; VLM caption goes to a separate field.
             field = "caption" if col == "infographic" else "text"
-            batch_df.at[row_idx, col][item_idx][field] = caption
+            _write_caption(
+                batch_df,
+                row_idx=row_idx,
+                column=col,
+                item_idx=item_idx,
+                field=field,
+                caption=caption,
+            )
     else:
         all_b64 = [b64 for _, _, _, b64 in pending]
 
@@ -458,6 +535,13 @@ def caption_images(
 
         for (row_idx, col, item_idx, _), caption in zip(pending, all_captions):
             field = "caption" if col == "infographic" else "text"
-            batch_df.at[row_idx, col][item_idx][field] = caption
+            _write_caption(
+                batch_df,
+                row_idx=row_idx,
+                column=col,
+                item_idx=item_idx,
+                field=field,
+                caption=caption,
+            )
 
     return batch_df

--- a/nemo_retriever/tests/test_caption.py
+++ b/nemo_retriever/tests/test_caption.py
@@ -8,6 +8,7 @@ import base64
 import io
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -48,6 +49,99 @@ def test_caption_images_skips_already_captioned():
     result = caption_images(_make_page_df(captioned=True), model=mock_model)
     mock_model.caption_batch.assert_not_called()
     assert result.iloc[0]["images"][0]["text"] == "done"
+
+
+def test_caption_images_uses_page_image_for_direct_image_when_images_is_empty():
+    from nemo_retriever.operators.extract.caption.caption import caption_images
+
+    b64 = _make_test_png_b64()
+    df = pd.DataFrame([{"path": "/data/direct.png", "text": "", "page_image": {"image_b64": b64}, "images": []}])
+    mock_model = MagicMock()
+    mock_model.caption_batch.return_value = ["a red square"]
+
+    result = caption_images(df, model=mock_model)
+
+    mock_model.caption_batch.assert_called_once()
+    assert result.iloc[0]["images"] == [
+        {
+            "image_b64": b64,
+            "text": "a red square",
+            "bbox_xyxy_norm": [0.0, 0.0, 1.0, 1.0],
+        }
+    ]
+
+
+def test_caption_images_uses_page_image_for_direct_image_with_ray_object_array():
+    from nemo_retriever.operators.extract.caption.caption import caption_images
+
+    b64 = _make_test_png_b64()
+    df = pd.DataFrame(
+        [
+            {
+                "path": "/data/direct.png",
+                "text": "",
+                "page_image": {"image_b64": b64},
+                "images": np.array([], dtype=object),
+            }
+        ]
+    )
+    mock_model = MagicMock()
+    mock_model.caption_batch.return_value = ["a red square"]
+
+    result = caption_images(df, model=mock_model)
+
+    mock_model.caption_batch.assert_called_once()
+    assert result.iloc[0]["images"][0]["text"] == "a red square"
+
+
+def test_caption_images_persists_caption_in_arrow_backed_images_column():
+    pa = pytest.importorskip("pyarrow")
+
+    from nemo_retriever.graph.executor import arrow_table_to_pandas
+    from nemo_retriever.operators.extract.caption.caption import caption_images
+
+    b64 = _make_test_png_b64()
+    df = arrow_table_to_pandas(
+        pa.Table.from_pylist(
+            [
+                {
+                    "path": "/data/direct.png",
+                    "text": "",
+                    "page_image": {"image_b64": b64},
+                    "images": [{"image_b64": b64, "text": "", "bbox_xyxy_norm": [0.0, 0.0, 1.0, 1.0]}],
+                }
+            ]
+        )
+    )
+    assert isinstance(df["images"].dtype, pd.ArrowDtype)
+    mock_model = MagicMock()
+    mock_model.caption_batch.return_value = ["a red square"]
+
+    result = caption_images(df, model=mock_model)
+
+    mock_model.caption_batch.assert_called_once()
+    assert result.iloc[0]["images"][0]["text"] == "a red square"
+
+
+def test_caption_images_does_not_use_pdf_page_image_when_images_is_empty():
+    from nemo_retriever.operators.extract.caption.caption import caption_images
+
+    df = pd.DataFrame(
+        [
+            {
+                "path": "/data/document.pdf",
+                "text": "page text",
+                "page_image": {"image_b64": _make_test_png_b64()},
+                "images": [],
+            }
+        ]
+    )
+    mock_model = MagicMock()
+
+    result = caption_images(df, model=mock_model)
+
+    mock_model.caption_batch.assert_not_called()
+    assert result.iloc[0]["images"] == []
 
 
 @patch("nemo_retriever.operators.extract.pdf.extract.extract_image_like_objects_from_pdfium_page")

--- a/nemo_retriever/tests/test_evidence.py
+++ b/nemo_retriever/tests/test_evidence.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_retriever.query.evidence import _evidence_item
+
+
+@pytest.mark.parametrize("bbox", ["", []])
+def test_blank_bbox_without_page_falls_through_to_default_locator(bbox) -> None:
+    # LanceDB rows default bbox_xyxy_norm to "" (and metadata may be a JSON
+    # string, so meta is empty). With no page/segment/frame, a blank bbox must
+    # NOT produce a malformed {"kind": "bbox", "value": ""} locator.
+    hit = {"text": "t", "source": "a.pdf", "bbox_xyxy_norm": bbox, "metadata": {}}
+    assert _evidence_item(hit)["locator"] == {"kind": "page", "value": None}
+
+
+def test_top_level_bbox_produces_bbox_locator() -> None:
+    hit = {"text": "t", "source": "a.pdf", "bbox_xyxy_norm": [0.1, 0.2, 0.3, 0.4], "metadata": {}}
+    assert _evidence_item(hit)["locator"] == {"kind": "bbox", "value": [0.1, 0.2, 0.3, 0.4]}


### PR DESCRIPTION
## Description

This PR fixes direct image captioning in Ray batch mode. Ray materializes nested images values as NumPy object arrays backed by Arrow, while the caption stage previously handled only Python lists and updated nested dictionaries in place. This caused caption requests to be skipped or generated captions to be discarded during write-back. The caption stage now normalizes Ray image collections, falls back to page_image for standalone images with no extracted image entries, and replaces the complete nested collection so the caption persists in images[0]["text"].

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
