### PR TITLE
fix(cli): honor explicit no-rerank

### DIFF
--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -198,7 +198,8 @@ def _local_command(
     _validate_output_options(output_format, max_text_chars)
     if reranker_invoke_url is None:
         reranker_invoke_url = os.environ.get("RERANKER_INVOKE_URL") or None
-    rerank = rerank or bool(reranker_invoke_url) or bool(reranker_model_name) or bool(reranker_backend)
+    if click.get_current_context().get_parameter_source("rerank") is click.core.ParameterSource.DEFAULT:
+        rerank = bool(reranker_invoke_url) or bool(reranker_model_name) or bool(reranker_backend)
     silence_noisy_libraries()
     if agentic:
         # Relaxed model gating: an explicit model is required only for the remote

--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -182,7 +182,7 @@ def _local_command(
     reranker_api_key_env: opts.RerankerApiKeyEnvOption = None,
     reranker_model_name: opts.RerankerModelNameOption = None,
     reranker_backend: opts.RerankerBackendOption = None,
-    rerank: opts.RerankOption = False,
+    rerank: opts.RerankOption = None,
     retrieval_mode: opts.RetrievalModeOption = "auto",
     output_format: opts.OutputFormatOption = "hits",
     max_text_chars: opts.MaxTextCharsOption = None,
@@ -199,7 +199,7 @@ def _local_command(
     _validate_output_options(output_format, max_text_chars)
     if reranker_invoke_url is None:
         reranker_invoke_url = os.environ.get("RERANKER_INVOKE_URL") or None
-    if click.get_current_context().get_parameter_source("rerank") is click.core.ParameterSource.DEFAULT:
+    if rerank is None:
         rerank = bool(reranker_invoke_url) or bool(reranker_model_name) or bool(reranker_backend)
     silence_noisy_libraries()
     if agentic:

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -126,8 +126,8 @@ RerankOption = Annotated[
     typer.Option(
         "--rerank/--no-rerank",
         help=(
-            "Enable reranking after vector retrieval. Default off. Implicitly enabled when "
-            "any of --reranker-invoke-url / --reranker-model-name / --reranker-backend is set."
+            "Enable reranking after vector retrieval. Default off. When neither flag is passed, implicitly enabled "
+            "when any of --reranker-invoke-url / --reranker-model-name / --reranker-backend is set."
         ),
     ),
 ]

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -122,7 +122,7 @@ RerankerBackendOption = Annotated[
     ),
 ]
 RerankOption = Annotated[
-    bool,
+    bool | None,
     typer.Option(
         "--rerank/--no-rerank",
         help=(

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -203,6 +203,43 @@ def test_root_query_passes_reranker_url(monkeypatch) -> None:
     assert json.loads(result.output) == []
 
 
+def test_root_query_no_rerank_overrides_reranker_options(monkeypatch) -> None:
+    retriever_calls: list[dict[str, Any]] = []
+
+    class FakeRetriever:
+        def __init__(self, **kwargs: Any) -> None:
+            retriever_calls.append(kwargs)
+
+        def query(self, query: str, **_kwargs: Any) -> list[dict[str, Any]]:
+            return []
+
+    monkeypatch.setattr(query_core, "Retriever", FakeRetriever)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "Which passages mention deployment?",
+            "--reranker-invoke-url",
+            "http://rerank:8000/v1/ranking",
+            "--reranker-model-name",
+            "reranker-model",
+            "--reranker-backend",
+            "hf",
+            "--no-rerank",
+        ],
+        env={"NVIDIA_API_KEY": "", "NGC_API_KEY": ""},
+    )
+
+    assert result.exit_code == 0
+    assert retriever_calls == [
+        {
+            "top_k": 10,
+            "vdb_kwargs": {"uri": "lancedb", "table_name": "nemo-retriever"},
+        }
+    ]
+
+
 def test_root_query_passes_reranker_api_key_env(monkeypatch) -> None:
     retriever_calls: list[dict[str, Any]] = []
     monkeypatch.delenv("NVIDIA_API_KEY", raising=False)


### PR DESCRIPTION
## Description

Fixes `retriever query --no-rerank` being ignored when reranker options are configured.

Explicit `--no-rerank` now takes precedence, while reranker options continue to enable reranking when neither flag is provided. Includes regression coverage and updated CLI help.

## Checklist

- [x] I am familiar with the [[Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.