### PR TITLE
fix: limit batch stage error scans

### DIFF
--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -91,6 +91,7 @@ _REMOTE_EMBED_ENDPOINT_FIELDS = ("embedding_endpoint", "embed_invoke_url")
 _DEFAULT_PAGE_ELEMENTS_COLUMN = "page_elements_v3"
 _DEFAULT_EMBED_COLUMN = "text_embeddings_1b_v2"
 _ERROR_MESSAGE_LIMIT = 256
+_SOURCE_IDENTIFIER_COLUMNS = ("document_id", "path", "source_path", "metadata", "source_id", "source_name")
 logger = logging.getLogger(__name__)
 _HTTP_STATUS_FIELDS: tuple[str, ...] = ("status_code", "http_status", "status", "code")
 _EXPLICIT_MODE_INPUT_TYPES: dict[str, frozenset[str]] = {
@@ -1201,14 +1202,15 @@ class GraphIngestor(ingestor):
             return []
         requested_columns = list(columns) if columns is not None else None
 
-        if callable(iter_batches):
-            batches = (arrow_table_to_pandas(batch_df) for batch_df in iter_batches(batch_format="pyarrow"))
-        else:
-            batches = (batch,)
+        batches = iter_batches(batch_format="pyarrow") if callable(iter_batches) else (batch,)
 
         records: list[dict[str, Any]] = []
-        for batch_df in batches:
-            available_columns = getattr(batch_df, "columns", None)
+        for raw_batch in batches:
+            available_columns = (
+                getattr(raw_batch, "column_names", None)
+                if callable(iter_batches)
+                else getattr(raw_batch, "columns", None)
+            )
             if available_columns is None:
                 continue
             target_columns = (
@@ -1216,11 +1218,24 @@ class GraphIngestor(ingestor):
                 if requested_columns is None
                 else [c for c in requested_columns if c in available_columns]
             )
-            # ``iterrows`` materializes the full frame through NumPy, which is
-            # unsafe for Ray pickled-object columns containing empty arrays.
-            row_values = batch_df.itertuples(index=False, name=None)
-            for row_index, values in zip(batch_df.index, row_values):
-                row = dict(zip(available_columns, values))
+            if not target_columns:
+                continue
+            # Finalization only needs diagnostic payloads and source context.
+            # Reading the full frame can iterate unrelated Arrow-backed image
+            # columns that pandas cannot safely materialize row by row.
+            scan_columns = list(
+                dict.fromkeys(
+                    [*target_columns, *(column for column in _SOURCE_IDENTIFIER_COLUMNS if column in available_columns)]
+                )
+            )
+            batch_df = (
+                arrow_table_to_pandas(raw_batch.select(scan_columns))
+                if callable(iter_batches)
+                else raw_batch.loc[:, scan_columns]
+            )
+            column_values = {column: batch_df[column].array for column in scan_columns}
+            for row_position, row_index in enumerate(batch_df.index):
+                row = {column: values[row_position] for column, values in column_values.items()}
                 source_identifier = cls._source_identifier_from_row(row, row_index)
                 for column in target_columns:
                     for record in cls._iter_stage_errors_from_value(row[column]):

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -977,3 +977,41 @@ def test_batch_ingest_finalization_handles_ray_pickled_object_arrays(
         assert records[0]["source_identifier"] == "second.pdf"
         assert records[0]["column"] == "page_elements_v3"
         assert records[0]["path"] == "error"
+
+
+def test_batch_ingest_finalization_skips_unrelated_arrow_extension_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = pa.Table.from_arrays(
+        [
+            pa.array(["first.pdf"]),
+            pa.array([{"timing": None, "error": None}]),
+            pa.array([[{"stored_image_uri": "file:///tmp/stored-images/first.png"}]]),
+        ],
+        names=["path", "page_elements_v3", "images"],
+    )
+    batch_df = table.to_pandas(types_mapper=pd.ArrowDtype)
+    assert pa.types.is_list(batch_df["images"].dtype.pyarrow_dtype)
+
+    original_iter = pd.arrays.ArrowExtensionArray.__iter__
+
+    def fail_for_arrow_list_column(values):
+        # Reproduce the RC3 failure without requiring the customer NIM output:
+        # only whole-column iteration of the stored image payload is invalid.
+        if pa.types.is_list(values.dtype.pyarrow_dtype):
+            raise pa.ArrowIndexError("index with value of 1 is out-of-bounds for array of length 1")
+        return original_iter(values)
+
+    monkeypatch.setattr(pd.arrays.ArrowExtensionArray, "__iter__", fail_for_arrow_list_column)
+    ingestor = GraphIngestor(run_mode="batch").extract(
+        page_elements_invoke_url="http://remote.example/v1/page-elements",
+        extract_text=False,
+        extract_images=True,
+        extract_tables=False,
+        extract_charts=False,
+        extract_infographics=False,
+    )
+
+    result = _run_graph_ingest_with_result(ingestor, batch_df, monkeypatch)
+
+    assert result is batch_df


### PR DESCRIPTION
## Summary

- Limit batch stage-error finalization to configured diagnostic and source-identifier columns.
- Avoid full-frame pandas row iteration over unrelated Arrow-backed image payloads.
- Add regression coverage for the RC3 `ArrowIndexError` failure.

## Root cause

PR #2481 replaced `iterrows()` with `itertuples()` to avoid NumPy reshaping of Ray pickled-object columns. `itertuples()` still eagerly iterates every DataFrame extension column, including stored `images` payloads that are unrelated to the configured remote-stage error scan. A successful extract/store pipeline can therefore fail during result finalization.

The finalizer now projects only the requested diagnostic columns and source context before Arrow-to-pandas conversion, then reads those columns positionally. The returned result remains unchanged and genuine stage errors are still reported.

## Validation

- Exact RC3 regression: failed before the fix with `pyarrow.lib.ArrowIndexError`, passes after it.
- PyArrow 24.0.0 / Ray 2.57.0 focused ingest and store tests: 74 passed, 2 deselected.
- Full retriever unit suite: 3,199 passed, 142 skipped, 12 deselected, 26 subtests passed.
- Black, Flake8, and `git diff --check`: passed.
