### PR TITLE
docs: 6609699 .env not auto-loaded; 6609790 Helm NGC secrets; 6610201 LanceDB IVF small-corpus README

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -21,7 +21,7 @@ export NVIDIA_API_KEY="nvapi-..."
 
 On Windows PowerShell you can use `$env:NVIDIA_API_KEY = "nvapi-..."`.
 
-For a full list of related variables, refer to [Environment configuration variables](environment-config.md).
+The SDK and CLI do not load a `.env` file automatically. For a full list of related variables and how to source a `.env` file into the shell, refer to [Environment configuration variables](environment-config.md).
 
 When you call hosted object-detection NIMs (Page Elements, Table Structure, Graphic Elements) with images larger than about 180,000 characters (roughly 180 KB) inline, you also use this key with the [NVCF Asset API](https://docs.api.nvidia.com/cloud-functions/reference/createasset) to upload inputs and reference them by `asset_id`. Refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits) for the workflow and example code.
 

--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -63,4 +63,19 @@ When you create an NGC key, select the following for **Services Included**.
 
 ## Using your NGC key with Helm { #using-your-ngc-key-with-helm }
 
-Configure your key through the chart values described in the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md): for example `imagePullSecret.create` / `imagePullSecret.password` for pulls from `nvcr.io`, `nimApiKey` (inline value or `existingSecret`) for the retriever service, and `nims.ngcApiKey` when `nims.enabled=true`. Exact paths are versioned—use the **Secrets** section in that README and [`values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/values.yaml) as the source of truth.
+Set the chart values in the [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#secrets) section of the Helm chart README so the chart renders `ngc-secret` and `ngc-api`:
+
+- `ngcImagePullSecret.create` and `ngcImagePullSecret.password` create the `ngc-secret` dockerconfigjson Secret for pulls from `nvcr.io`.
+- `ngcApiSecret.create` and `ngcApiSecret.password` create the `ngc-api` Secret. The service container reads `NGC_API_KEY` and `NVIDIA_API_KEY` from that Secret when it exists.
+
+```bash
+helm install retriever ./nemo_retriever/helm \
+  --set ngcImagePullSecret.create=true \
+  --set ngcImagePullSecret.password=$NGC_API_KEY \
+  --set ngcApiSecret.create=true \
+  --set ngcApiSecret.password=$NGC_API_KEY
+```
+
+Helm accepts unknown `--set` paths without error. Paths such as `imagePullSecret`, `nimApiKey`, and `nims.ngcApiKey` do not create either Secret.
+
+For defaults and additional fields, refer to [`values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/values.yaml).

--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -66,7 +66,7 @@ When you create an NGC key, select the following for **Services Included**.
 Set the chart values in the [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#secrets) section of the Helm chart README so the chart renders `ngc-secret` and `ngc-api`:
 
 - `ngcImagePullSecret.create` and `ngcImagePullSecret.password` create the `ngc-secret` dockerconfigjson Secret for pulls from `nvcr.io`.
-- `ngcApiSecret.create` and `ngcApiSecret.password` create the `ngc-api` Secret. The service container reads `NGC_API_KEY` and `NVIDIA_API_KEY` from that Secret when it exists.
+- `ngcApiSecret.create` and `ngcApiSecret.password` create the `ngc-api` Secret with `NGC_API_KEY` and `NGC_CLI_API_KEY`. The service container maps `NGC_API_KEY` and `NVIDIA_API_KEY` from the Secret `NGC_API_KEY` key when the Secret exists.
 
 ```bash
 helm install retriever ./nemo_retriever/helm \

--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -60,6 +60,13 @@ When you create an NGC key, select the following for **Services Included**.
 
 ![Generate Personal Key](images/generate_personal_key.png)
 
+After you copy the key, set it in your environment. The Helm example below reads `$NGC_API_KEY`. If that variable is empty, Helm fails because `ngcImagePullSecret.password` is required when `create=true`.
+
+```bash
+export NGC_API_KEY="<ngc-personal-key>"
+```
+
+On Windows PowerShell you can use `$env:NGC_API_KEY = "<ngc-personal-key>"`.
 
 ## Using your NGC key with Helm { #using-your-ngc-key-with-helm }
 

--- a/docs/docs/extraction/environment-config.md
+++ b/docs/docs/extraction/environment-config.md
@@ -3,7 +3,7 @@
 The following are the environment variables that you can use to configure [NeMo Retriever Library](overview.md).
 Set them in the process environment before you run the public SDK or the `retriever` CLI. The SDK and CLI do not load a working-directory `.env` file automatically.
 
-If you keep values in a `.env` file, export that file into the current shell first:
+If you keep values in a `.env` file, source that file into the current shell first:
 
 ```bash
 set -a

--- a/docs/docs/extraction/environment-config.md
+++ b/docs/docs/extraction/environment-config.md
@@ -1,7 +1,17 @@
 # Environment Variables for NeMo Retriever Library
 
 The following are the environment variables that you can use to configure [NeMo Retriever Library](overview.md).
-You can specify these in a .env file in your working directory or directly as shell environment variables.
+Set them in the process environment before you run the public SDK or the `retriever` CLI. The SDK and CLI do not load a working-directory `.env` file automatically.
+
+If you keep values in a `.env` file, export that file into the current shell first:
+
+```bash
+set -a
+source .env
+set +a
+```
+
+On Windows PowerShell, set the variables in the session, for example `$env:NVIDIA_API_KEY = "nvapi-..."`. Refer to [Authentication and API keys](api-keys.md).
 
 
 ## General Environment Variables { #general-environment-variables }

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -223,8 +223,7 @@ ValueError: Configured max_batch_size (30) is larger than the model''s supported
 ```
 
 If you are using hardware where the embedding NIM uses the ONNX model profile,
-you must set `EMBEDDER_BATCH_SIZE=3` in your environment.
-You can set the variable in your .env file or directly in your environment.
+you must set `EMBEDDER_BATCH_SIZE=3` in the process environment (for example `export EMBEDDER_BATCH_SIZE=3`). The Library does not load a `.env` file automatically. Refer to [Environment variables](environment-config.md).
 
 
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -223,7 +223,7 @@ ValueError: Configured max_batch_size (30) is larger than the model''s supported
 ```
 
 If you are using hardware where the embedding NIM uses the ONNX model profile,
-you must set `EMBEDDER_BATCH_SIZE=3` in the process environment (for example `export EMBEDDER_BATCH_SIZE=3`). The Library does not load a `.env` file automatically. Refer to [Environment variables](environment-config.md).
+you must set `EMBEDDER_BATCH_SIZE=3` in the process environment. For example, run `export EMBEDDER_BATCH_SIZE=3`. The SDK and CLI do not load a `.env` file automatically. Refer to [Environment variables](environment-config.md).
 
 
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -187,7 +187,7 @@ that PDF or with your own file or directory.
 > 16 IVF partitions by default. When the table has fewer rows, the adapter
 > clamps that count to one less than the row count. An ingest that produces
 > 2 through 15 rows still builds an IVF index. A one-row table is stored
-> without a vector index and does not fail. An ingest that produces zero rows
+> without a vector index, and ingest succeeds. An ingest that produces zero rows
 > is a separate empty-result error. Use a larger corpus when you want more
 > representative retrieval quality.
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -178,17 +178,21 @@ chunks = ingestor.ingest()  # pandas.DataFrame (batch and inprocess)
 
 ### Ingest a test corpus (CLI)
 
-Point `retriever ingest` at a **directory** of PDFs to produce a ready-to-query
-LanceDB table.
+`retriever ingest` accepts a file or a directory and writes a ready-to-query
+LanceDB table. From a clone of this repository, `./data/multimodal_test.pdf`
+is a valid first-run input. Replace `/path/to/file-or-directory` below with
+that PDF or with your own file or directory.
 
-> **Corpus size matters.** LanceDB's default IVF index needs at least 16
-> chunks to train its 16 k-means partitions. Single-PDF ingestion will fail
-> at the indexing step; point `retriever ingest` at a directory with enough
-> documents to clear that threshold. Replace `/your-example-dir` below with
-> the path to your own corpus.
+> **Small corpora are supported.** The NeMo Retriever LanceDB adapter requests
+> 16 IVF partitions by default. When the table has fewer rows, the adapter
+> clamps that count to one less than the row count. An ingest that produces
+> 2 through 15 rows still builds an IVF index. A one-row table is stored
+> without a vector index and does not fail. An ingest that produces zero rows
+> is a separate empty-result error. Use a larger corpus when you want more
+> representative retrieval quality.
 
 ```bash
-retriever ingest /your-example-dir \
+retriever ingest /path/to/file-or-directory \
   --lancedb-uri lancedb \
   --table-name nemo-retriever
 ```
@@ -196,8 +200,7 @@ retriever ingest /your-example-dir \
 Chunks land at `./lancedb/nemo-retriever`, which matches the storage settings
 used in [Run a recall query](#run-a-recall-query) below. With the
 `[local]` extra installed (see setup), defaults point at local-GPU extraction
-and embedding. Use enough documents in the directory to clear the LanceDB IVF
-training threshold described above.
+and embedding.
 
 **No local GPU?** Set [`NVIDIA_API_KEY`](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/#nvidia-api-key) (refer to [Authentication and API keys](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/)) and route extraction and embedding
 through [build.nvidia.com](https://build.nvidia.com/) NIMs instead:
@@ -205,7 +208,7 @@ through [build.nvidia.com](https://build.nvidia.com/) NIMs instead:
 ```bash
 export NVIDIA_API_KEY=nvapi-...
 
-retriever ingest /your-example-dir \
+retriever ingest /path/to/file-or-directory \
   --lancedb-uri lancedb \
   --table-name nemo-retriever \
   --page-elements-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3 \


### PR DESCRIPTION
## Summary
- Docs-only fix for NVBug 6609699. The published environment-config page implied a working-directory `.env` file would be loaded; the public SDK and `retriever` CLI read the process environment only.
- Removes that automatic-load claim and documents sourcing `.env` into the shell (`set -a; source .env; set +a`).
- Aligns the same statement on the API keys and troubleshoot pages.
- Docs-only fix for NVBug 6609790. The API keys Helm section listed `imagePullSecret.*`, `nimApiKey`, and `nims.ngcApiKey`, which Helm accepts but the chart ignores, so `ngc-secret` and `ngc-api` are not created.
- Replaces those paths with `ngcImagePullSecret.create` / `ngcImagePullSecret.password` and `ngcApiSecret.create` / `ngcApiSecret.password`, adds the chart README install example, and deep-links the Helm README Secrets section.
- Docs-only fix for NVBug 6610201. The library README warned that LanceDB IVF needs at least 16 chunks and that single-PDF ingest fails. That is stale: the NeMo Retriever LanceDB adapter clamps requested partitions to `row_count - 1` for tables with more than one row, and skips vector-index creation for a one-row table.
- Updates `nemo_retriever/README.md` so `retriever ingest` accepts a file or a directory, documents the clamp and one-row fallback, and distinguishes the separate zero-row empty-result error.
- Audit polish: `source` (not export) a `.env` file; scope the no-autoload claim to the SDK and CLI; document that `ngc-api` stores `NGC_API_KEY` / `NGC_CLI_API_KEY` and the service maps `NVIDIA_API_KEY` from the `NGC_API_KEY` key; README one-row wording is now “ingest succeeds” instead of “does not fail.”

This PR does not change SDK, CLI, or Helm chart behavior. A shared `.env` loader, a Helm values schema, and a README-shaped CLI contract test would be separate eng PRs.

### Review analysis (`::a`, `::p`, `::r`)

Repo rules: base `main`; docs-only; allowed paths only (`api-keys.md`, `environment-config.md`, `troubleshoot.md`, `nemo_retriever/README.md`); no `src/`, tests, Helm templates, lockfiles, or CI env; claims match current `main` behavior.

**Audit (`::a`).** Deterministic checks (Skill Library scripts): code-block syntax pass; no broken links; freshness fresh. Readability: api-keys 63.9 Standard; environment-config 57.5 Fairly Difficult; troubleshoot 48.9 Difficult (page-level, pre-existing); README 55.3 Fairly Difficult. README skipped 3 pre-existing partial snippets.

Conceptual claims verified against source:

- SDK/CLI do not load a working-directory `.env` (`remote_auth.py` uses `os.getenv`; CLI has no `load_dotenv`). `generate_sql.py` does load `.env`, so the scoped “SDK and CLI” wording is required. Confidence 95%.
- Helm creates `ngc-secret` / `ngc-api` from `ngcImagePullSecret.*` and `ngcApiSecret.*`. `imagePullSecret`, `nimApiKey`, and `nims.ngcApiKey` do not (`secrets.yaml`, `values.yaml`, `deployment.yaml`, Helm README `#secrets`). Confidence 95%.
- `retriever ingest` accepts a file or directory (`options.py` DocumentsArgument). IVF partitions clamp to `row_count - 1`; one-row tables skip the vector index; zero-row ingest errors (`lancedb.py`, `test_lancedb_ivf_partitions.py`, `execution.py`). Confidence 95%.

**Polish (`::p`).** Accuracy and signal-to-noise only. Applied: “export that file” → “source that file”; “The Library” → “The SDK and CLI”; Helm Secret keys and container env mapping; README “and does not fail” → “and ingest succeeds.” Changed-section scores: Signal High, Diataxis High (how-to), Disclosure High.

**Style (`::r`).** Changed prose compliant after polish on all four PR files. Brand, numbers, links, and grammar on changed lines are clean. `#secrets` heading exists.

Not in this PR: README-shaped CLI contract test (separate eng follow-up). NVBug 6610201 supersedes the opposite 16-chunk-minimum recommendation in NVBug 6167965.

## Test plan
- [ ] Confirm `environment-config` no longer says the Library loads `.env` automatically
- [ ] Confirm the source-into-shell procedure is present and uses `source`, not export
- [ ] Confirm API keys and troubleshoot no longer tell readers to rely on an unloaded `.env` file
- [ ] Confirm troubleshoot scopes the no-autoload claim to the SDK and CLI
- [ ] Confirm the API keys Helm section uses only `ngcImagePullSecret.*` and `ngcApiSecret.*`
- [ ] Confirm it does not document `imagePullSecret`, `nimApiKey`, or `nims.ngcApiKey` as working credential paths
- [ ] Confirm the Secrets deep-link points at `nemo_retriever/helm/README.md#secrets`
- [ ] Confirm `ngc-api` Secret keys and the `NVIDIA_API_KEY` mapping are described accurately
- [ ] Confirm the library README no longer claims a 16-chunk minimum or single-PDF ingest failure
- [ ] Confirm the README states `retriever ingest` accepts a file or a directory
- [ ] Confirm the README explains partition clamping, the one-row unindexed fallback (ingest succeeds), and the separate zero-row error
