### PR TITLE
fix: update HF revisions for Transformers 5 compatibility

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
+++ b/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
@@ -25,14 +25,14 @@ logger = logging.getLogger(__name__)
 
 HF_MODEL_REVISIONS: dict[str, str] = {
     "nvidia/llama-3.2-nv-embedqa-1b-v2": "cefc2394cc541737b7867df197984cf23f05367f",
-    "nvidia/llama-nemotron-embed-1b-v2": "b4caa8456edd360b3b4e938d94ed4398dd437fad",
+    "nvidia/llama-nemotron-embed-1b-v2": "113abe4acafa848e77ead9c0623205e511932348",
     "nvidia/parakeet-ctc-1.1b": "a707e818195cb97c8f7da2fc36b221a29f69a5db",
     "nvidia/NVIDIA-Nemotron-Parse-v1.2": "f42c8040b12ee64370922d108778ab655b722c5d",
     "nvidia/llama-nemotron-embed-vl-1b-v2": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
     "meta-llama/Llama-3.2-1B": "4e20de362430cd3b72f300e6b0f18e50e7166e08",
     "intfloat/e5-large-unsupervised": "15af9288f69a6291f37bfb89b47e71abc747b206",
     "nvidia/llama-nemotron-rerank-1b-v2": "8fd3e5d962d44cfe65d4ba0784eebed44cf136b0",
-    "nvidia/llama-nemotron-rerank-vl-1b-v2": "edc083f4b3a433d65287cbca916759c9f88fa887",
+    "nvidia/llama-nemotron-rerank-vl-1b-v2": "9c20c4aedf9ec87b6b7346c3bc4754ea030dab35",
     "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16": "5d250e2e111dc5e1434131bdf3d590c27a878ade",
     "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8": "7394488badb786e1decc0e00e308de1cab9560e6",
     "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD": "b8d3c170d9ee3a078917ef9bfd508eff988d6de7",

--- a/nemo_retriever/tests/test_hf_model_registry.py
+++ b/nemo_retriever/tests/test_hf_model_registry.py
@@ -44,6 +44,16 @@ def test_extraction_hf_repos_have_pinned_revisions():
     )
 
 
+def test_local_hf_nemotron_models_use_transformers_5_compatible_revisions() -> None:
+    assert (
+        registry.HF_MODEL_REVISIONS["nvidia/llama-nemotron-embed-1b-v2"] == "113abe4acafa848e77ead9c0623205e511932348"
+    )
+    assert (
+        registry.HF_MODEL_REVISIONS["nvidia/llama-nemotron-rerank-vl-1b-v2"]
+        == "9c20c4aedf9ec87b6b7346c3bc4754ea030dab35"
+    )
+
+
 def test_hf_hub_download_with_pinned_revision_injects_known_revision(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Description

Updates the immutable Hugging Face revisions for the local Nemotron text embedder and VL reranker to revisions compatible with Transformers 5.

The previously pinned model code called `create_bidirectional_mask()` using the deprecated `input_embeds` keyword. Transformers 5.15 requires `inputs_embeds`, causing embedding batches to fail and leaving LanceDB with no vectors to persist.

This PR updates the pins to their direct upstream successors:

- Text embedder: `113abe4acafa848e77ead9c0623205e511932348`
- VL reranker: `9c20c4aedf9ec87b6b7346c3bc4754ea030dab35`

Both upstream revisions contain only the compatible positional `create_bidirectional_mask()` call. A focused regression test protects the two pins.

Validation included focused model tests, H200 execution with Transformers 5.15.0, and the reported end-to-end batch ingest workflow. The batch command completed successfully, persisted 8 LanceDB rows with finite 2048-dimensional vectors, and recorded the new embedding revision in table metadata.

There are no public API, CLI, configuration, dependency, schema, default-model, Helm, or documentation changes. The existing LanceDB revision guard remains strict, so tables stamped with the previous embedding revision require overwrite or a new table. The separately packaged VL Reranker NIM `2.3.0` is outside the scope of these Python model pins.

## Checklist

- [x] I am familiar with the [[Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.