### PR TITLE
Preserve source page numbers during text chunking

### DIFF
--- a/nemo_retriever/src/nemo_retriever/common/modality/txt/split.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/txt/split.py
@@ -166,7 +166,6 @@ def split_df(
                 meta["chunk_index"] = i
                 meta["chunk_count"] = len(chunks)
                 meta["content"] = chunk
-            new_row["page_number"] = i + 1
             # Only the first chunk keeps structured content so that
             # downstream explode does not duplicate tables/charts/etc.
             if i > 0:

--- a/nemo_retriever/tests/test_txt_split.py
+++ b/nemo_retriever/tests/test_txt_split.py
@@ -14,6 +14,7 @@ import pytest
 
 from nemo_retriever.common.modality.txt.split import (
     TextChunkParams,
+    split_df,
     split_text_by_tokens,
     text_to_chunks_df,
     txt_bytes_to_chunks_df,
@@ -61,6 +62,23 @@ def test_split_text_by_tokens_max_tokens_positive():
     tokenizer = _MockTokenizer()
     with pytest.raises(ValueError, match="max_tokens must be positive"):
         split_text_by_tokens("hello", tokenizer=tokenizer, max_tokens=0)
+
+
+def test_split_df_preserves_source_page_numbers(monkeypatch):
+    monkeypatch.setattr(
+        "nemo_retriever.common.modality.txt.split._get_tokenizer", lambda model_id, cache_dir=None: _MockTokenizer()
+    )
+    source = pd.DataFrame(
+        [
+            {"text": "one two three four", "page_number": 2, "metadata": {}},
+            {"text": "five six seven eight", "page_number": 7, "metadata": {}},
+        ]
+    )
+
+    chunks = split_df(source, max_tokens=2)
+
+    assert chunks["page_number"].tolist() == [2, 2, 7, 7]
+    assert [metadata["chunk_index"] for metadata in chunks["metadata"]] == [0, 1, 0, 1]
 
 
 def test_txt_file_to_chunks_df(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

- preserve each extracted row's source `page_number` when token chunking expands it
- continue recording per-row chunk order in `metadata.chunk_index`
- add regression coverage across multiple source pages

## Why

`split_df` copied the extracted row and then replaced its source page number with `chunk_index + 1`. This made PDF citations point to the wrong page and prevented `--page-dedup` from collapsing chunks from the same document page.

Raw text and HTML chunk numbering are unchanged; this only corrects the post-extraction chunking path for rows that already carry page provenance.

## Validation

- `pytest -q tests/test_txt_split.py tests/test_actor_operators.py tests/test_retriever_queries.py` — 130 passed
- repository pre-commit hooks on both changed files — passed
