### PR TITLE
Fix Helm service URL port routing

### DIFF
--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -316,11 +316,22 @@ To run self-hosted Parakeet for [audio and video extraction](https://github.com/
 
 The retriever service picks up the in-cluster ASR endpoint when `nimOperator.audio` is enabled; refer to [NIM Operator sub-stack](#nim-operator-sub-stack).
 
+### Service networking
+
+| Path | Default | Notes |
+|------|---------|-------|
+| `networkService.port` | `7670` | Kubernetes Service port. The chart uses this port for generated Service DNS URLs. |
+| `serviceConfig.server.port` | `7670` | Retriever service container listener port. |
+
+You can set these values independently. When they differ, Kubernetes Services
+listen on `networkService.port` and route to the container listener on
+`serviceConfig.server.port`.
+
 ### Service configuration (rendered into `retriever-service.yaml`)
 
 | Path                                              | Default | Notes |
 |---------------------------------------------------|---------|-------|
-| `serviceConfig.server.port`                       | `7670`  | Container + Service port. |
+| `serviceConfig.server.port`                       | `7670`  | Retriever service container listener port. Refer to [Service networking](#service-networking). |
 | `serviceConfig.pipeline.realtimeWorkers`          | `24`    | Per-pod realtime worker count. |
 | `serviceConfig.pipeline.batchWorkers`             | `48`    | Per-pod batch worker count. Refer to [Timeouts and alleviating ingest failures](#timeouts-and-alleviating-ingest-failures) if embed or pool errors appear under load. |
 | `serviceConfig.resources.maxUploadBytes`          | `500000000` | Maximum upload file size in bytes; requests exceeding the limit are rejected before buffering. |

--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -178,7 +178,7 @@ pipeline:
   batch_queue_size: {{ .Values.serviceConfig.pipeline.batchQueueSize }}
 
 work_queue:
-  gateway_url: "http://{{ .gatewaySvc }}:{{ .Values.serviceConfig.server.port }}"
+  gateway_url: "http://{{ .gatewaySvc }}:{{ .Values.networkService.port }}"
   spool_directory: {{ .Values.serviceConfig.workQueue.spoolDirectory | quote }}
   spool_limit_bytes: {{ .Values.serviceConfig.workQueue.spoolLimitBytes }}
   claim_timeout_s: {{ .Values.serviceConfig.workQueue.claimTimeoutS }}
@@ -222,7 +222,7 @@ vectordb:
 
 {{- $vectordbSvc := printf "%s-vectordb" (include "nemo-retriever.fullname" .) -}}
 {{- $vectordbPort := ((.Values.topology.vectordb).port | default 7671) -}}
-{{- $gatewaySvc := printf "%s-gateway" (include "nemo-retriever.fullname" .) -}}
+{{- $gatewaySvc := include "nemo-retriever.fullname" . -}}
 {{- if eq .Values.topology.mode "standalone" }}
 # =========================================================================
 # Standalone mode — single ConfigMap with mode: standalone
@@ -243,8 +243,9 @@ data:
 # =========================================================================
 {{- $fullname := include "nemo-retriever.fullname" . -}}
 {{- $realtimeSvc := printf "%s-realtime" $fullname -}}
+{{- $gatewaySvc = printf "%s-gateway" $fullname -}}
 {{- $batchSvc := printf "%s-batch" $fullname -}}
-{{- $port := .Values.serviceConfig.server.port -}}
+{{- $port := .Values.networkService.port -}}
 {{- $roles := list "gateway" "realtime" "batch" }}
 {{- range $role := $roles }}
 ---

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -209,6 +209,7 @@ service:
 # =============================================================================
 networkService:
   type: NodePort
+  # Kubernetes Service port, including chart-generated Service-DNS URLs.
   port: 7670
   # Optional: override the targetPort name. Should match container port name.
   targetPort: http
@@ -531,6 +532,7 @@ topology:
 serviceConfig:
   server:
     host: "0.0.0.0"
+    # Retriever process listener and named container port.
     port: 7670
 
   logging:

--- a/nemo_retriever/tests/test_helm_work_queue.py
+++ b/nemo_retriever/tests/test_helm_work_queue.py
@@ -44,7 +44,61 @@ def test_split_work_queue_identity_spool_and_gateway_url() -> None:
     )
 
 
+def test_chart_service_urls_use_network_service_port() -> None:
+    documents = _render(
+        "--set",
+        "topology.mode=split",
+        "--set",
+        "networkService.port=18080",
+        "--set",
+        "serviceMonitor.autoEnableInSplitMode=false",
+    )
+    services = [document for document in documents if document.get("kind") == "Service"]
+    assert len(services) == 3
+    assert all(service["spec"]["ports"][0]["port"] == 18080 for service in services)
+
+    configs = {
+        document["metadata"]["labels"]["app.kubernetes.io/component"]: document["data"]["retriever-service.yaml"]
+        for document in documents
+        if document.get("kind") == "ConfigMap" and "retriever-service.yaml" in document.get("data", {})
+    }
+    assert 'realtime_url: "http://shared-results-test-nemo-retriever-realtime:18080"' in configs["gateway"]
+    assert 'batch_url: "http://shared-results-test-nemo-retriever-batch:18080"' in configs["gateway"]
+    assert all(
+        'gateway_url: "http://shared-results-test-nemo-retriever-gateway:18080"' in config
+        for config in configs.values()
+    )
+    assert all(
+        next(
+            container
+            for container in deployment["spec"]["template"]["spec"]["containers"]
+            if container["name"] == "nemo-retriever"
+        )["ports"][0]["containerPort"]
+        == 7670
+        for deployment in _service_deployments(documents)
+    )
+
+
+def test_standalone_work_queue_gateway_url_uses_service_port_and_name() -> None:
+    documents = _render("--set", "networkService.port=18080")
+    service = next(document for document in documents if document.get("kind") == "Service")
+    assert service["metadata"]["name"] == "shared-results-test-nemo-retriever"
+    assert service["spec"]["ports"][0]["port"] == 18080
+
+    config = next(
+        document["data"]["retriever-service.yaml"]
+        for document in documents
+        if document.get("kind") == "ConfigMap" and "retriever-service.yaml" in document.get("data", {})
+    )
+    assert 'gateway_url: "http://shared-results-test-nemo-retriever:18080"' in config
+    deployment = _service_deployments(documents)[0]
+    container = next(
+        item for item in deployment["spec"]["template"]["spec"]["containers"] if item["name"] == "nemo-retriever"
+    )
+    assert container["ports"][0]["containerPort"] == 7670
 def test_split_gateway_spool_size_limit_preserves_sub_gib_bytes() -> None:
+
+
     documents = _render(
         "--set",
         "topology.mode=split",

--- a/nemo_retriever/tests/test_helm_work_queue.py
+++ b/nemo_retriever/tests/test_helm_work_queue.py
@@ -96,9 +96,9 @@ def test_standalone_work_queue_gateway_url_uses_service_port_and_name() -> None:
         item for item in deployment["spec"]["template"]["spec"]["containers"] if item["name"] == "nemo-retriever"
     )
     assert container["ports"][0]["containerPort"] == 7670
+
+
 def test_split_gateway_spool_size_limit_preserves_sub_gib_bytes() -> None:
-
-
     documents = _render(
         "--set",
         "topology.mode=split",

--- a/nemo_retriever/tests/test_helm_work_queue.py
+++ b/nemo_retriever/tests/test_helm_work_queue.py
@@ -53,8 +53,17 @@ def test_chart_service_urls_use_network_service_port() -> None:
         "--set",
         "serviceMonitor.autoEnableInSplitMode=false",
     )
-    services = [document for document in documents if document.get("kind") == "Service"]
-    assert len(services) == 3
+    services = [
+        document
+        for document in documents
+        if document.get("kind") == "Service"
+        and document["metadata"]["labels"].get("app.kubernetes.io/component") in {"gateway", "realtime", "batch"}
+    ]
+    assert {service["metadata"]["labels"]["app.kubernetes.io/component"] for service in services} == {
+        "gateway",
+        "realtime",
+        "batch",
+    }
     assert all(service["spec"]["ports"][0]["port"] == 18080 for service in services)
 
     configs = {
@@ -81,7 +90,11 @@ def test_chart_service_urls_use_network_service_port() -> None:
 
 def test_standalone_work_queue_gateway_url_uses_service_port_and_name() -> None:
     documents = _render("--set", "networkService.port=18080")
-    service = next(document for document in documents if document.get("kind") == "Service")
+    service = next(
+        document
+        for document in documents
+        if document.get("kind") == "Service" and document["metadata"]["name"] == "shared-results-test-nemo-retriever"
+    )
     assert service["metadata"]["name"] == "shared-results-test-nemo-retriever"
     assert service["spec"]["ports"][0]["port"] == 18080
 


### PR DESCRIPTION
## Description

Fix chart-generated URLs that target NeMo Retriever Kubernetes Services so they use `networkService.port`, while preserving `serviceConfig.server.port` as the container listener port.

This updates split gateway backend URLs and work-queue gateway URLs. It also corrects the standalone work-queue URL to use the standalone Service name and port.

Adds divergent-port Helm render coverage and clarifies the values in the chart README. The tests select only the gateway, realtime, and batch retriever Services so chart-owned OpenTelemetry and Zipkin Services do not affect the assertions.

## Validation:
- `helm lint nemo_retriever/helm --set topology.mode=split --set networkService.port=18080 --set nims.enabled=false --set serviceConfig.vectordb.enabled=false`
- Split and standalone `helm template` renders with `networkService.port=18080`
- `uv run pytest tests/test_helm_work_queue.py -q` — 12 passed
- `uvx black==25.9.0 --check --line-length=120 tests/test_helm_work_queue.py`
- `git diff --check`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.