### PR TITLE
fix(otel): export service and NIM metrics

### DIFF
--- a/docs/docs/extraction/environment-config.md
+++ b/docs/docs/extraction/environment-config.md
@@ -13,6 +13,8 @@ You can specify these in a .env file in your working directory or directly as sh
 | `NVIDIA_API_KEY`                    | `nvapi-*************` <br/>                              | An authorized build.nvidia.com API key, used to interact with NVIDIA-hosted NIMs. Create through build.nvidia.com or through [NGC](https://org.ngc.nvidia.com/setup/api-keys). |
 | `NGC_API_KEY`                | —                                                          | The key that NIM microservices in the cluster use to access NGC resources. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`    | `http://otel-collector:4317` <br/>                       | The endpoint for the OpenTelemetry exporter, used for sending telemetry data. |
+| `OTEL_METRICS_EXPORTER` | `otlp` | The retriever service metrics exporter. Set to `none` to disable OpenTelemetry metric export while retaining other supported telemetry. |
+| `OTEL_METRIC_EXPORT_INTERVAL` | `5000` | The metric export interval in milliseconds for Helm deployments. Set a larger value to reduce export frequency. |
 
 
 ## Related Topics { #related-topics }

--- a/nemo_retriever/dev/compose/service-mode.compose.yaml
+++ b/nemo_retriever/dev/compose/service-mode.compose.yaml
@@ -18,10 +18,11 @@ x-nim-environment: &nim-environment
   NGC_API_KEY: ${NGC_API_KEY:-}
   NIM_ENABLE_OTEL: ${NIM_OTEL_ENABLED:-false}
   NIM_OTEL_TRACES_EXPORTER: otlp
-  NIM_OTEL_METRICS_EXPORTER: console
+  NIM_OTEL_METRICS_EXPORTER: otlp
   NIM_OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
   TRITON_OTEL_URL: http://otel-collector:4318/v1/traces
   TRITON_OTEL_RATE: "1"
+  OTEL_METRIC_EXPORT_INTERVAL: "5000"
 x-nim-service: &nim-service
   runtime: nvidia
   shm_size: ${NIM_SHM_SIZE:-16gb}
@@ -54,6 +55,7 @@ services:
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-nemo-retriever-service}
       OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-otlp}
       OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-otlp}
+      OTEL_METRIC_EXPORT_INTERVAL: ${OTEL_METRIC_EXPORT_INTERVAL:-5000}
       OTEL_LOGS_EXPORTER: ${OTEL_LOGS_EXPORTER:-none}
       OTEL_PROPAGATORS: ${OTEL_PROPAGATORS:-tracecontext,baggage}
       OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-service.namespace=nemo-retriever,service.role=standalone}

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -1116,8 +1116,8 @@ sanity check before opening Grafana.
 Helm installs the chart-owned OpenTelemetry Collector and Zipkin backend on by
 default. This is intentional: the legacy 26.1.2 Helm chart shipped with a
 managed Zipkin deployment enabled, so the new chart keeps a default trace
-backend available for functional parity. Pod trace export is also enabled by
-default for retriever service pods and chart-managed NIMs:
+backend available for functional parity. OTLP trace and metric export is also
+enabled by default for retriever service pods and chart-managed NIMs:
 
 ```yaml
 topology:
@@ -1141,10 +1141,12 @@ before upgrading if your deployment uses an external backend or should not run
 chart-owned Zipkin.
 
 With default values, retriever service pods and chart-managed NIMs emit OTLP to
-the chart's OpenTelemetry Collector, which exports traces to the chart-owned
-Zipkin service. Set `service.otel.enabled=false` or
-`nimOperator.otel.enabled=false` to opt out by surface. Open a job and read the
-Zipkin lookup key from either the JSON body or the `x-trace-id` response header:
+the chart's OpenTelemetry Collector. The Collector exports traces to the
+chart-owned Zipkin service and exposes received metrics in Prometheus format.
+The chart configures a 5-second metric export interval. Set
+`service.otel.enabled=false` or `nimOperator.otel.enabled=false` to opt out by
+surface. Open a job and read the Zipkin lookup key from either the JSON body or
+the `x-trace-id` response header:
 
 ```bash
 kubectl port-forward svc/tracing-smoke-nemo-retriever 7670:80
@@ -1170,18 +1172,36 @@ curl "http://localhost:9411/api/v2/trace/${TRACE_ID}"
 When `topology.otel.enabled=true`, the chart-owned OpenTelemetry Collector
 exposes metrics received through OTLP in Prometheus format. The endpoint uses
 `topology.otel.ports.prometheus`, which defaults to port `8889`. The
-chart-owned OpenTelemetry Collector Service exposes the same port.
+chart-owned OpenTelemetry Collector Service exposes the same port. With default
+values, the retriever service and chart-managed NIMs export OTLP metrics to this
+endpoint.
 
-After your workload sends telemetry, verify the endpoint by port-forwarding the
-Collector Service:
+The retriever service also retains its native Prometheus `/metrics` endpoint.
+Enable `serviceMonitor.enabled=true` when a Prometheus Operator should scrape
+that endpoint directly. Direct scraping remains useful for service metrics that
+do not use OTLP, including the worker-pool metrics used by split-mode
+autoscaling.
+
+After a successful ingestion, allow up to 30 seconds for metric export and
+verify the endpoint by port-forwarding the Collector Service:
 
 ```bash
 kubectl port-forward svc/<release>-nemo-retriever-otel 8889:8889
-curl -fsS http://127.0.0.1:8889/metrics
+metric_found=false
+for attempt in {1..30}; do
+  if curl -fsS http://127.0.0.1:8889/metrics | grep -q '^nemo_retriever_'; then
+    metric_found=true
+    break
+  fi
+  sleep 1
+done
+test "${metric_found}" = true
 ```
 
 Set `topology.otel.ports.prometheus` to use a different port. The chart updates
-the Collector listener and Service port together.
+the Collector listener and Service port together. If the command does not find
+a metric after 30 seconds, confirm that `topology.otel.enabled` and the
+workload's OpenTelemetry settings are enabled, then inspect the Collector logs.
 
 Common opt-out and override knobs:
 
@@ -1195,23 +1215,35 @@ topology:
 
 service:
   otel:
-    enabled: false                 # do not inject service pod instrumentation env
+    enabled: true                  # required for the following service overrides to render
+    env:
+      OTEL_METRICS_EXPORTER: none  # retain tracing, but do not export service metrics
+      OTEL_METRIC_EXPORT_INTERVAL: "10000" # service metric cadence in milliseconds
+# To opt out of all service OTLP telemetry instead, set `service.otel.enabled: false`.
 
 nimOperator:
   otel:
-    enabled: false                 # do not inject inherited NIM OTLP env
+    enabled: true                  # required for the following inherited NIM override to render
+    env:
+      NIM_OTEL_METRICS_EXPORTER: "console" # do not send inherited NIM metrics to OTLP
+# To opt out of all inherited NIM OTLP telemetry instead, set `nimOperator.otel.enabled: false`.
   page_elements:
     otel:
       enabled: false               # per-NIM opt-out
   ocr:
     otel:
       env:
+        NIM_OTEL_METRICS_EXPORTER: "console" # per-NIM metric-export opt-out
         TRITON_OTEL_RATE: "10"     # per-NIM Triton OTel override
 ```
 
 Set `topology.zipkin.exporter.endpoint` when you run your own Zipkin-compatible
 collector. Set `topology.otel.enabled=false` to disable the chart-owned collector
-and all chart-rendered collector wiring.
+and all chart-rendered collector wiring. Values in `service.env` override the
+chart-managed service OpenTelemetry environment variables. Existing NIM
+container environment variables take precedence over inherited
+`nimOperator.otel.env` values, and per-NIM `nimOperator.<key>.otel.env` values
+override the inherited NIM values.
 
 ---
 

--- a/nemo_retriever/helm/templates/_helpers.tpl
+++ b/nemo_retriever/helm/templates/_helpers.tpl
@@ -425,6 +425,7 @@ Tracing helpers
   "OTEL_SERVICE_NAME" (default "nemo-retriever-service" (get $serviceOtel "serviceName"))
   "OTEL_TRACES_EXPORTER" "otlp"
   "OTEL_METRICS_EXPORTER" "otlp"
+  "OTEL_METRIC_EXPORT_INTERVAL" "5000"
   "OTEL_LOGS_EXPORTER" "none"
   "OTEL_PROPAGATORS" "tracecontext,baggage"
   "OTEL_RESOURCE_ATTRIBUTES" (printf "service.namespace=nemo-retriever,service.role=%s" $role)
@@ -490,8 +491,9 @@ Tracing helpers
   "NIM_ENABLE_OTEL" "true"
   "NIM_OTEL_SERVICE_NAME" $serviceName
   "NIM_OTEL_TRACES_EXPORTER" "otlp"
-  "NIM_OTEL_METRICS_EXPORTER" "console"
+  "NIM_OTEL_METRICS_EXPORTER" "otlp"
   "NIM_OTEL_EXPORTER_OTLP_ENDPOINT" $endpoint
+  "OTEL_METRIC_EXPORT_INTERVAL" "5000"
   "TRITON_OTEL_URL" (printf "%s%s" $endpoint $tritonPath)
   "TRITON_OTEL_RATE" "1"
 -}}

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -187,7 +187,7 @@ service:
   # Do not also set INSTALL_FFMPEG manually in service.env.
   installFfmpeg: true
 
-  # OpenTelemetry env defaults for the retriever service container.
+  # OpenTelemetry defaults for the retriever service container. The chart exports metrics every 5 seconds by default; override through service.otel.env.
   otel:
     enabled: true
     serviceName: nemo-retriever-service
@@ -1003,8 +1003,9 @@ nimOperator:
     env:
       NIM_ENABLE_OTEL: "true"
       NIM_OTEL_TRACES_EXPORTER: "otlp"
-      NIM_OTEL_METRICS_EXPORTER: "console"
+      NIM_OTEL_METRICS_EXPORTER: "otlp"
       TRITON_OTEL_RATE: "1"
+      OTEL_METRIC_EXPORT_INTERVAL: "5000"
 
   # ---------------------------------------------------------------------------
   # Per-NIM defaults

--- a/nemo_retriever/src/nemo_retriever/service/app.py
+++ b/nemo_retriever/src/nemo_retriever/service/app.py
@@ -225,6 +225,9 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     shutdown_event_bus()
     shutdown_job_tracker()
     shutdown_metrics()
+    from nemo_retriever.service.metrics_otel import shutdown_metrics as shutdown_otel_metrics
+
+    shutdown_otel_metrics()
     logger.info("Retriever service stopped")
 
 
@@ -262,8 +265,10 @@ def create_app(config: ServiceConfig) -> FastAPI:
                 exc,
             )
 
+    from nemo_retriever.service.metrics_otel import configure_metrics, instrument_app as instrument_otel_metrics
     from nemo_retriever.service.tracing import configure_tracing
 
+    configure_metrics(service_role=config.mode)
     configure_tracing(service_role=config.mode)
 
     app = FastAPI(
@@ -306,6 +311,7 @@ def create_app(config: ServiceConfig) -> FastAPI:
     # role; the handler self-reports an empty pool dict on gateway pods.
     app.include_router(admin.router, prefix="/v1")
     app.include_router(work.router, prefix="/v1")
+    instrument_otel_metrics(app, role=config.mode)
     instrument_app(app, role=config.mode)
 
     if config.mode == "gateway":

--- a/nemo_retriever/src/nemo_retriever/service/metrics_otel.py
+++ b/nemo_retriever/src/nemo_retriever/service/metrics_otel.py
@@ -65,11 +65,16 @@ def configure_metrics(*, service_role: str, service_name: str | None = None) -> 
     reader: Any | None = None
     exporter: Any | None = None
     try:
-        if any(component is None for component in (OTLPMetricExporter, MeterProvider, PeriodicExportingMetricReader, Resource)):
+        if any(
+            component is None
+            for component in (OTLPMetricExporter, MeterProvider, PeriodicExportingMetricReader, Resource)
+        ):
             raise RuntimeError("OpenTelemetry metrics SDK/exporter packages are not importable")
 
         resolved_service_name = (service_name or os.environ.get("OTEL_SERVICE_NAME") or _DEFAULT_SERVICE_NAME).strip()
-        resource = Resource.create({"service.name": resolved_service_name or _DEFAULT_SERVICE_NAME, "service.role": service_role})
+        resource = Resource.create(
+            {"service.name": resolved_service_name or _DEFAULT_SERVICE_NAME, "service.role": service_role}
+        )
         exporter = OTLPMetricExporter()
         reader = PeriodicExportingMetricReader(exporter)
         provider = MeterProvider(resource=resource, metric_readers=[reader])

--- a/nemo_retriever/src/nemo_retriever/service/metrics_otel.py
+++ b/nemo_retriever/src/nemo_retriever/service/metrics_otel.py
@@ -99,12 +99,31 @@ def instrument_app(app: "FastAPI", *, role: str) -> None:
         try:
             response = await call_next(request)
         except Exception:
-            record_ingest_request(role=role, endpoint=request.url.path, status="5xx", duration_s=time.perf_counter() - started)
+            record_ingest_request(
+                role=role,
+                endpoint=_ingest_route_template(request),
+                status="5xx",
+                duration_s=time.perf_counter() - started,
+            )
             raise
 
         status = f"{response.status_code // 100}xx"
-        record_ingest_request(role=role, endpoint=request.url.path, status=status, duration_s=time.perf_counter() - started)
+        record_ingest_request(
+            role=role,
+            endpoint=_ingest_route_template(request),
+            status=status,
+            duration_s=time.perf_counter() - started,
+        )
         return response
+
+
+def _ingest_route_template(request: Any) -> str:
+    """Return a bounded metric label for the matched ingest route."""
+    route = request.scope.get("route")
+    path = getattr(route, "path", None)
+    if isinstance(path, str) and path.startswith("/v1/ingest/"):
+        return path
+    return "/v1/ingest/unmatched"
 
 
 def record_ingest_accepted(*, role: str, endpoint: str, file_size: int, is_page: bool) -> None:

--- a/nemo_retriever/src/nemo_retriever/service/metrics_otel.py
+++ b/nemo_retriever/src/nemo_retriever/service/metrics_otel.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenTelemetry metrics for Retriever service ingestion.
+
+The service also exposes native Prometheus metrics at ``/metrics``.  This
+module is the complementary OTLP path used by the chart-owned Collector.
+Telemetry setup and recording are deliberately best effort: an unavailable
+collector must never prevent an ingestion request from completing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING, Any, Mapping
+
+from opentelemetry import metrics
+
+try:
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+except Exception:  # pragma: no cover - covered through configuration failure handling.
+    OTLPMetricExporter = None  # type: ignore[assignment]
+    MeterProvider = None  # type: ignore[assignment]
+    PeriodicExportingMetricReader = None  # type: ignore[assignment]
+    Resource = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SERVICE_NAME = "nemo-retriever-service"
+_METER_NAME = "nemo_retriever.service"
+_CONFIGURED_PROVIDER: Any | None = None
+_METRICS: dict[str, Any] = {}
+
+
+def metrics_enabled_from_env(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether Helm-compatible environment enables OTLP metrics."""
+    source = os.environ if env is None else env
+    if source.get("OTEL_SDK_DISABLED", "").strip().lower() == "true":
+        return False
+    return bool(
+        source.get("OTEL_METRICS_EXPORTER", "").strip().lower() == "otlp"
+        and source.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    )
+
+
+def configure_metrics(*, service_role: str, service_name: str | None = None) -> bool:
+    """Configure process-wide OTLP metrics when enabled by environment."""
+    global _CONFIGURED_PROVIDER
+
+    if _CONFIGURED_PROVIDER is not None:
+        return True
+    if not metrics_enabled_from_env():
+        return False
+
+    provider: Any | None = None
+    reader: Any | None = None
+    exporter: Any | None = None
+    try:
+        if any(component is None for component in (OTLPMetricExporter, MeterProvider, PeriodicExportingMetricReader, Resource)):
+            raise RuntimeError("OpenTelemetry metrics SDK/exporter packages are not importable")
+
+        resolved_service_name = (service_name or os.environ.get("OTEL_SERVICE_NAME") or _DEFAULT_SERVICE_NAME).strip()
+        resource = Resource.create({"service.name": resolved_service_name or _DEFAULT_SERVICE_NAME, "service.role": service_role})
+        exporter = OTLPMetricExporter()
+        reader = PeriodicExportingMetricReader(exporter)
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        if metrics.get_meter_provider() is not provider:
+            raise RuntimeError("OpenTelemetry meter provider is already configured")
+
+        _configure_instruments()
+        _CONFIGURED_PROVIDER = provider
+        logger.info("OpenTelemetry metrics configured: service=%s role=%s", resolved_service_name, service_role)
+        return True
+    except Exception as exc:
+        _cleanup_partial_metrics_setup(provider=provider, reader=reader, exporter=exporter)
+        logger.warning("OpenTelemetry metrics setup failed: %s", exc)
+        return False
+
+
+def instrument_app(app: "FastAPI", *, role: str) -> None:
+    """Record request count, duration, and failures for ingest routes."""
+
+    @app.middleware("http")
+    async def otel_ingest_metrics(request: Any, call_next: Any) -> Any:
+        if not request.url.path.startswith("/v1/ingest/"):
+            return await call_next(request)
+
+        started = time.perf_counter()
+        try:
+            response = await call_next(request)
+        except Exception:
+            record_ingest_request(role=role, endpoint=request.url.path, status="5xx", duration_s=time.perf_counter() - started)
+            raise
+
+        status = f"{response.status_code // 100}xx"
+        record_ingest_request(role=role, endpoint=request.url.path, status=status, duration_s=time.perf_counter() - started)
+        return response
+
+
+def record_ingest_accepted(*, role: str, endpoint: str, file_size: int, is_page: bool) -> None:
+    """Record accepted ingest payload cardinality and size."""
+    attributes = {"role": role, "endpoint": endpoint}
+    _add("bytes", file_size, attributes)
+    _add("pages" if is_page else "documents", 1, {"role": role})
+
+
+def record_ingest_request(*, role: str, endpoint: str, status: str, duration_s: float) -> None:
+    """Record an ingest response and its duration."""
+    attributes = {"role": role, "endpoint": endpoint, "status": status}
+    _add("requests", 1, attributes)
+    _record("request_duration", duration_s, attributes)
+    if not status.startswith("2"):
+        _add("errors", 1, attributes)
+
+
+def force_flush(timeout_millis: int = 1000) -> None:
+    """Best-effort flush of configured metrics."""
+    if _CONFIGURED_PROVIDER is None:
+        return
+    try:
+        _CONFIGURED_PROVIDER.force_flush(timeout_millis=timeout_millis)
+    except Exception as exc:
+        logger.warning("OpenTelemetry metrics flush failed: %s", exc)
+
+
+def shutdown_metrics() -> None:
+    """Best-effort shutdown of the configured metric provider."""
+    global _CONFIGURED_PROVIDER
+    provider = _CONFIGURED_PROVIDER
+    _CONFIGURED_PROVIDER = None
+    _METRICS.clear()
+    if provider is None:
+        return
+    try:
+        provider.shutdown()
+    except Exception as exc:
+        logger.warning("OpenTelemetry metrics shutdown failed: %s", exc)
+
+
+def _configure_instruments() -> None:
+    meter = metrics.get_meter(_METER_NAME)
+    _METRICS.update(
+        {
+            "requests": meter.create_counter("nemo_retriever.ingest.requests", unit="{request}"),
+            "errors": meter.create_counter("nemo_retriever.ingest.errors", unit="{error}"),
+            "bytes": meter.create_counter("nemo_retriever.ingest.bytes", unit="By"),
+            "documents": meter.create_counter("nemo_retriever.ingest.documents", unit="{document}"),
+            "pages": meter.create_counter("nemo_retriever.ingest.pages", unit="{page}"),
+            "request_duration": meter.create_histogram("nemo_retriever.ingest.request.duration", unit="s"),
+        }
+    )
+
+
+def _add(name: str, value: int, attributes: Mapping[str, str]) -> None:
+    instrument = _METRICS.get(name)
+    if instrument is None or value <= 0:
+        return
+    try:
+        instrument.add(value, attributes=dict(attributes))
+    except Exception as exc:
+        logger.warning("OpenTelemetry metric recording failed: %s", exc)
+
+
+def _record(name: str, value: float, attributes: Mapping[str, str]) -> None:
+    instrument = _METRICS.get(name)
+    if instrument is None:
+        return
+    try:
+        instrument.record(value, attributes=dict(attributes))
+    except Exception as exc:
+        logger.warning("OpenTelemetry metric recording failed: %s", exc)
+
+
+def _cleanup_partial_metrics_setup(*, provider: Any | None, reader: Any | None, exporter: Any | None) -> None:
+    for component in (provider, reader, exporter):
+        if component is None:
+            continue
+        try:
+            component.shutdown()
+        except Exception:
+            logger.debug("Ignoring OpenTelemetry metrics cleanup failure", exc_info=True)
+
+
+def _reset_metrics_for_tests() -> None:
+    """Reset metric globals and SDK state for isolated tests."""
+    shutdown_metrics()
+    try:
+        metrics._METER_PROVIDER = None  # type: ignore[attr-defined]  # noqa: SLF001
+        metrics._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]  # noqa: SLF001
+    except AttributeError:
+        logger.debug("OpenTelemetry metrics test reset skipped private provider state reset", exc_info=True)

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -75,6 +75,7 @@ from nemo_retriever.service.services.prometheus import (
     INGEST_REQUESTS_TOTAL,
 )
 from nemo_retriever.service.services.proxy import get_proxy
+from nemo_retriever.service.metrics_otel import record_ingest_accepted
 from nemo_retriever.service.services.worker_result_store import (
     ResultStoreTemporarilyUnavailable,
     get_result_data,
@@ -232,6 +233,7 @@ def _record_prometheus(
         INGEST_PAGES_TOTAL.labels(role=role).inc()
     else:
         INGEST_DOCUMENTS_TOTAL.labels(role=role).inc()
+    record_ingest_accepted(role=role, endpoint=endpoint, file_size=file_size, is_page=is_page)
 
 
 def _register_document_under_job(

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -1231,25 +1231,26 @@ async def submit_page_to_job(
                     filename=file.filename,
                 )
 
-            _record_prometheus(
-                request,
-                "/v1/ingest/job/page",
-                "2xx",
-                file_size=file_size,
-                is_page=True,
-            )
-            if (m := get_metrics()) is not None:
-                m.record_request("/v1/ingest/job/page")
-                m.record_page_accepted(
-                    page_id=page_id,
-                    document_id=document_id,
-                    job_id=job_id,
-                    endpoint="/v1/ingest/job/page",
-                    page_number=page_number,
-                    file_size_bytes=file_size,
-                    file_category=classification.category.value,
-                    content_type=classification.content_type,
+            if not dry_run:
+                _record_prometheus(
+                    request,
+                    "/v1/ingest/job/page",
+                    "2xx",
+                    file_size=file_size,
+                    is_page=True,
                 )
+                if (m := get_metrics()) is not None:
+                    m.record_request("/v1/ingest/job/page")
+                    m.record_page_accepted(
+                        page_id=page_id,
+                        document_id=document_id,
+                        job_id=job_id,
+                        endpoint="/v1/ingest/job/page",
+                        page_number=page_number,
+                        file_size_bytes=file_size,
+                        file_category=classification.category.value,
+                        content_type=classification.content_type,
+                    )
 
             return PageIngestAccepted(
                 page_id=page_id,
@@ -1289,26 +1290,27 @@ async def submit_page_to_job(
                 ),
             )
 
-        _record_prometheus(
-            request,
-            "/v1/ingest/job/page",
-            "2xx",
-            file_size=len(file_bytes),
-            is_page=True,
-        )
-
-        if (m := get_metrics()) is not None:
-            m.record_request("/v1/ingest/job/page")
-            m.record_page_accepted(
-                page_id=page_id,
-                document_id=document_id,
-                job_id=job_id,
-                endpoint="/v1/ingest/job/page",
-                page_number=page_number,
-                file_size_bytes=len(file_bytes),
-                file_category=classification.category.value,
-                content_type=classification.content_type,
+        if not dry_run:
+            _record_prometheus(
+                request,
+                "/v1/ingest/job/page",
+                "2xx",
+                file_size=len(file_bytes),
+                is_page=True,
             )
+
+            if (m := get_metrics()) is not None:
+                m.record_request("/v1/ingest/job/page")
+                m.record_page_accepted(
+                    page_id=page_id,
+                    document_id=document_id,
+                    job_id=job_id,
+                    endpoint="/v1/ingest/job/page",
+                    page_number=page_number,
+                    file_size_bytes=len(file_bytes),
+                    file_category=classification.category.value,
+                    content_type=classification.content_type,
+                )
 
         return PageIngestAccepted(
             page_id=page_id,
@@ -1356,7 +1358,8 @@ async def submit_whole_document_to_job(
         )
         now = datetime.now(timezone.utc).isoformat()
 
-        if not _is_dry_run(request):
+        dry_run = _is_dry_run(request)
+        if not dry_run:
             record = await _submit_job_work_item(request, route, item, manifest_entry_id=manifest_entry_id)
             if record is not None:
                 return DocumentIngestAccepted(
@@ -1370,19 +1373,19 @@ async def submit_whole_document_to_job(
                 )
 
         file_size = _file_size_from_upload(file) if _is_gateway(request) else len(item.payload)
-        _record_prometheus(request, "/v1/ingest/job/whole", "2xx", file_size=file_size)
-        if (m := get_metrics()) is not None:
-            m.record_request("/v1/ingest/job/whole")
-            m.record_document_accepted(
-                document_id=item.id,
-                job_id=item.job_id,
-                filename=classification.filename,
-                file_category=classification.category.value,
-                content_type=classification.content_type,
-                file_size_bytes=file_size,
-                endpoint="/v1/ingest/job/whole",
-            )
-
+        if not dry_run:
+            _record_prometheus(request, "/v1/ingest/job/whole", "2xx", file_size=file_size)
+            if (m := get_metrics()) is not None:
+                m.record_request("/v1/ingest/job/whole")
+                m.record_document_accepted(
+                    document_id=item.id,
+                    job_id=item.job_id,
+                    filename=classification.filename,
+                    file_category=classification.category.value,
+                    content_type=classification.content_type,
+                    file_size_bytes=file_size,
+                    endpoint="/v1/ingest/job/whole",
+                )
         return DocumentIngestAccepted(
             document_id=item.write.storage_document_id,
             attempt_id=item.id,

--- a/nemo_retriever/tests/test_helm_tracing_zipkin.py
+++ b/nemo_retriever/tests/test_helm_tracing_zipkin.py
@@ -327,6 +327,7 @@ def test_default_injects_managed_service_and_nim_otel_env() -> None:
     assert service_values["OTEL_SERVICE_NAME"] == "nemo-retriever-service"
     assert service_values["OTEL_TRACES_EXPORTER"] == "otlp"
     assert service_values["OTEL_METRICS_EXPORTER"] == "otlp"
+    assert service_values["OTEL_METRIC_EXPORT_INTERVAL"] == "5000"
     assert service_values["OTEL_LOGS_EXPORTER"] == "none"
     assert service_values["OTEL_PROPAGATORS"] == "tracecontext,baggage"
     assert service_values["OTEL_RESOURCE_ATTRIBUTES"] == "service.namespace=nemo-retriever,service.role=standalone"
@@ -343,8 +344,9 @@ def test_default_injects_managed_service_and_nim_otel_env() -> None:
         assert values["NIM_ENABLE_OTEL"] == "true"
         assert values["NIM_OTEL_SERVICE_NAME"] == name
         assert values["NIM_OTEL_TRACES_EXPORTER"] == "otlp"
-        assert values["NIM_OTEL_METRICS_EXPORTER"] == "console"
+        assert values["NIM_OTEL_METRICS_EXPORTER"] == "otlp"
         assert values["NIM_OTEL_EXPORTER_OTLP_ENDPOINT"] == f"http://{OTEL_NAME}:4318"
+        assert values["OTEL_METRIC_EXPORT_INTERVAL"] == "5000"
         assert values["TRITON_OTEL_URL"] == f"http://{OTEL_NAME}:4318/v1/traces"
         assert values["TRITON_OTEL_RATE"] == "1"
 
@@ -695,6 +697,7 @@ def test_standalone_service_gets_otel_env_without_duplicate_user_overrides() -> 
     assert values["OTEL_SERVICE_NAME"] == "user-service-name"
     assert values["OTEL_TRACES_EXPORTER"] == "otlp"
     assert values["OTEL_METRICS_EXPORTER"] == "otlp"
+    assert values["OTEL_METRIC_EXPORT_INTERVAL"] == "5000"
     assert values["OTEL_LOGS_EXPORTER"] == "none"
     assert values["OTEL_PROPAGATORS"] == "tracecontext,baggage"
     assert values["OTEL_RESOURCE_ATTRIBUTES"] == "service.namespace=nemo-retriever,service.role=standalone"
@@ -728,8 +731,9 @@ def test_all_enabled_nimservices_inherit_otel_env() -> None:
         assert values["NIM_ENABLE_OTEL"] == "true"
         assert values["NIM_OTEL_SERVICE_NAME"] == name
         assert values["NIM_OTEL_TRACES_EXPORTER"] == "otlp"
-        assert values["NIM_OTEL_METRICS_EXPORTER"] == "console"
+        assert values["NIM_OTEL_METRICS_EXPORTER"] == "otlp"
         assert values["NIM_OTEL_EXPORTER_OTLP_ENDPOINT"] == f"http://{OTEL_NAME}:4318"
+        assert values["OTEL_METRIC_EXPORT_INTERVAL"] == "5000"
         assert values["TRITON_OTEL_URL"] == f"http://{OTEL_NAME}:4318/v1/traces"
         assert values["TRITON_OTEL_RATE"] == "1"
 

--- a/nemo_retriever/tests/test_service_metrics_otel.py
+++ b/nemo_retriever/tests/test_service_metrics_otel.py
@@ -66,9 +66,7 @@ def test_configured_metrics_export_ingest_core_instruments(monkeypatch: pytest.M
     metrics_otel.record_ingest_accepted(
         role="standalone", endpoint="/v1/ingest/job/document", file_size=42, is_page=False
     )
-    metrics_otel.record_ingest_accepted(
-        role="standalone", endpoint="/v1/ingest/job/page", file_size=7, is_page=True
-    )
+    metrics_otel.record_ingest_accepted(role="standalone", endpoint="/v1/ingest/job/page", file_size=7, is_page=True)
 
     points = _metric_points(reader)
     assert sum(point.value for point in points["nemo_retriever.ingest.requests"]) == 2
@@ -85,7 +83,9 @@ def test_disabled_metrics_do_not_create_instruments(monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel:4317")
 
     assert not metrics_otel.configure_metrics(service_role="standalone")
-    metrics_otel.record_ingest_accepted(role="standalone", endpoint="/v1/ingest/job/document", file_size=1, is_page=False)
+    metrics_otel.record_ingest_accepted(
+        role="standalone", endpoint="/v1/ingest/job/document", file_size=1, is_page=False
+    )
     assert not metrics_otel._METRICS
 
 

--- a/nemo_retriever/tests/test_service_metrics_otel.py
+++ b/nemo_retriever/tests/test_service_metrics_otel.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 from nemo_retriever.service import metrics_otel
@@ -85,3 +87,34 @@ def test_disabled_metrics_do_not_create_instruments(monkeypatch: pytest.MonkeyPa
     assert not metrics_otel.configure_metrics(service_role="standalone")
     metrics_otel.record_ingest_accepted(role="standalone", endpoint="/v1/ingest/job/document", file_size=1, is_page=False)
     assert not metrics_otel._METRICS
+
+
+def test_ingest_middleware_uses_route_templates_for_metric_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[dict[str, Any]] = []
+    monkeypatch.setattr(metrics_otel, "record_ingest_request", lambda **kwargs: recorded.append(kwargs))
+
+    app = FastAPI()
+
+    @app.get("/v1/ingest/job/{job_id}")
+    async def get_job(job_id: str) -> dict[str, str]:
+        return {"job_id": job_id}
+
+    @app.get("/v1/ingest/job/{job_id}/fail")
+    async def fail_job(job_id: str) -> None:
+        raise RuntimeError(job_id)
+
+    metrics_otel.instrument_app(app, role="standalone")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert client.get("/v1/ingest/job/job-one").status_code == 200
+        assert client.get("/v1/ingest/job/job-two").status_code == 200
+        assert client.get("/v1/ingest/job/job-three/fail").status_code == 500
+        assert client.get("/v1/ingest/not-a-route").status_code == 404
+
+    assert [entry["endpoint"] for entry in recorded] == [
+        "/v1/ingest/job/{job_id}",
+        "/v1/ingest/job/{job_id}",
+        "/v1/ingest/job/{job_id}/fail",
+        "/v1/ingest/unmatched",
+    ]
+    assert [entry["status"] for entry in recorded] == ["2xx", "2xx", "5xx", "4xx"]

--- a/nemo_retriever/tests/test_service_metrics_otel.py
+++ b/nemo_retriever/tests/test_service_metrics_otel.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for service-mode OpenTelemetry metric instrumentation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from nemo_retriever.service import metrics_otel
+
+
+class _Exporter:
+    def shutdown(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics() -> None:
+    metrics_otel._reset_metrics_for_tests()
+    yield
+    metrics_otel._reset_metrics_for_tests()
+
+
+def _metric_points(reader: InMemoryMetricReader) -> dict[str, list[Any]]:
+    data = reader.get_metrics_data()
+    assert data is not None
+    return {
+        metric.name: list(metric.data.data_points)
+        for resource_metric in data.resource_metrics
+        for scope_metric in resource_metric.scope_metrics
+        for metric in scope_metric.metrics
+    }
+
+
+def test_metrics_enabled_from_env_requires_otlp_exporter_and_endpoint() -> None:
+    assert not metrics_otel.metrics_enabled_from_env({})
+    assert not metrics_otel.metrics_enabled_from_env({"OTEL_METRICS_EXPORTER": "otlp"})
+    assert not metrics_otel.metrics_enabled_from_env({"OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel:4317"})
+    assert metrics_otel.metrics_enabled_from_env(
+        {"OTEL_METRICS_EXPORTER": "OTLP", "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel:4317"}
+    )
+
+
+def test_configured_metrics_export_ingest_core_instruments(monkeypatch: pytest.MonkeyPatch) -> None:
+    reader = InMemoryMetricReader()
+    monkeypatch.setenv("OTEL_METRICS_EXPORTER", "otlp")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel:4317")
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    monkeypatch.setattr(metrics_otel, "OTLPMetricExporter", _Exporter)
+    monkeypatch.setattr(metrics_otel, "PeriodicExportingMetricReader", lambda exporter: reader)
+
+    assert metrics_otel.configure_metrics(service_role="standalone", service_name="metrics-test")
+    metrics_otel.record_ingest_request(
+        role="standalone", endpoint="/v1/ingest/job/document", status="2xx", duration_s=0.25
+    )
+    metrics_otel.record_ingest_request(
+        role="standalone", endpoint="/v1/ingest/job/document", status="4xx", duration_s=0.1
+    )
+    metrics_otel.record_ingest_accepted(
+        role="standalone", endpoint="/v1/ingest/job/document", file_size=42, is_page=False
+    )
+    metrics_otel.record_ingest_accepted(
+        role="standalone", endpoint="/v1/ingest/job/page", file_size=7, is_page=True
+    )
+
+    points = _metric_points(reader)
+    assert sum(point.value for point in points["nemo_retriever.ingest.requests"]) == 2
+    assert sum(point.value for point in points["nemo_retriever.ingest.errors"]) == 1
+    assert sum(point.value for point in points["nemo_retriever.ingest.bytes"]) == 49
+    assert points["nemo_retriever.ingest.documents"][0].value == 1
+    assert points["nemo_retriever.ingest.pages"][0].value == 1
+    assert sum(point.count for point in points["nemo_retriever.ingest.request.duration"]) == 2
+
+
+def test_disabled_metrics_do_not_create_instruments(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.setenv("OTEL_METRICS_EXPORTER", "otlp")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel:4317")
+
+    assert not metrics_otel.configure_metrics(service_role="standalone")
+    metrics_otel.record_ingest_accepted(role="standalone", endpoint="/v1/ingest/job/document", file_size=1, is_page=False)
+    assert not metrics_otel._METRICS

--- a/nemo_retriever/tests/test_service_work_queue.py
+++ b/nemo_retriever/tests/test_service_work_queue.py
@@ -16,6 +16,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from nemo_retriever.service.app import create_app
+from nemo_retriever.service.routers import ingest as ingest_router
 from nemo_retriever.service.config import (
     AuthConfig,
     LoggingConfig,
@@ -529,7 +530,7 @@ def test_split_worker_uses_internal_gateway_credential_when_configured(tmp_path)
     assert compatibility_pool._batch._pull_client.headers == {"Authorization": "Bearer public-secret"}
 
 
-def test_gateway_dry_run_does_not_register_or_enqueue_work(tmp_path):
+def test_gateway_dry_run_does_not_register_or_enqueue_work(tmp_path, monkeypatch):
     config = ServiceConfig(
         mode="gateway",
         auth=AuthConfig(allow_unscoped_dev=True),
@@ -544,6 +545,22 @@ def test_gateway_dry_run_does_not_register_or_enqueue_work(tmp_path):
         assert created.status_code == 201
         job_id = created.json()["job_id"]
         headers = {"X-Nemo-Dry-Run": "true"}
+        accepted_metrics = []
+
+        class Metrics:
+            def record_request(self, *_args, **_kwargs):
+                accepted_metrics.append("request")
+
+            def record_page_accepted(self, *_args, **_kwargs):
+                accepted_metrics.append("page")
+
+            def record_document_accepted(self, *_args, **_kwargs):
+                accepted_metrics.append("document")
+
+        monkeypatch.setattr(
+            ingest_router, "_record_prometheus", lambda *_args, **_kwargs: accepted_metrics.append("otel")
+        )
+        monkeypatch.setattr(ingest_router, "get_metrics", lambda: Metrics())
 
         page = client.post(
             f"/v1/ingest/job/{job_id}/page",
@@ -579,6 +596,7 @@ def test_gateway_dry_run_does_not_register_or_enqueue_work(tmp_path):
             == 204
         )
         assert not list((tmp_path / "spool").glob("*.payload"))
+        assert accepted_metrics == []
 
 
 def test_gateway_restart_is_explicit_loss_boundary(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description

Fixes the chart-owned OpenTelemetry Collector metrics flow so successful ingestion produces OTLP metrics that the Collector exposes on port 8889.

- Adds best-effort OTLP ingest metrics from the retriever service while preserving native Prometheus `/metrics`.
- Changes chart-managed NIM metrics from console output to OTLP and sets a 5-second export interval.
- Normalizes OTLP ingest `endpoint` labels to FastAPI route templates, preventing per-job Prometheus time-series cardinality.
- Excludes `X-Nemo-Dry-Run` page and whole-document requests from native and OTLP accepted-work counters, so documents, pages, and bytes represent queue-admitted work.
- Updates Helm and published environment documentation, plus Helm/service telemetry regression coverage.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation:

- `uv run --project nemo_retriever pytest -q nemo_retriever/tests/test_service_metrics_otel.py nemo_retriever/tests/test_helm_tracing_zipkin.py` (49 passed).
- `uv run --project nemo_retriever pytest -q nemo_retriever/tests/test_service_ingest_router.py nemo_retriever/tests/test_service_tracing.py` (64 passed).
- `uv run pytest tests/test_service_work_queue.py tests/test_service_metrics_otel.py tests/test_helm_tracing_zipkin.py -q` (73 passed).
- Helm lint, render, and in-process OTLP middleware smoke checks passed.
- Minikube E2E passed with NIM Operator `3.1.2`: the Collector `/metrics` endpoint returned HTTP 200 and was initially empty, then exposed positive Retriever request, byte, and document metrics after a successful PDF ingestion.
- MkDocs strict build and Ruff could not run because `mkdocs` and `ruff` are not installed in this environment.
