### PR TITLE
fix(service): separate liveness from readiness

### DIFF
--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -22,6 +22,11 @@ Build and run the NeMo Retriever service image with the [Docker service image gu
 3. **Published Library Helm charts (supported):** cluster install and upgrade procedures are covered in [About getting started](getting-started-about.md) — use alongside the NeMo Retriever chart README for your release
 4. [Environment variables](environment-config.md) and [Troubleshoot](troubleshoot.md) as needed
 
+The Helm chart uses `GET /v1/live` for startup and liveness probes and
+`GET /v1/health` for readiness. Both endpoints are unauthenticated. In split
+topology, `/v1/health` returns HTTP `503` when the required realtime or batch
+worker is unavailable, so Kubernetes removes the gateway from Service endpoints.
+Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes).
 **Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are auto-wired into the retriever service. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, and **Parakeet ASR** are optional and not auto-wired. For a minimal GPU footprint, disable optional keys you do not need (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims) and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 
 For audio and video extraction in Kubernetes, refer to [Audio and video](audio-video.md).

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -306,6 +306,18 @@ that path — use a prebuilt service image instead; refer to [Audio and video on
 For air-gapped clusters, refer to [Deployment options — Air-gapped and disconnected deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/deployment-options/#air-gapped-deployment).
 
 ### Audio and video (Parakeet ASR) { #audio-video-parakeet }
+### Health probes
+
+The service exposes unauthenticated health endpoints for Kubernetes probes:
+
+| Endpoint | Purpose | Default Helm use |
+| --- | --- | --- |
+| `GET /v1/live` | Shallow process liveness. The endpoint does not check worker backends or wait for service readiness. | Startup and liveness probes. In split mode, the realtime and batch init containers use this endpoint while waiting for the gateway. |
+| `GET /v1/health` | Deep readiness. In split gateway mode, the endpoint checks the realtime and batch workers. It returns HTTP `503` when either required worker is unreachable or returns a non-2xx health response. | Readiness probe. |
+
+When a gateway returns HTTP `503` from `/v1/health`, Kubernetes removes it from the Service endpoints until its required workers are ready. The response includes backend health details to help diagnose the unavailable dependency.
+
+
 
 To run self-hosted Parakeet for [audio and video extraction](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/audio-video.md):
 

--- a/nemo_retriever/helm/templates/deployment.yaml
+++ b/nemo_retriever/helm/templates/deployment.yaml
@@ -287,11 +287,11 @@ spec:
               GATEWAY="{{ include "nemo-retriever.role.fullname" (dict "context" $ "role" "gateway") }}"
               PORT="{{ $.Values.networkService.port }}"
               echo "Waiting for gateway at ${GATEWAY}:${PORT} ..."
-              until wget -qO- --timeout=3 "http://${GATEWAY}:${PORT}/v1/health" >/dev/null 2>&1; do
-                echo "  gateway not ready — retrying in 3s"
+              until wget -qO- --timeout=3 "http://${GATEWAY}:${PORT}/v1/live" >/dev/null 2>&1; do
+                echo "  gateway not live — retrying in 3s"
                 sleep 3
               done
-              echo "Gateway is healthy — starting worker"
+              echo "Gateway is live — starting worker"
       {{- end }}
       containers:
         - name: nemo-retriever

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -148,12 +148,12 @@ service:
     count: 0
     productClass: ""
 
-  # Liveness, readiness, and startup probes.  All use the dedicated
-  # GET /v1/health endpoint which returns {"status":"ok"} with no auth.
+  # Startup and liveness use the shallow, unauthenticated GET /v1/live
+  # endpoint. Readiness uses the deep, unauthenticated GET /v1/health endpoint.
   livenessProbe:
     enabled: true
     httpGet:
-      path: /v1/health
+      path: /v1/live
       port: http
     initialDelaySeconds: 30
     periodSeconds: 30
@@ -173,7 +173,7 @@ service:
   startupProbe:
     enabled: true
     httpGet:
-      path: /v1/health
+      path: /v1/live
       port: http
     initialDelaySeconds: 5
     periodSeconds: 5
@@ -720,6 +720,7 @@ serviceConfig:
       key: scope-tokens.json
     headerName: "Authorization"
     bypassPaths:
+      - "/v1/live"
       - "/v1/health"
       - "/docs"
       - "/openapi.json"

--- a/nemo_retriever/src/nemo_retriever/service/app.py
+++ b/nemo_retriever/src/nemo_retriever/service/app.py
@@ -324,8 +324,14 @@ def create_app(config: ServiceConfig) -> FastAPI:
                 name="dashboard-static",
             )
 
-    @app.get("/v1/health", tags=["system"], summary="Liveness / readiness probe")
-    async def health() -> dict:
+    @app.get("/v1/live", tags=["system"], summary="Shallow liveness probe")
+    async def live() -> dict:
+        """Report whether this service process can answer HTTP requests."""
+        return {"status": "ok", "mode": config.mode}
+
+    @app.get("/v1/health", tags=["system"], summary="Deep readiness probe")
+    async def health() -> JSONResponse:
+        """Report whether this service role is ready to serve its workload."""
         base: dict = {"status": "ok", "mode": config.mode}
         if (
             config.mode in ("standalone", "realtime", "batch")
@@ -345,14 +351,22 @@ def create_app(config: ServiceConfig) -> FastAPI:
             from nemo_retriever.service.services.proxy import get_proxy
 
             proxy = get_proxy()
-            if proxy is not None:
+            if proxy is None:
+                base["status"] = "unavailable"
+                base["backends"] = {"status": "unavailable", "error": "Gateway proxy not initialised"}
+            else:
                 from nemo_retriever.service.services.pipeline_pool import PoolType
 
                 base["backends"] = {
                     "realtime": await proxy.check_backend(PoolType.REALTIME),
                     "batch": await proxy.check_backend(PoolType.BATCH),
                 }
-        return base
+                if any(backend["status"] != "ok" for backend in base["backends"].values()):
+                    base["status"] = "unavailable"
+
+        status_code = 200 if base["status"] == "ok" else 503
+
+        return JSONResponse(status_code=status_code, content=base)
 
     @app.exception_handler(Exception)
     async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:

--- a/nemo_retriever/src/nemo_retriever/service/app.py
+++ b/nemo_retriever/src/nemo_retriever/service/app.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import sys
@@ -357,9 +358,13 @@ def create_app(config: ServiceConfig) -> FastAPI:
             else:
                 from nemo_retriever.service.services.pipeline_pool import PoolType
 
+                realtime, batch = await asyncio.gather(
+                    proxy.check_backend(PoolType.REALTIME),
+                    proxy.check_backend(PoolType.BATCH),
+                )
                 base["backends"] = {
-                    "realtime": await proxy.check_backend(PoolType.REALTIME),
-                    "batch": await proxy.check_backend(PoolType.BATCH),
+                    "realtime": realtime,
+                    "batch": batch,
                 }
                 if any(backend["status"] != "ok" for backend in base["backends"].values()):
                     base["status"] = "unavailable"

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -315,7 +315,7 @@ class AuthConfig(RichModel):
     scope_token_file: str | None = None
     allow_unscoped_dev: bool = False
     header_name: str = "Authorization"
-    bypass_paths: list[str] = Field(default_factory=lambda: ["/v1/health", "/docs", "/openapi.json", "/redoc"])
+    bypass_paths: list[str] = Field(default_factory=lambda: ["/v1/live", "/v1/health", "/docs", "/openapi.json", "/redoc"])
 
 
 class MCPConfig(RichModel):

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -315,7 +315,9 @@ class AuthConfig(RichModel):
     scope_token_file: str | None = None
     allow_unscoped_dev: bool = False
     header_name: str = "Authorization"
-    bypass_paths: list[str] = Field(default_factory=lambda: ["/v1/live", "/v1/health", "/docs", "/openapi.json", "/redoc"])
+    bypass_paths: list[str] = Field(
+        default_factory=lambda: ["/v1/live", "/v1/health", "/docs", "/openapi.json", "/redoc"]
+    )
 
 
 class MCPConfig(RichModel):

--- a/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
+++ b/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
@@ -187,6 +187,7 @@ auth:
   api_token: null
   header_name: "Authorization"
   bypass_paths:
+    - "/v1/live"
     - "/v1/health"
     - "/docs"
     - "/openapi.json"

--- a/nemo_retriever/src/nemo_retriever/service/services/proxy.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/proxy.py
@@ -34,6 +34,8 @@ from nemo_retriever.service import tracing as tracing_module
 
 logger = logging.getLogger(__name__)
 
+_HEALTH_CHECK_TIMEOUT_SECONDS = 3.0
+
 
 def _inject_trace_context(headers: dict[str, str]) -> None:
     try:
@@ -210,7 +212,7 @@ class GatewayProxy:
         """Quick health probe against a backend."""
         client = self._client_for(pool_type)
         try:
-            resp = await client.get("/v1/health", timeout=5.0)
+            resp = await client.get("/v1/health", timeout=_HEALTH_CHECK_TIMEOUT_SECONDS)
             if 200 <= resp.status_code < 300:
                 return {"status": "ok", "code": resp.status_code}
             return {"status": "unhealthy", "code": resp.status_code}

--- a/nemo_retriever/src/nemo_retriever/service/services/proxy.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/proxy.py
@@ -211,7 +211,9 @@ class GatewayProxy:
         client = self._client_for(pool_type)
         try:
             resp = await client.get("/v1/health", timeout=5.0)
-            return {"status": "ok", "code": resp.status_code}
+            if 200 <= resp.status_code < 300:
+                return {"status": "ok", "code": resp.status_code}
+            return {"status": "unhealthy", "code": resp.status_code}
         except httpx.HTTPError as exc:
             return {"status": "unreachable", "error": str(exc)}
 

--- a/nemo_retriever/tests/test_service_health.py
+++ b/nemo_retriever/tests/test_service_health.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for service liveness and readiness endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from nemo_retriever.service.app import create_app
+from nemo_retriever.service.config import AuthConfig, GatewayConfig, ServiceConfig
+from nemo_retriever.service.services import proxy as proxy_module
+from nemo_retriever.service.services.pipeline_pool import PoolType
+from nemo_retriever.service.services.proxy import GatewayProxy
+
+
+class _HealthProxy:
+    def __init__(self, statuses: dict[str, dict[str, object]]) -> None:
+        self._statuses = statuses
+
+    async def check_backend(self, pool_type: PoolType) -> dict[str, object]:
+        return self._statuses[pool_type.value]
+
+
+class _HealthClient:
+    def __init__(self, status_code: int) -> None:
+        self._status_code = status_code
+
+    async def get(self, path: str, *, timeout: float) -> httpx.Response:
+        assert path == "/v1/health"
+        assert timeout == 5.0
+        return httpx.Response(self._status_code)
+
+
+def test_live_is_shallow_and_unauthenticated() -> None:
+    app = create_app(ServiceConfig(mode="gateway", auth=AuthConfig(enabled=True, api_token="secret")))
+
+    with TestClient(app) as client:
+        response = client.get("/v1/live")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "mode": "gateway"}
+
+
+@pytest.mark.parametrize(
+    ("statuses", "expected_status"),
+    [
+        (
+            {"realtime": {"status": "ok", "code": 200}, "batch": {"status": "ok", "code": 200}},
+            200,
+        ),
+        (
+            {
+                "realtime": {"status": "unreachable", "error": "connection refused"},
+                "batch": {"status": "ok", "code": 200},
+            },
+            503,
+        ),
+        (
+            {"realtime": {"status": "unhealthy", "code": 503}, "batch": {"status": "ok", "code": 200}},
+            503,
+        ),
+    ],
+)
+def test_gateway_health_reflects_required_backend_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    statuses: dict[str, dict[str, object]],
+    expected_status: int,
+) -> None:
+    monkeypatch.setattr(proxy_module, "get_proxy", lambda: _HealthProxy(statuses))
+    app = create_app(ServiceConfig(mode="gateway"))
+
+    with TestClient(app) as client:
+        response = client.get("/v1/health")
+
+    assert response.status_code == expected_status
+    assert response.json()["backends"] == statuses
+    assert response.json()["status"] == ("ok" if expected_status == 200 else "unavailable")
+
+
+@pytest.mark.parametrize("status_code", [400, 500, 503])
+def test_backend_non_success_response_is_unhealthy(status_code: int) -> None:
+    proxy = GatewayProxy.__new__(GatewayProxy)
+    proxy._config = GatewayConfig(realtime_url="http://realtime.test", batch_url="http://batch.test")  # noqa: SLF001
+    proxy._realtime = _HealthClient(status_code)  # noqa: SLF001
+
+    result = asyncio.run(proxy.check_backend(PoolType.REALTIME))
+
+    assert result == {"status": "unhealthy", "code": status_code}

--- a/nemo_retriever/tests/test_service_health.py
+++ b/nemo_retriever/tests/test_service_health.py
@@ -110,6 +110,7 @@ def test_gateway_health_checks_backends_concurrently(monkeypatch: pytest.MonkeyP
         "batch": {"status": "ok", "code": 200, "pool": "batch"},
     }
 
+
 @pytest.mark.parametrize("status_code", [400, 500, 503])
 def test_backend_non_success_response_is_unhealthy(status_code: int) -> None:
     proxy = GatewayProxy.__new__(GatewayProxy)

--- a/nemo_retriever/tests/test_service_health.py
+++ b/nemo_retriever/tests/test_service_health.py
@@ -27,6 +27,20 @@ class _HealthProxy:
         return self._statuses[pool_type.value]
 
 
+class _ConcurrentHealthProxy:
+    def __init__(self) -> None:
+        self._checks_started = 0
+        self._both_checks_started = asyncio.Event()
+
+    async def check_backend(self, pool_type: PoolType) -> dict[str, object]:
+        self._checks_started += 1
+        if self._checks_started == 2:
+            self._both_checks_started.set()
+
+        await asyncio.wait_for(self._both_checks_started.wait(), timeout=0.5)
+        return {"status": "ok", "code": 200, "pool": pool_type.value}
+
+
 class _HealthClient:
     def __init__(self, status_code: int) -> None:
         self._status_code = status_code
@@ -82,6 +96,19 @@ def test_gateway_health_reflects_required_backend_readiness(
     assert response.json()["backends"] == statuses
     assert response.json()["status"] == ("ok" if expected_status == 200 else "unavailable")
 
+
+def test_gateway_health_checks_backends_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(proxy_module, "get_proxy", _ConcurrentHealthProxy)
+    app = create_app(ServiceConfig(mode="gateway"))
+
+    with TestClient(app) as client:
+        response = client.get("/v1/health")
+
+    assert response.status_code == 200
+    assert response.json()["backends"] == {
+        "realtime": {"status": "ok", "code": 200, "pool": "realtime"},
+        "batch": {"status": "ok", "code": 200, "pool": "batch"},
+    }
 
 @pytest.mark.parametrize("status_code", [400, 500, 503])
 def test_backend_non_success_response_is_unhealthy(status_code: int) -> None:

--- a/nemo_retriever/tests/test_service_health.py
+++ b/nemo_retriever/tests/test_service_health.py
@@ -47,7 +47,7 @@ class _HealthClient:
 
     async def get(self, path: str, *, timeout: float) -> httpx.Response:
         assert path == "/v1/health"
-        assert timeout == 5.0
+        assert timeout == 3.0
         return httpx.Response(self._status_code)
 
 


### PR DESCRIPTION
## Description

Separates shallow process liveness from deep service readiness in the Retriever service.

- Adds unauthenticated `GET /v1/live` for startup, liveness, and split-worker gateway waits.
- Makes `GET /v1/health` return HTTP `503` when required gateway worker pools are unreachable or return non-2xx health responses.
- Checks required gateway backends concurrently and caps each internal health request at 3 seconds, leaving headroom within the 5-second Kubernetes readiness probe.
- Updates Helm probe defaults, authentication bypass paths, tests, and deployment documentation.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

- `uv run --project nemo_retriever pytest nemo_retriever/tests/test_service_health.py nemo_retriever/tests/test_service_proxy_tracing.py -q` (12 passed).
- Local pre-commit hooks passed. The latest CI pre-commit and Greptile checks passed.
- Rendered the split Helm chart and verified `/v1/live` is used for startup/liveness and worker gateway waits, while `/v1/health` is used for readiness.
- `git diff --check` and Python compilation passed.
- Strict MkDocs build was attempted but is blocked by an existing missing `THIRD_PARTY_LICENSES.md` snippet referenced by `docs/docs/license.md`.