### PR TITLE
Fix VDB uploads without embeddings

### DIFF
--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -35,7 +35,7 @@ It does not store the embeddings for images.
 NeMo Retriever Library supports uploading data through `.vdb_upload()` on `create_ingestor(...)` ([Python API guide](nemo-retriever-api-reference.md)).
 Currently, data upload is not supported through the [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
 
-
+Add `.embed()` before `.vdb_upload()`. You can instead use a custom stage that provides vectors in `metadata["embedding"]` or the default `text_embeddings_1b_v2` payload. If the pipeline produces uploadable rows but none contains an embedding, `vdb_upload` raises `ValueError` instead of silently skipping the upload. A pipeline that produces no rows remains a successful no-op.
 
 ## LanceDB Overview { #why-lancedb }
 

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -35,7 +35,23 @@ It does not store the embeddings for images.
 NeMo Retriever Library supports uploading data through `.vdb_upload()` on `create_ingestor(...)` ([Python API guide](nemo-retriever-api-reference.md)).
 Currently, data upload is not supported through the [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
 
-Add `.embed()` before `.vdb_upload()`. You can instead use a custom stage that provides vectors in `metadata["embedding"]` or the default `text_embeddings_1b_v2` payload. If the pipeline produces uploadable rows but none contains an embedding, `vdb_upload` raises `ValueError` instead of silently skipping the upload. A pipeline that produces no rows remains a successful no-op.
+`.vdb_upload()` does not generate embeddings. For dense SDK ingestion, include `.embed()` in the pipeline:
+
+```python
+from nemo_retriever import create_ingestor
+
+
+result = (
+    create_ingestor(run_mode="inprocess")
+    .files(["document.pdf"])
+    .extract(extract_text=True)
+    .embed()
+    .vdb_upload()
+    .ingest()
+)
+```
+
+You can omit `.embed()` if a custom stage provides an embedding in `metadata["embedding"]` or `text_embeddings_1b_v2["embedding"]`. If extracted content reaches `.vdb_upload()` without embeddings, `.ingest()` raises `ValueError`. An extraction that produces no content completes without uploading records.
 
 ## LanceDB Overview { #why-lancedb }
 

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -329,7 +329,18 @@ def _client_record_from_graph_row(row: dict[str, Any], *, require_embedding: boo
     return {"document_type": str(document_type), "metadata": record_metadata}
 
 
-def to_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
+def _row_has_uploadable_content_without_embedding(row: dict[str, Any]) -> bool:
+    metadata = _dict_or_empty(row.get("metadata"))
+    if _embedding_from_graph_row(row, metadata) is not None:
+        return False
+    return bool(_text_from_graph_row(row, metadata)) or _is_image_backed_row(row)
+
+
+def to_client_vdb_records(
+    rows: Any,
+    *,
+    raise_on_missing_embeddings: bool = False,
+) -> list[list[dict[str, Any]]]:
     """Convert graph-ingest rows into the nested record shape expected by client VDBs.
 
     Dense rows require an embedding and either nonblank text or concrete image backing.
@@ -337,6 +348,8 @@ def to_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
     ``if not records`` skips :meth:`~nemo_retriever.vdb.adt_vdb.VDB.run`.
     When at least one row converts, returns ``[batch]`` with a single non-empty inner list
     (never ``[[]]``, which would be truthy and could trip backends on an empty insert).
+    When ``raise_on_missing_embeddings`` is true, uploadable graph content with
+    no supported embedding payload raises ``ValueError`` instead of returning ``[]``.
     """
     if isinstance(rows, list) and all(isinstance(batch, list) for batch in rows):
         return rows
@@ -344,14 +357,21 @@ def to_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
         rows = rows.to_pandas()
     if hasattr(rows, "to_dict"):
         rows = rows.to_dict("records")
+    graph_rows = [row for row in rows or [] if isinstance(row, dict)]
     # Walrus: bind conversion once per row — a plain ``if f(row)`` + ``f(row)`` list comp
     # would call _client_record_from_graph_row twice per row on large datasets.
     # isinstance(row, dict): plain lists are not normalized like DataFrame rows; skip None/Series/etc.
-    inner = [
-        record
-        for row in rows or []
-        if isinstance(row, dict) and (record := _client_record_from_graph_row(row)) is not None
-    ]
+    inner = [record for row in graph_rows if (record := _client_record_from_graph_row(row)) is not None]
+    if (
+        raise_on_missing_embeddings
+        and graph_rows
+        and not inner
+        and any(_row_has_uploadable_content_without_embedding(row) for row in graph_rows)
+    ):
+        raise ValueError(
+            "vdb_upload requires embedded records, but no embeddings were found. "
+            "Add an embed stage or provide a supported embedding column."
+        )
     # Preserve legacy contract: no uploadable rows → [], not [[]].
     return [inner] if inner else []
 

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -336,11 +336,7 @@ def _row_has_uploadable_content_without_embedding(row: dict[str, Any]) -> bool:
     return bool(_text_from_graph_row(row, metadata)) or _is_image_backed_row(row)
 
 
-def to_client_vdb_records(
-    rows: Any,
-    *,
-    raise_on_missing_embeddings: bool = False,
-) -> list[list[dict[str, Any]]]:
+def to_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
     """Convert graph-ingest rows into the nested record shape expected by client VDBs.
 
     Dense rows require an embedding and either nonblank text or concrete image backing.
@@ -348,8 +344,8 @@ def to_client_vdb_records(
     ``if not records`` skips :meth:`~nemo_retriever.vdb.adt_vdb.VDB.run`.
     When at least one row converts, returns ``[batch]`` with a single non-empty inner list
     (never ``[[]]``, which would be truthy and could trip backends on an empty insert).
-    When ``raise_on_missing_embeddings`` is true, uploadable graph content with
-    no supported embedding payload raises ``ValueError`` instead of returning ``[]``.
+    Uploadable graph content without an embedding raises ``ValueError`` when no
+    row survives conversion. Genuinely empty input continues to return ``[]``.
     """
     if isinstance(rows, list) and all(isinstance(batch, list) for batch in rows):
         return rows
@@ -362,12 +358,7 @@ def to_client_vdb_records(
     # would call _client_record_from_graph_row twice per row on large datasets.
     # isinstance(row, dict): plain lists are not normalized like DataFrame rows; skip None/Series/etc.
     inner = [record for row in graph_rows if (record := _client_record_from_graph_row(row)) is not None]
-    if (
-        raise_on_missing_embeddings
-        and graph_rows
-        and not inner
-        and any(_row_has_uploadable_content_without_embedding(row) for row in graph_rows)
-    ):
+    if not inner and any(_row_has_uploadable_content_without_embedding(row) for row in graph_rows):
         raise ValueError(
             "vdb_upload requires embedded records, but no embeddings were found. "
             "Add an embed stage or provide a supported embedding column."

--- a/nemo_retriever/src/nemo_retriever/operators/vdb.py
+++ b/nemo_retriever/src/nemo_retriever/operators/vdb.py
@@ -136,7 +136,7 @@ class IngestVdbOperator(AbstractOperator):
     def process(self, data: Any, **kwargs: Any) -> Any:
         # Graph ingest emits flat embedded rows, while
         # nv-ingest-client VDB.run still expects nested Nemo Retriever Library (NRL) records.
-        records = to_client_vdb_records(data)
+        records = to_client_vdb_records(data, raise_on_missing_embeddings=True)
         if self._sidecar_spec is not None and self._sidecar_lookup is not None:
             records = apply_sidecar_metadata_to_client_batches(
                 records,

--- a/nemo_retriever/src/nemo_retriever/operators/vdb.py
+++ b/nemo_retriever/src/nemo_retriever/operators/vdb.py
@@ -136,7 +136,7 @@ class IngestVdbOperator(AbstractOperator):
     def process(self, data: Any, **kwargs: Any) -> Any:
         # Graph ingest emits flat embedded rows, while
         # nv-ingest-client VDB.run still expects nested Nemo Retriever Library (NRL) records.
-        records = to_client_vdb_records(data, raise_on_missing_embeddings=True)
+        records = to_client_vdb_records(data)
         if self._sidecar_spec is not None and self._sidecar_lookup is not None:
             records = apply_sidecar_metadata_to_client_batches(
                 records,

--- a/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
+++ b/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
@@ -220,6 +220,44 @@ def test_ingest_operator_converts_graph_rows_to_client_vdb_records() -> None:
 
 
 @pytest.mark.parametrize(
+    "row",
+    [
+        pytest.param({"text": "extracted chunk"}, id="text"),
+        pytest.param({"text": "", "_image_b64": "page-image"}, id="image"),
+    ],
+)
+def test_ingest_operator_rejects_uploadable_dataframe_without_embeddings(row: dict[str, Any]) -> None:
+    vdb = FakeVDB()
+    operator = IngestVdbOperator(vdb=vdb)
+    data = pd.DataFrame([row])
+
+    with pytest.raises(
+        ValueError,
+        match="vdb_upload requires embedded records, but no embeddings were found",
+    ):
+        operator.process(data)
+    assert vdb.run_calls == []
+
+
+def test_ingest_operator_rejects_unembedded_content_when_embedded_row_is_filtered() -> None:
+    vdb = FakeVDB()
+    operator = IngestVdbOperator(vdb=vdb)
+    data = pd.DataFrame(
+        [
+            {"text": "", "metadata": {"embedding": [0.1]}},
+            {"text": "extracted chunk"},
+        ]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="vdb_upload requires embedded records, but no embeddings were found",
+    ):
+        operator.process(data)
+    assert vdb.run_calls == []
+
+
+@pytest.mark.parametrize(
     "text",
     [pytest.param("", id="empty"), pytest.param(" \n\t ", id="whitespace")],
 )
@@ -308,36 +346,28 @@ def test_ingest_operator_retains_image_only_row_with_stored_image_uri(
     }
 
 
-@pytest.mark.parametrize(
-    "row",
-    [
-        pytest.param(
-            {
-                "text": "",
-                "text_embeddings_1b_v2": {"embedding": [0.1] * 2048},
-                "source_id": "/tmp/empty.pdf",
-                "page_number": 1,
-            },
-            id="no-image-backing",
-        ),
-        pytest.param(
-            {
-                "text": "",
-                "text_embeddings_1b_v2": {"embedding": None},
-                "_image_b64": "page-image",
-                "source_id": "/tmp/scanned.pdf",
-                "page_number": 7,
-            },
-            id="no-embedding",
-        ),
-    ],
-)
-def test_ingest_operator_drops_ineligible_blank_row(row: dict[str, Any]) -> None:
+def test_ingest_operator_drops_embedded_blank_row_without_image_backing() -> None:
     vdb = FakeVDB()
     operator = IngestVdbOperator(vdb=vdb)
-    data = [row]
+    data = [
+        {
+            "text": "",
+            "text_embeddings_1b_v2": {"embedding": [0.1] * 2048},
+            "source_id": "/tmp/empty.pdf",
+            "page_number": 1,
+        }
+    ]
 
     assert operator(data) is data
+    assert vdb.run_calls == []
+
+
+def test_ingest_operator_allows_genuinely_empty_dataframe() -> None:
+    vdb = FakeVDB()
+    operator = IngestVdbOperator(vdb=vdb)
+    data = pd.DataFrame()
+
+    assert operator.process(data) is data
     assert vdb.run_calls == []
 
 


### PR DESCRIPTION
## Summary

`vdb_upload` silently skipped writing when extracted rows did not contain embeddings. This change raises an actionable error for uploadable rows without embeddings while keeping empty inputs as successful no-ops.

It also adds regression coverage and documents the embedding requirement.

## Testing

- 131 tests passed, 3 skipped.
- Exact in-process `data/multimodal_test.pdf` reproduction passed.
- Pre-commit checks passed.
- Strict MkDocs build passed.
