### PR TITLE
fix(agentic): honor --reranker-invoke-url instead of loading local vLLM

### DIFF
--- a/nemo_retriever/src/nemo_retriever/query/agentic.py
+++ b/nemo_retriever/src/nemo_retriever/query/agentic.py
@@ -371,7 +371,9 @@ class AgenticRetriever:
             rerank=bool(cfg.reranker),
             rerank_kwargs={
                 "model_name": cfg.reranker or VL_RERANK_MODEL,
-                "invoke_url": cfg.reranker_endpoint,
+                # NemotronRerankActor selects its remote CPU variant on
+                # ``rerank_invoke_url``; any other key silently loads a local model.
+                "rerank_invoke_url": (cfg.reranker_endpoint or "").strip() or None,
                 "api_key": cfg.reranker_api_key,
                 "local_reranker_backend": str(cfg.local_reranker_backend),
                 "modality": str(cfg.embed_modality),

--- a/nemo_retriever/tests/test_agentic_eval.py
+++ b/nemo_retriever/tests/test_agentic_eval.py
@@ -189,6 +189,46 @@ def test_run_agentic_audio_recall_evaluation_computes_metrics(tmp_path):
 
 
 @patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
+def test_agentic_retriever_forwards_reranker_endpoint_as_rerank_invoke_url():
+    """A configured reranker endpoint must reach the remote rerank variant.
+
+    ``NemotronRerankActor`` dispatches on ``rerank_invoke_url``; any other key
+    leaves the URL unused and loads the reranker locally instead.
+    """
+    from nemo_retriever.operators.rerank import NemotronRerankActor
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    cfg = AgenticRetrievalConfig(
+        llm_model="test-model",
+        invoke_url=_REMOTE_URL,
+        reranker="nvidia/llama-nemotron-rerank-vl-1b-v2",
+        reranker_endpoint="http://localhost:8015",
+    )
+    rerank_kwargs = AgenticRetriever(cfg, match_mode="pdf_page")._retriever.kwargs["rerank_kwargs"]
+
+    assert rerank_kwargs["rerank_invoke_url"] == "http://localhost:8015"
+    assert "invoke_url" not in rerank_kwargs
+    assert NemotronRerankActor.prefers_cpu_variant(rerank_kwargs) is True
+
+
+@patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
+def test_agentic_retriever_without_reranker_endpoint_uses_local_variant():
+    from nemo_retriever.operators.rerank import NemotronRerankActor
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    cfg = AgenticRetrievalConfig(
+        llm_model="test-model",
+        invoke_url=_REMOTE_URL,
+        reranker="nvidia/llama-nemotron-rerank-vl-1b-v2",
+        reranker_endpoint="   ",
+    )
+    rerank_kwargs = AgenticRetriever(cfg, match_mode="pdf_page")._retriever.kwargs["rerank_kwargs"]
+
+    assert rerank_kwargs["rerank_invoke_url"] is None
+    assert NemotronRerankActor.prefers_cpu_variant(rerank_kwargs) is False
+
+
+@patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
 def test_run_agentic_beir_evaluation_loads_queries_and_qrels():
     from nemo_retriever.query.agentic import AgenticRetrievalConfig, run_agentic_beir_evaluation
     from nemo_retriever.tools.recall.beir import BeirDataset


### PR DESCRIPTION
## Description
- Agentic retrieval was passing the configured reranker endpoint as `invoke_url`, but `NemotronRerankActor` only selects the remote CPU variant when `rerank_invoke_url` is set.
- That made `--agentic --rerank --reranker-invoke-url <url>` silently load a local vLLM reranker, so the configured NIM was never contacted and results could differ from the dense path.
- Forward the endpoint under `rerank_invoke_url` (same key as the dense query path / BEIR harness) and add regression coverage for the remote vs local dispatch.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
