### PR TITLE
fix(helm): configure service query reranking

### DIFF
--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -94,6 +94,25 @@ The production Helm chart reconciles NIM microservices through `nimOperator.<key
 | `audio` | [parakeet-1-1b-ctc-en-us](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/index.html) | `nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0` | [Audio and video](audio-video.md) transcription | No |
 | `answer_llm` | [llama-3.3-nemotron-super-49b-v1.5](https://build.nvidia.com/nvidia/llama-3.3-nemotron-super-49b-v1.5) | `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5` | Optional `/v1/answer` generation LLM (not part of the default extraction pipeline) | No |
 
+### Configure query reranking with Helm { #configure-query-reranking-with-helm }
+
+The optional `nimOperator.rerankqa` NIM is not auto-wired into the retriever service. To use service query reranking, enable the NIM and explicitly configure its in-cluster ranking endpoint and model ID. Add the following values to your Helm values file:
+
+```yaml
+nimOperator:
+  rerankqa:
+    enabled: true
+
+serviceConfig:
+  nimEndpoints:
+    rerankInvokeUrl: http://llama-nemotron-rerank-vl-1b-v2:8000/v1/ranking
+    rerankModelName: nvidia/llama-nemotron-rerank-vl-1b-v2
+```
+
+The chart renders these values as `nim_endpoints.rerank_invoke_url` and `nim_endpoints.rerank_model_name` in the retriever service configuration. After deployment, send `rerank: true` in a `/v1/query` request to use the configured reranker.
+
+Setting `nimOperator.rerankqa.enabled=true` without these `serviceConfig.nimEndpoints` values deploys the NIM but does not enable query reranking.
+
 <a id="nemotron-ocr-v2-language-mode"></a>
 
 ### Default NVCF endpoints { #default-nvcf-endpoints }

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -236,6 +236,23 @@ The chart auto-wires the operator-managed in-cluster URLs of the three
 | `nimOperator.ocr` | `nemotron-ocr-v2` | `/v1/ocr` |
 | `nimOperator.vlm_embed`       | `llama-nemotron-embed-vl-1b-v2` | `/v1/embeddings` |
 
+### Query reranking (optional)
+
+The optional `nimOperator.rerankqa` NIM is not auto-wired into the retriever service. To use `POST /v1/query` with `rerank=true`, enable the NIM and configure the service endpoint explicitly:
+
+```yaml
+nimOperator:
+  rerankqa:
+    enabled: true
+
+serviceConfig:
+  nimEndpoints:
+    rerankInvokeUrl: http://llama-nemotron-rerank-vl-1b-v2:8000/v1/ranking
+    rerankModelName: nvidia/llama-nemotron-rerank-vl-1b-v2
+```
+
+Enabling `nimOperator.rerankqa.enabled=true` without `serviceConfig.nimEndpoints.rerankInvokeUrl` deploys the NIM but does not enable service query reranking.
+
 Track operator reconciliation with:
 
 ```bash
@@ -326,6 +343,8 @@ The retriever service picks up the in-cluster ASR endpoint when `nimOperator.aud
 | `serviceConfig.resources.maxUploadBytes`          | `500000000` | Maximum upload file size in bytes; requests exceeding the limit are rejected before buffering. |
 | `serviceConfig.nimEndpoints.*InvokeUrl`           | `""`    | Override the auto-resolved NIM Operator URL. Available knobs: `pageElementsInvokeUrl`, `tableStructureInvokeUrl`, `ocrInvokeUrl`, `embedInvokeUrl`, and `captionInvokeUrl` (refer to [Image captioning (Omni 30B)](#image-captioning-omni-30b)). |
 | `serviceConfig.nimEndpoints.captionModelName`     | `""`    | Model id sent to the remote VLM. Auto-set to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` whenever a caption URL is resolved. |
+| `serviceConfig.nimEndpoints.rerankInvokeUrl`      | `""`    | Ranking API URL used by `POST /v1/query` when `rerank=true`. The optional `rerankqa` NIM is not auto-wired; configure this URL explicitly. |
+| `serviceConfig.nimEndpoints.rerankModelName`      | `""`    | Model ID sent to the ranking API. Defaults to `nvidia/llama-nemotron-rerank-vl-1b-v2` when a rerank URL is configured; set it explicitly for a different compatible reranker. |
 | `serviceConfig.llm.enabled`                         | `false` | Enables `POST /v1/answer`. Auto-flips to true when `nimOperator.answer_llm` is enabled and the operator URL resolves. |
 | `serviceConfig.llm.apiBase`                         | `""`    | OpenAI-compatible LLM base URL. Explicit value wins; otherwise `answer_llm` opt-in resolves to `http://answer-llm:8000/v1` by default. |
 | `serviceConfig.llm.apiKeySecret.name`                | `""`    | Optional Secret name for external LLM credentials. Explicit values win; otherwise operator-managed `answer_llm` mounts its `authSecret` as `NEMO_RETRIEVER_LLM_API_KEY` so LiteLLM/OpenAI has a credential value without writing it to the ConfigMap. |

--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -109,6 +109,8 @@ nim_endpoints:
 {{- else }}
   embed_model_provider_prefix: null
 {{- end }}
+  rerank_invoke_url: {{ if .Values.serviceConfig.nimEndpoints.rerankInvokeUrl }}{{ .Values.serviceConfig.nimEndpoints.rerankInvokeUrl | quote }}{{ else }}null{{ end }}
+  rerank_model_name: {{ if .Values.serviceConfig.nimEndpoints.rerankModelName }}{{ .Values.serviceConfig.nimEndpoints.rerankModelName | quote }}{{ else }}null{{ end }}
   caption_invoke_url: {{ if .captionURL }}{{ .captionURL | quote }}{{ else }}null{{ end }}
   caption_model_name: {{ if .captionModelName }}{{ .captionModelName | quote }}{{ else }}null{{ end }}
   audio_grpc_endpoint: {{ if .audioGrpcEndpoint }}{{ .audioGrpcEndpoint | quote }}{{ else }}null{{ end }}

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -554,6 +554,13 @@ serviceConfig:
     # nvidia/nemotron-parse or self-hosted v1.2 contract from the URL.
     nemotronParseModel: ""
     embedInvokeUrl: ""
+    # Optional remote reranking endpoint used by POST /v1/query with
+    # rerank=true. The optional rerankqa NIM is not auto-wired; set this
+    # explicitly to its in-cluster Service URL or another compatible endpoint.
+    rerankInvokeUrl: ""
+    # Server-owned model identifier sent to rerankInvokeUrl. Use the VL
+    # reranker ID for the chart's optional rerankqa NIM.
+    rerankModelName: ""
     # Optional remote VLM endpoint for image captioning (Nemotron 3 Nano
     # Omni). Auto-wired from the in-cluster Service when
     # `nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled=true`

--- a/nemo_retriever/src/nemo_retriever/operators/rerank.py
+++ b/nemo_retriever/src/nemo_retriever/operators/rerank.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Reranking stage using nvidia/llama-nemotron-rerank-1b-v2.
+Reranking stage using nvidia/llama-nemotron-rerank-vl-1b-v2.
 
 Provides:
   - ``rerank_hits``         – rerank a list of LanceDB hits for a single query
@@ -18,7 +18,7 @@ URLs append ``/v1/ranking`` automatically::
 
     POST /v1/ranking
     {
-      "model": "nvidia/llama-nemotron-rerank-1b-v2",
+      "model": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "query": {"text": "..."},
       "passages": [{"text": "..."}, {"text": "..."}],
       "truncate": "END"
@@ -39,7 +39,7 @@ Ray Data actor usage::
         num_gpus=1,
         compute=ray.data.ActorPoolStrategy(size=4),
         fn_constructor_kwargs={
-            "model_name": "nvidia/llama-nemotron-rerank-1b-v2",
+            "model_name": "nvidia/llama-nemotron-rerank-vl-1b-v2",
             "query_column": "query",
             "text_column": "text",
             "score_column": "rerank_score",
@@ -70,7 +70,7 @@ from nemo_retriever.common.remote_auth import resolve_remote_api_key
 logger = logging.getLogger(__name__)
 
 _render_warned = False
-_DEFAULT_MODEL = "nvidia/llama-nemotron-rerank-1b-v2"
+_DEFAULT_MODEL = "nvidia/llama-nemotron-rerank-vl-1b-v2"
 _DEFAULT_RERANK_INVOKE_URL = "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking"
 _DEFAULT_VL_RERANK_INVOKE_URL = "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking"
 _DEFAULT_MAX_LENGTH = 512
@@ -208,7 +208,7 @@ def _rerank_via_endpoint(
         already end with ``/reranking``, ``/ranking``, or ``/rerank``.
     model_name:
         Model identifier sent to the remote endpoint (default
-        ``"nvidia/llama-nemotron-rerank-1b-v2"``).
+        ``"nvidia/llama-nemotron-rerank-vl-1b-v2"``).
     api_key:
         Bearer token for the remote endpoint (if required).
 
@@ -278,7 +278,7 @@ def rerank_hits(
         already end with ``/reranking``.
     model_name:
         Model identifier sent to the remote endpoint (default
-        ``"nvidia/llama-nemotron-rerank-1b-v2"``).
+        ``"nvidia/llama-nemotron-rerank-vl-1b-v2"``).
     api_key:
         Bearer token for the remote endpoint.
     max_length:
@@ -404,7 +404,7 @@ class NemotronRerankGPUActor(AbstractOperator, GPUOperator):
     """
     Ray Data-compatible stateful actor for cross-encoder reranking.
 
-    Initialises ``nvidia/llama-nemotron-rerank-1b-v2`` **once** per actor
+    Initialises ``nvidia/llama-nemotron-rerank-vl-1b-v2`` **once** per actor
     instance and reuses it across batches, avoiding repeated model loads.
 
     Each row in the input DataFrame is expected to have a *query* column and a
@@ -421,7 +421,7 @@ class NemotronRerankGPUActor(AbstractOperator, GPUOperator):
             num_gpus=1,
             compute=ray.data.ActorPoolStrategy(size=4),
             fn_constructor_kwargs={
-                "model_name": "nvidia/llama-nemotron-rerank-1b-v2",
+                "model_name": "nvidia/llama-nemotron-rerank-vl-1b-v2",
                 "query_column": "query",
                 "text_column": "text",
                 "score_column": "rerank_score",
@@ -433,7 +433,7 @@ class NemotronRerankGPUActor(AbstractOperator, GPUOperator):
     Parameters
     ----------
     model_name:
-        HuggingFace model ID (default ``"nvidia/llama-nemotron-rerank-1b-v2"``).
+        HuggingFace model ID (default ``"nvidia/llama-nemotron-rerank-vl-1b-v2"``).
     api_key:
         Bearer token for the remote endpoint.
     device:

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -91,7 +91,7 @@ class LocalRerankConfig(RichModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = False
-    model_name: str = "nvidia/llama-nemotron-rerank-1b-v2"
+    model_name: str = "nvidia/llama-nemotron-rerank-vl-1b-v2"
     backend: Literal["hf", "vllm"] = "vllm"
     gpu_memory_utilization: float = Field(default=0.5, gt=0, le=1)
     max_length: int = Field(default=512, ge=1, le=8192)
@@ -195,7 +195,7 @@ class NimEndpointsConfig(RichModel):
     rerank_model_name: str | None = Field(
         default=None,
         description=(
-            "Model identifier passed to rerank_invoke_url. Defaults to the " "Nemotron text reranker when omitted."
+            "Model identifier passed to rerank_invoke_url. Defaults to the " "Nemotron VL reranker when omitted."
         ),
     )
     audio_grpc_endpoint: str | None = Field(

--- a/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
+++ b/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
@@ -91,7 +91,7 @@ local_models:
   # when using a remote/NIM reranker configured under ``nim_endpoints``.
   rerank:
     enabled: false
-    model_name: nvidia/llama-nemotron-rerank-1b-v2
+    model_name: nvidia/llama-nemotron-rerank-vl-1b-v2
     backend: vllm
     gpu_memory_utilization: 0.5
     max_length: 512

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -1948,7 +1948,7 @@ async def query(request: Request) -> Response:
             if use_remote_reranker:
                 rerank_kwargs.update(
                     rerank_invoke_url=config.nim_endpoints.rerank_invoke_url,
-                    model_name=config.nim_endpoints.rerank_model_name or "nvidia/llama-nemotron-rerank-1b-v2",
+                    model_name=config.nim_endpoints.rerank_model_name or "nvidia/llama-nemotron-rerank-vl-1b-v2",
                     api_key=config.nim_endpoints.api_key or "",
                 )
             else:

--- a/nemo_retriever/tests/test_helm_rerank_endpoint.py
+++ b/nemo_retriever/tests/test_helm_rerank_endpoint.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for manual Helm service-reranker configuration."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from unittest import SkipTest, TestCase
+
+
+_RERANK_URL = "http://llama-nemotron-rerank-vl-1b-v2:8000/v1/ranking"
+_RERANK_MODEL = "nvidia/llama-nemotron-rerank-vl-1b-v2"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _helm_template(*args: str) -> subprocess.CompletedProcess[str]:
+    helm = shutil.which("helm")
+    if helm is None:
+        raise SkipTest("`helm` binary not available in this environment.")
+    return subprocess.run(
+        [
+            helm,
+            "template",
+            "retriever",
+            str(_repo_root() / "nemo_retriever/helm"),
+            "--set",
+            "ngcImagePullSecret.create=false",
+            "--set",
+            "ngcApiSecret.create=false",
+            *args,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+class HelmRerankEndpointTests(TestCase):
+    def test_values_expose_manual_rerank_configuration(self) -> None:
+        values = (_repo_root() / "nemo_retriever/helm/values.yaml").read_text(encoding="utf-8")
+        self.assertIn('rerankInvokeUrl: ""', values)
+        self.assertIn('rerankModelName: ""', values)
+
+    def test_explicit_rerank_values_render_into_service_config(self) -> None:
+        rendered = _helm_template(
+            "--api-versions",
+            "apps.nvidia.com/v1alpha1",
+            "--set",
+            f"serviceConfig.nimEndpoints.rerankInvokeUrl={_RERANK_URL}",
+            "--set",
+            f"serviceConfig.nimEndpoints.rerankModelName={_RERANK_MODEL}",
+        )
+        self.assertEqual(rendered.returncode, 0, rendered.stderr)
+        self.assertIn(f'rerank_invoke_url: "{_RERANK_URL}"', rendered.stdout)
+        self.assertIn(f'rerank_model_name: "{_RERANK_MODEL}"', rendered.stdout)
+
+    def test_enabling_rerank_nim_does_not_auto_wire_service_config(self) -> None:
+        rendered = _helm_template(
+            "--api-versions",
+            "apps.nvidia.com/v1alpha1",
+            "--set",
+            "nimOperator.rerankqa.enabled=true",
+        )
+        self.assertEqual(rendered.returncode, 0, rendered.stderr)
+        self.assertIn("rerank_invoke_url: null", rendered.stdout)
+        self.assertIn("rerank_model_name: null", rendered.stdout)

--- a/nemo_retriever/tests/test_nemotron_rerank_v2.py
+++ b/nemo_retriever/tests/test_nemotron_rerank_v2.py
@@ -565,7 +565,7 @@ class TestRerankViaEndpoint:
 class TestNemotronRerankActor:
     """Test the Ray Data-compatible actor."""
 
-    def test_cpu_actor_defaults_to_hosted_text_endpoint(self, monkeypatch):
+    def test_cpu_actor_defaults_to_hosted_vl_endpoint(self, monkeypatch):
         from nemo_retriever.operators.rerank import NemotronRerankCPUActor
 
         monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
@@ -576,10 +576,10 @@ class TestNemotronRerankActor:
         assert actor._model is None
         assert actor._kwargs["api_key"] == "nvapi-test"
         assert actor._kwargs["rerank_invoke_url"] == (
-            "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking"
+            "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking"
         )
 
-    def test_cpu_actor_defaults_to_hosted_vl_endpoint(self, monkeypatch):
+    def test_cpu_actor_uses_hosted_vl_endpoint_for_explicit_vl_model(self, monkeypatch):
         from nemo_retriever.operators.rerank import NemotronRerankCPUActor
 
         monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")

--- a/nemo_retriever/tests/test_service_query_rerank.py
+++ b/nemo_retriever/tests/test_service_query_rerank.py
@@ -110,6 +110,49 @@ def test_reranked_query_uses_main_service_orchestration(monkeypatch, tmp_path) -
     }
 
 
+def test_reranked_query_defaults_remote_model_to_vl(monkeypatch, tmp_path) -> None:
+    _configure_noop_workers(monkeypatch)
+    seen: dict[str, object] = {}
+
+    class _Response:
+        status_code = 200
+        content = json.dumps({"results": [{"hits": [{"text": "first"}]}]}).encode()
+
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url, **kwargs):
+            return _Response()
+
+    def _rerank(query, hits, **kwargs):
+        seen["kwargs"] = kwargs
+        return hits
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+    monkeypatch.setattr("nemo_retriever.operators.rerank.rerank_hits", _rerank)
+    config = ServiceConfig(
+        mode="standalone",
+        auth=AuthConfig(allow_unscoped_dev=True),
+        logging=LoggingConfig(file=str(tmp_path / "service.log")),
+        pipeline=PipelinePoolConfig(realtime_workers=1, batch_workers=1),
+        vectordb=VectorDbConfig(enabled=True, vectordb_url="http://vectordb:7671"),
+        nim_endpoints=NimEndpointsConfig(rerank_invoke_url="http://reranker:8080"),
+    )
+
+    with TestClient(create_app(config)) as client:
+        response = client.post("/v1/query", json={"query": "revenue", "top_k": 1, "rerank": True})
+
+    assert response.status_code == 200
+    assert seen["kwargs"]["model_name"] == "nvidia/llama-nemotron-rerank-vl-1b-v2"
+
+
 def test_reranked_query_requires_main_service_reranker(monkeypatch, tmp_path) -> None:
     _configure_noop_workers(monkeypatch)
     config = ServiceConfig(


### PR DESCRIPTION
## Description

Adds a durable Helm configuration path for service-side query reranking through `serviceConfig.nimEndpoints.rerankInvokeUrl` and `rerankModelName`.

The optional `nimOperator.rerankqa` NIM remains opt-in and is not auto-wired. Reranker defaults now use the VL model so service, library, Helm, and documentation behavior align.

Adds Helm rendering and service reranking regression coverage, plus Helm and published extraction documentation.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.