### PR TITLE
docs(extraction): FAQ extraction-only DataFrame and CLI scope

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -10,10 +10,31 @@ Some NIM microservices and models that the library calls may be individually cov
 
 ## What if I already have a retrieval pipeline? Can I just use NeMo Retriever Library? { #use-with-existing-retrieval-pipeline }
 
-You can use the CLI or Python APIs to perform extraction only, and then consume the results.
-Using the Python API, `results` is a list object with one entry.
-For code examples, refer to the Jupyter notebooks [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb) 
-and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb).
+Yes. Use the Python API to extract content, then pass the extracted rows into your existing retrieval stack.
+
+Chain `.files()`, `.extract()`, and `.ingest()`. Omit `.embed()` and `.vdb_upload()` so the graph does not embed or write an index. The result is a `pandas.DataFrame` with one row per extracted unit, not a one-entry list. Typical columns include `text`, `content`, `path`, `page_number`, and `metadata`. For field-level metadata, refer to [Metadata reference](content-metadata.md).
+
+```python
+from nemo_retriever import create_ingestor
+
+result = (
+    create_ingestor(run_mode="inprocess")
+    .files(["document.md"])
+    .extract()
+    .ingest()
+)
+
+for record in result.to_dict(orient="records"):
+    text = record.get("text") or record.get("content")
+    source_path = record["path"]
+    metadata = record.get("metadata")
+```
+
+Iterate the DataFrame, or convert it with `to_dict(orient="records")`, then send text, path, and metadata to your retriever.
+
+The public `retriever ingest` CLI runs extraction, embedding, and LanceDB indexing as one workflow. It does not return extraction-only rows. Use that command when you want a ready-to-query LanceDB table. For CLI usage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
+
+For Python ingest and indexing, refer to [Ingest documents into a searchable VDB collection](workflow-document-ingestion.md). After you have an index, the Jupyter notebooks [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb) and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb) show framework integration.
 
 ## Where does NeMo Retriever Library ingest to? { #where-does-nrl-ingest-to }
 

--- a/nemo_retriever/tests/test_docs_faq_extraction_contract.py
+++ b/nemo_retriever/tests/test_docs_faq_extraction_contract.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Documentation contracts for NVBug 6610405 (extraction FAQ).
+
+The FAQ must describe the Python extraction-only result as a pandas.DataFrame
+and must not recommend ``retriever ingest`` as an extraction-only surface.
+The public CLI plan includes embedding and LanceDB upload.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+import nemo_retriever.ingest.execution as ingest_execution
+import nemo_retriever.ingest.plan as ingest_plan
+from nemo_retriever.ingestor import create_ingestor
+
+RUNNER = CliRunner()
+cli_main = importlib.import_module("nemo_retriever.cli.main")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FAQ_PATH = _REPO_ROOT / "docs" / "docs" / "extraction" / "faq.md"
+_STALE_FAQ_CLAIMS = (
+    "CLI or Python APIs to perform extraction only",
+    "list object with one entry",
+)
+_FAQ_AVAILABLE = pytest.mark.skipif(not _FAQ_PATH.exists(), reason="Published FAQ is not in this checkout")
+
+
+@_FAQ_AVAILABLE
+def test_faq_describes_python_dataframe_not_cli_extraction_only() -> None:
+    text = _FAQ_PATH.read_text(encoding="utf-8")
+    for claim in _STALE_FAQ_CLAIMS:
+        assert claim not in text
+    assert "pandas.DataFrame" in text
+    assert "retriever ingest" in text
+    assert "LanceDB" in text
+
+
+@_FAQ_AVAILABLE
+def test_faq_python_examples_are_valid_syntax() -> None:
+    text = _FAQ_PATH.read_text(encoding="utf-8")
+    blocks = re.findall(r"```python\n(.*?)```", text, re.DOTALL)
+    assert blocks
+    for code in blocks:
+        ast.parse(code)
+
+
+def test_extraction_only_python_graph_returns_dataframe(tmp_path: Path) -> None:
+    document = tmp_path / "README.md"
+    document.write_text("# Heading\n\nBody text\n", encoding="utf-8")
+
+    result = create_ingestor(run_mode="inprocess").files([str(document)]).extract().ingest(show_progress=False)
+
+    assert isinstance(result, pd.DataFrame)
+    assert not isinstance(result, list)
+    assert len(result) >= 1
+    for column in ("text", "content", "path", "page_number", "metadata"):
+        assert column in result.columns
+
+
+def test_public_ingest_cli_dry_run_plan_includes_embed_and_vdb_upload(monkeypatch, tmp_path: Path) -> None:
+    document = tmp_path / "README.md"
+    document.write_text("# Heading\n\nBody text\n", encoding="utf-8")
+
+    def fail_create_ingestor(**_kwargs: Any) -> Any:
+        raise AssertionError("create_ingestor should not be called for --dry-run")
+
+    monkeypatch.setattr(ingest_execution, "create_ingestor", fail_create_ingestor)
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(document), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is True
+    assert payload["vdb_upload"] is not None
+    assert payload["vdb_upload"]["vdb_op"] == "lancedb"
+    vdb_kwargs = payload["vdb_upload"]["vdb_kwargs"]
+    assert vdb_kwargs["uri"]
+    assert vdb_kwargs["table_name"]
+
+    plan = ingest_plan.resolve_ingest_plan(
+        ingest_plan.IngestPlanRequest(
+            source=ingest_plan.IngestSourceOptions(documents=[str(document)]),
+        )
+    )
+    assert plan.sparse is False
+    assert plan.vdb_params is not None
+    assert plan.vdb_params.vdb_op == "lancedb"


### PR DESCRIPTION
## Summary

- Fixes NVBug 6610405: the FAQ told readers that both CLI and Python can return extraction-only results, and that Python `results` is a one-entry list.
- Documents the actual Python contract: `create_ingestor(...).files(...).extract().ingest()` returns a `pandas.DataFrame` with one row per extracted unit.
- Describes `retriever ingest` as the end-to-end extract, embed, and LanceDB-index workflow, not an extraction-only result mode.
- Adds FAQ/CLI documentation contract tests.

## Test plan

- [ ] Confirm the existing-pipeline FAQ answer no longer says CLI+Python extraction-only or a one-entry list
- [ ] Confirm the Python example consumes DataFrame rows (`to_dict(orient=records)`)
- [ ] Confirm `retriever ingest` is described as extract+embed+LanceDB index
- [ ] `pytest nemo_retriever/tests/test_docs_faq_extraction_contract.py`
- [ ] After publish: spot-check the rendered FAQ page

## Out of scope

- No extraction-only CLI export mode (not a supported public surface)
- Fern `faq.mdx` (not on `main`)
- Unrelated Concepts bugs on #2487