### PR TITLE
Fail ingestion without input sources

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -23,6 +23,20 @@ not parse them as stable codes. The stable text-generation codes documented in
 [One-shot text generation](#one-shot-text-generation) apply to generation
 operator output columns, not to document extraction.
 
+### Configure at least one input source
+
+Before you call `.ingest()`, configure at least one input source by calling
+`.files()`, `.texts()`, or `.buffers()` with a nonempty value. Omitting input
+configuration or passing an empty collection raises `ValueError` before
+pipeline execution.
+
+A configured source can legitimately produce blank text or an empty result.
+For example, OCR can find no text on an image-only page. This outcome does not
+raise the missing-input error.
+
+A nonempty optional glob passed to `.files()` also counts as a configured
+source. If it matches no files, `.ingest()` can return an empty result.
+
 ### Select a supported extraction method
 
 `ExtractParams` validates `method` when you construct the model. For PDF

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -25,17 +25,18 @@ operator output columns, not to document extraction.
 
 ### Configure at least one input source
 
-Before you call `.ingest()`, configure at least one input source by calling
-`.files()`, `.texts()`, or `.buffers()` with a nonempty value. Omitting input
-configuration or passing an empty collection raises `ValueError` before
-pipeline execution.
+Before you call `.ingest()`, `.ingest_stream()`, or `.aingest_stream()`,
+configure at least one input source by calling `.files()`, `.texts()`, or
+`.buffers()` with a nonempty value. Omitting input configuration or passing an
+empty collection raises `ValueError` before pipeline execution.
 
 A configured source can legitimately produce blank text or an empty result.
 For example, OCR can find no text on an image-only page. This outcome does not
 raise the missing-input error.
 
 A nonempty optional glob passed to `.files()` also counts as a configured
-source. If it matches no files, `.ingest()` can return an empty result.
+source. If it matches no files, `.ingest()` can return an empty result, and the
+streaming methods can yield no results.
 
 ### Select a supported extraction method
 

--- a/nemo_retriever/src/nemo_retriever/ingestor/core.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/core.py
@@ -102,6 +102,13 @@ class ingestor:
             f"{self.__class__.__name__}.{method_name}() is not implemented yet " f"(run_mode={self.RUN_MODE})."
         )
 
+    def _validate_input_sources(self, inline_texts: Sequence[str] | None) -> None:
+        if self._documents or self._buffers or inline_texts:
+            return
+        raise ValueError(
+            "No input sources configured. Call files(), texts(), or buffers() with at least one source before ingest()."
+        )
+
     def files(self, documents: Union[str, List[str]]) -> "ingestor":
         """Add document paths/URIs for processing."""
         self._not_implemented("files")

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -777,6 +777,7 @@ class GraphIngestor(ingestor):
             service-style ``(source, error)`` tuples.
         """
         return_failures = self._resolve_return_failures(params, kwargs)
+        self._validate_input_sources(self._inline_texts)
         if not self._documents and not self._buffers and is_blank_inline_corpus(self._inline_texts):
             result = empty_text_chunks_df()
             if self._run_mode == "batch":

--- a/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
@@ -1190,6 +1190,7 @@ class ServiceIngestor(ingestor):
             self._resolve_execute_flags(params, kwargs)
         )
         del params, kwargs
+        self._validate_input_sources(self._inline_texts)
         if not self._documents and not self._buffers and is_blank_inline_corpus(self._inline_texts):
             self._document_ids.clear()
             self._last_run_elapsed_s = 0.0

--- a/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
@@ -1610,6 +1610,7 @@ class ServiceIngestor(ingestor):
 
     def _collect_inputs(self) -> list[UploadInput]:
         """Gather filesystem and in-memory inputs for the service client."""
+        self._validate_input_sources(self._inline_texts)
         if not self._documents and not self._buffers and is_blank_inline_corpus(self._inline_texts):
             return []
 

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -68,6 +68,8 @@ def _effective_graph_node_names(ingestor: GraphIngestor) -> list[str]:
 
 
 def _run_graph_ingest_with_result(ingestor: GraphIngestor, result, monkeypatch, **ingest_kwargs):
+    if not ingestor._documents and not ingestor._buffers and not ingestor._inline_texts:
+        ingestor.files(["document.pdf"])
     monkeypatch.setattr(ingestor, "_plan_default_extraction_branches", lambda: None)
     monkeypatch.setattr(
         ingestor,
@@ -123,6 +125,46 @@ def test_create_ingestor_rejects_unknown_kwargs() -> None:
 def test_create_ingestor_rejects_unknown_run_modes() -> None:
     with pytest.raises(ValueError, match="supports run modes"):
         create_ingestor(run_mode="parallel")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("run_mode", ["inprocess", "batch", "service"])
+@pytest.mark.parametrize("input_method", [None, "files", "texts", "buffers"])
+def test_ingest_requires_input_sources(
+    run_mode: str,
+    input_method: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    create_kwargs = {"run_mode": run_mode}
+    if run_mode == "service":
+        create_kwargs["base_url"] = "http://retriever.example"
+    ingestor = create_ingestor(**create_kwargs)
+    if input_method is not None:
+        getattr(ingestor, input_method)([])
+
+    if run_mode == "batch":
+        monkeypatch.setattr(
+            ingestor,
+            "_ensure_batch_runtime",
+            lambda: pytest.fail("input validation must run before starting Ray"),
+        )
+    elif run_mode == "service":
+        monkeypatch.setattr(
+            ingestor,
+            "ingest_stream",
+            lambda **kwargs: pytest.fail("input validation must run before contacting the service"),
+        )
+    else:
+        monkeypatch.setattr(
+            ingestor,
+            "_execute_single_graph",
+            lambda *args, **kwargs: pytest.fail("input validation must run before executing the graph"),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=r"No input sources configured\. Call files\(\), texts\(\), or buffers\(\) with at least one source",
+    ):
+        ingestor.extract(params=ExtractParams(extract_text=True)).ingest()
 
 
 def test_texts_accepts_scalar(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/nemo_retriever/tests/test_service_ingest_async.py
+++ b/nemo_retriever/tests/test_service_ingest_async.py
@@ -81,7 +81,7 @@ def _fake_materialize_completed_document(
 @pytest.fixture
 def stub_ingestor() -> Iterator[ServiceIngestor]:
     """A ``ServiceIngestor`` whose stream yields a fixed event sequence."""
-    ing = ServiceIngestor(base_url="http://example:7670")
+    ing = ServiceIngestor(base_url="http://example:7670").files(["a.pdf", "b.pdf"])
     events = _stub_event_sequence()
     stream_calls: list[dict[str, Any]] = []
     setattr(ing, "_stream_calls", stream_calls)

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -166,7 +166,6 @@ def test_service_empty_inline_list_preserves_explicit_extraction_mode(
     assert ingestor._pipeline_payload()["extraction_mode"] == expected_mode
 
 
-@pytest.mark.parametrize("values", [[], ["", "  \n"]])
 @pytest.mark.parametrize(
     ("result_schema", "expected_columns"),
     [
@@ -174,13 +173,12 @@ def test_service_empty_inline_list_preserves_explicit_extraction_mode(
         ("compact", ["text", "source_id", "element_type", "page_number"]),
     ],
 )
-def test_service_inline_empty_corpus_short_circuits_with_schema(
-    values: list[str],
+def test_service_blank_inline_corpus_short_circuits_with_schema(
     result_schema: str,
     expected_columns: list[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    ingestor = ServiceIngestor(base_url="http://retriever.example").texts(values).embed()
+    ingestor = ServiceIngestor(base_url="http://retriever.example").texts(["", "  \n"]).embed()
     monkeypatch.setattr(
         ingestor,
         "ingest_stream",

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -16,6 +16,7 @@ Covers three layers:
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -192,6 +193,22 @@ def test_service_blank_inline_corpus_short_circuits_with_schema(
     assert result.dataframe.empty
     assert result.dataframe.columns.tolist() == expected_columns
     assert ingestor._collect_inputs() == []
+
+
+@pytest.mark.parametrize("input_method", [None, "files", "texts", "buffers"])
+def test_service_streaming_ingest_requires_input_sources(input_method: str | None) -> None:
+    ingestor = ServiceIngestor(base_url="http://retriever.example")
+    if input_method is not None:
+        getattr(ingestor, input_method)([])
+
+    with pytest.raises(ValueError, match="No input sources configured"):
+        ingestor.ingest_stream()
+
+    async def consume_async_stream() -> list[dict]:
+        return [event async for event in ingestor.aingest_stream()]
+
+    with pytest.raises(ValueError, match="No input sources configured"):
+        asyncio.run(consume_async_stream())
 
 
 def test_legacy_pipeline_payload_disables_bulk_result_payloads() -> None:

--- a/nemo_retriever/tests/test_service_save_to_disk.py
+++ b/nemo_retriever/tests/test_service_save_to_disk.py
@@ -207,7 +207,7 @@ def _result_row(document_id: str) -> dict[str, Any]:
 
 
 def test_ingest_reuses_one_result_client_across_documents(monkeypatch: pytest.MonkeyPatch) -> None:
-    ing = ServiceIngestor(base_url="http://example:7670")
+    ing = ServiceIngestor(base_url="http://example:7670").files(["a.pdf", "b.pdf"])
     monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a", "doc-b")))
     requests: list[httpx.Request] = []
     clients: list[httpx.Client] = []
@@ -241,7 +241,7 @@ def test_ingest_retries_transient_result_fetch_on_fresh_client(
     monkeypatch: pytest.MonkeyPatch,
     error_type: type[Exception],
 ) -> None:
-    ing = ServiceIngestor(base_url="http://example:7670")
+    ing = ServiceIngestor(base_url="http://example:7670").files(["a.pdf"])
     monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a")))
     clients: list[httpx.Client] = []
 
@@ -269,7 +269,7 @@ def test_ingest_retries_transient_result_fetch_on_fresh_client(
 
 
 def test_ingest_exhausted_result_retry_remains_visible(monkeypatch: pytest.MonkeyPatch) -> None:
-    ing = ServiceIngestor(base_url="http://example:7670")
+    ing = ServiceIngestor(base_url="http://example:7670").files(["a.pdf"])
     monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a")))
     clients: list[httpx.Client] = []
 
@@ -292,7 +292,7 @@ def test_ingest_exhausted_result_retry_remains_visible(monkeypatch: pytest.Monke
 
 
 def test_ingest_does_not_retry_http_status_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    ing = ServiceIngestor(base_url="http://example:7670")
+    ing = ServiceIngestor(base_url="http://example:7670").files(["a.pdf"])
     monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a")))
     clients: list[httpx.Client] = []
 


### PR DESCRIPTION
## Summary

- fail fast when `ingest()` is called without a source or with an empty `files()`, `texts()`, or `buffers()` collection
- apply the same validation to in-process, batch, and service run modes before graph execution, Ray startup, or service contact
- preserve valid blank-content behavior, including OCR/image sources that produce no text and optional globs that match no files
- document the empty-input versus empty-output contract

## Root cause

The ingestor initialized file and buffer inputs as empty collections but did not validate them before execution. Missing inputs and empty file or buffer collections therefore reached the zero-row pipeline and returned a successful empty DataFrame. Inline text had a separate blank-corpus short circuit, which also treated `texts([])` as successful.

## User impact

Configuration errors now surface as an actionable `ValueError` instead of appearing to complete successfully without ingesting documents. Sources that are present but legitimately produce blank text or no result rows remain supported.

## Validation

- `uv run --no-dev --extra dev pytest -q tests/test_ingest_interface.py tests/test_service_pipeline_spec.py` (`163 passed`, `2 deselected`)
- exact issue reproduction now raises the expected `ValueError`
- focused pre-commit hooks passed for all six changed files
- `uv run --with-requirements requirements.txt python -m mkdocs build --strict --config-file mkdocs.yml`
