### PR TITLE
fix(cli): add --agentic-local-tensor-parallel-size for local Super-49B

### DIFF
--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -10,7 +10,9 @@ NeMo Retriever Library provides ingestion, embedding, storage, and retrieval bui
 The `retriever query --agentic` and harness BEIR agentic paths default to an
 in-process local vLLM agent LLM. If no agent model is provided, the library loads
 `nemotron-8b` (`nvidia/Llama-3.1-Nemotron-Nano-8B-v1`) on the local CUDA host.
-The larger `super-49b` profile is also supported. Other custom in-process LLMs
+The larger `super-49b` profile is also supported. Pass
+`--agentic-local-tensor-parallel-size 2` with two visible GPUs for that
+profile. Other custom in-process LLMs
 are not supported yet because the agent loop depends on OpenAI-style tool-call
 messages; use an OpenAI-compatible endpoint for custom models.
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -357,6 +357,8 @@ embedding endpoint.
 **Local in-process vLLM agent LLM.** Omit `--agentic-invoke-url` to load the
 supported local agent LLM directly in the Python process. `nemotron-8b` is the
 default; `super-49b` is also supported when the process has enough visible GPUs.
+For `super-49b`, set `--agentic-local-tensor-parallel-size 2` with two visible
+GPUs (for example `CUDA_VISIBLE_DEVICES=0,1`).
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 retriever query "Given their activities, which animal is responsible for the typos in my documents?" \
@@ -366,6 +368,15 @@ CUDA_VISIBLE_DEVICES=0 retriever query "Given their activities, which animal is 
   --embed-model-name nvidia/llama-nemotron-embed-1b-v2
 ```
 
+```bash
+CUDA_VISIBLE_DEVICES=0,1 retriever query "Given their activities, which animal is responsible for the typos in my documents?" \
+  --agentic \
+  --agentic-llm-model super-49b \
+  --agentic-local-tensor-parallel-size 2 \
+  --lancedb-uri lancedb \
+  --table-name nemo-retriever \
+  --embed-model-name nvidia/llama-nemotron-embed-vl-1b-v2
+```
 **OpenAI-compatible agent endpoint.** Pass `--agentic-invoke-url` when you want a
 custom model or a separately hosted chat-completions server, such as vLLM server
 mode or a self-hosted NIM. When an invoke URL is provided, `--agentic-llm-model`

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -226,6 +226,10 @@ Agentic-only knobs (apply only with `--agentic`):
 - `--agentic-llm-model` — local profile alias/model ID when no invoke URL is
   provided (`nemotron-8b` by default; `super-49b` also supported), or the remote
   model ID when `--agentic-invoke-url` is provided.
+- `--agentic-local-tensor-parallel-size` (default `1`) — vLLM
+  `tensor_parallel_size` for the in-process agent LLM. Set to `2` (with two
+  visible GPUs via `CUDA_VISIBLE_DEVICES`) for local `super-49b`. Ignored when
+  `--agentic-invoke-url` is set.
 - `--agentic-invoke-url` — OpenAI-compatible chat-completions endpoint for the
   agent LLM. Providing it routes agent LLM calls to that remote endpoint; omit it
   to run the in-process local model.

--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -193,6 +193,7 @@ def _local_command(
     agentic_react_max_steps: opts.AgenticReactMaxStepsOption = 50,
     agentic_text_truncation: opts.AgenticTextTruncationOption = 0,
     agentic_temperature: opts.AgenticTemperatureOption = None,
+    agentic_local_tensor_parallel_size: opts.AgenticLocalTensorParallelSizeOption = 1,
     agentic_llm_client: opts.AgenticLlmClientOption = None,
 ) -> None:
     _validate_output_options(output_format, max_text_chars)
@@ -276,6 +277,7 @@ def _local_command(
                     react_max_steps=agentic_react_max_steps,
                     text_truncation=agentic_text_truncation,
                     temperature=agentic_temperature,
+                    local_tensor_parallel_size=agentic_local_tensor_parallel_size,
                     llm_client=agentic_llm_client,
                 ),
             )

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -216,6 +216,18 @@ AgenticTemperatureOption = Annotated[
         ),
     ),
 ]
+AgenticLocalTensorParallelSizeOption = Annotated[
+    int,
+    typer.Option(
+        "--agentic-local-tensor-parallel-size",
+        min=1,
+        help=(
+            "vLLM tensor_parallel_size for the in-process agent LLM. "
+            "Use 2 (with two visible GPUs) for local super-49b; ignored when "
+            "--agentic-invoke-url is set."
+        ),
+    ),
+]
 AgenticLlmClientOption = Annotated[
     str | None,
     typer.Option(

--- a/nemo_retriever/tests/test_agentic_eval.py
+++ b/nemo_retriever/tests/test_agentic_eval.py
@@ -397,3 +397,31 @@ def test_agentic_config_validates_local_vllm_knobs():
     assert cfg.local_tensor_parallel_size == 2
     assert cfg.local_max_model_len == 8192
     assert cfg.local_max_num_seqs == 4
+
+
+def test_agentic_config_passes_tensor_parallel_size_to_local_llm():
+    from nemo_retriever.query.agentic import (
+        AgenticRetrievalConfig,
+        _build_agent_chat_completion_fn,
+    )
+
+    cfg = AgenticRetrievalConfig(
+        llm_model="super-49b",
+        local_tensor_parallel_size=2,
+    )
+
+    with patch(
+        "nemo_retriever.models.create_local_agent_llm",
+        return_value=object(),
+    ) as create_local_llm:
+        _build_agent_chat_completion_fn(cfg)
+
+    create_local_llm.assert_called_once_with(
+        "super-49b",
+        backend="vllm",
+        hf_cache_dir=None,
+        gpu_memory_utilization=0.8,
+        tensor_parallel_size=2,
+        max_model_len=None,
+        max_num_seqs=None,
+    )

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -434,9 +434,7 @@ def test_root_query_agentic_local_tensor_parallel_size_plumbed_into_config(
             self.cfg = cfg
 
         def retrieve(self, query_ids: Any, query_texts: Any) -> Any:
-            return pd.DataFrame(
-                [{"query_id": "0", "doc_id": "a.pdf", "rank": 1, "result_source": "rrf"}]
-            )
+            return pd.DataFrame([{"query_id": "0", "doc_id": "a.pdf", "rank": 1, "result_source": "rrf"}])
 
         def unload(self) -> None:
             return None

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -415,6 +415,53 @@ def test_root_query_agentic_passes_config_and_prints_ranked(monkeypatch) -> None
     ]
 
 
+def test_root_query_agentic_local_tensor_parallel_size_plumbed_into_config(
+    monkeypatch,
+) -> None:
+    """The local tensor-parallel CLI option reaches agentic configuration."""
+    import pandas as pd
+
+    import nemo_retriever.query.agentic as agentic_retrieval
+
+    config_calls: list[dict[str, Any]] = []
+
+    class FakeConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            config_calls.append(kwargs)
+
+    class FakeAgenticRetriever:
+        def __init__(self, cfg: Any) -> None:
+            self.cfg = cfg
+
+        def retrieve(self, query_ids: Any, query_texts: Any) -> Any:
+            return pd.DataFrame(
+                [{"query_id": "0", "doc_id": "a.pdf", "rank": 1, "result_source": "rrf"}]
+            )
+
+        def unload(self) -> None:
+            return None
+
+    monkeypatch.setattr(agentic_retrieval, "AgenticRetrievalConfig", FakeConfig)
+    monkeypatch.setattr(agentic_retrieval, "AgenticRetriever", FakeAgenticRetriever)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "q",
+            "--agentic",
+            "--agentic-llm-model",
+            "super-49b",
+            "--agentic-local-tensor-parallel-size",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert config_calls[-1]["llm_model"] == "super-49b"
+    assert config_calls[-1]["local_tensor_parallel_size"] == 2
+
+
 def test_root_query_agentic_rejects_custom_in_process_llm_model() -> None:
     result = RUNNER.invoke(
         cli_main.app,


### PR DESCRIPTION
## Description
- Expose `--agentic-local-tensor-parallel-size` on `retriever query --agentic` and plumb it into `QueryAgenticOptions.local_tensor_parallel_size` (SDK path already supported this).
- Document the Super-49B 2-GPU workflow and add regression coverage for CLI → config → `create_local_agent_llm(..., tensor_parallel_size=...)`.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
