### PR TITLE
fix(audio): normalize segmented ASR timestamps

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/nim/primitives/model_interface/parakeet.py
+++ b/nemo_retriever/src/nemo_retriever/models/nim/primitives/model_interface/parakeet.py
@@ -414,8 +414,11 @@ def process_transcription_response(response):
     for word in words_list:
         # Mark the start of a segment if not already set.
         if segment_start is None:
-            segment_start = word.start_time
-        segment_end = word.end_time
+            # Riva WordInfo timestamps are milliseconds. Normalize both
+            # boundaries here so a small negative boundary offset cannot be
+            # mistaken for a seconds-valued timestamp downstream.
+            segment_start = float(word.start_time) / 1000.0
+        segment_end = float(word.end_time) / 1000.0
         current_words.append(word.word)
 
         # End the segment when a word ends with punctuation.

--- a/nemo_retriever/src/nemo_retriever/operators/extract/audio/asr_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/audio/asr_actor.py
@@ -276,7 +276,7 @@ class _ASRActorBase:
             out_rows: List[Dict[str, Any]] = []
             valid_segments: List[tuple[str, float, float]] = []
             segment_texts: List[str] = []
-            combine_with_valid_range = False
+            use_unaligned_fallback = False
             for segment in segments:
                 if not isinstance(segment, dict):
                     continue
@@ -288,12 +288,12 @@ class _ASRActorBase:
                 if segment_range is None:
                     if chunk_dur <= 0:
                         logger.warning(
-                            "Combining transcript over valid ASR ranges because segment range "
+                            "Falling back to an unaligned transcript because segment range "
                             "start=%r end=%r is invalid and chunk duration is unavailable",
                             segment.get("start"),
                             segment.get("end"),
                         )
-                        combine_with_valid_range = True
+                        use_unaligned_fallback = True
                         continue
                     logger.warning(
                         "Replacing invalid ASR segment range start=%r end=%r " "with chunk bounds",
@@ -303,11 +303,9 @@ class _ASRActorBase:
                     segment_range = (0.0, chunk_dur)
                 valid_segments.append((segment_text, *segment_range))
 
-            if combine_with_valid_range and valid_segments:
-                combined_text = transcript.strip() or " ".join(segment_texts)
-                combined_start = min(start for _, start, _ in valid_segments)
-                combined_end = max(end for _, _, end in valid_segments)
-                valid_segments = [(combined_text, combined_start, combined_end)]
+            if use_unaligned_fallback:
+                transcript = transcript.strip() or " ".join(segment_texts)
+                valid_segments = []
 
             segment_count = len(valid_segments)
             for segment_index, (segment_text, seg_s_secs, seg_e_secs) in enumerate(valid_segments):
@@ -335,10 +333,14 @@ class _ASRActorBase:
             if out_rows:
                 return out_rows
 
-        # Per-chunk fallback: anchor the row's span to the chunk's wall-clock
-        # window so audio_segment recall still works without per-utterance data.
-        metadata.setdefault("segment_start_seconds", chunk_start)
-        metadata.setdefault("segment_end_seconds", chunk_start + chunk_dur)
+        # Per-chunk fallback: publish a wall-clock span only when the chunk
+        # duration is known; otherwise keep the transcript explicitly unaligned.
+        if chunk_dur > 0:
+            metadata.setdefault("segment_start_seconds", chunk_start)
+            metadata.setdefault("segment_end_seconds", chunk_start + chunk_dur)
+        else:
+            metadata.pop("segment_start_seconds", None)
+            metadata.pop("segment_end_seconds", None)
         metadata["_content_type"] = "audio"
         metadata.setdefault("modality", "audio_segment")
         return [

--- a/nemo_retriever/src/nemo_retriever/operators/extract/audio/asr_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/audio/asr_actor.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import math
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -35,27 +36,40 @@ from nemo_retriever.operators.operator_archetype import ArchetypeOperator
 from nemo_retriever.common.params import ASRParams
 
 
-def _to_chunk_relative_seconds(value: Any, chunk_duration_secs: float) -> Optional[float]:
-    """Coerce a per-utterance timestamp to seconds, divided down from ms when needed.
-
-    Local Parakeet returns seconds; the remote NIM client returns milliseconds.
-    A seconds-valued utterance can't exceed the chunk duration — so anything
-    past it must be ms. When the chunk duration is unknown (probe_media
-    couldn't resolve it for some segmented MP4s and chunk_actor.py substitutes
-    0.0), fall back to a value-range check: no legitimate audio segment lasts
-    more than an hour, so anything past 3600 must be ms.
-    """
+def _to_chunk_relative_seconds(value: Any) -> Optional[float]:
+    """Coerce a normalized per-utterance timestamp to seconds."""
     if value is None:
         return None
     try:
         v = float(value)
     except (TypeError, ValueError):
         return None
-    if chunk_duration_secs > 0 and v > chunk_duration_secs:
-        return v / 1000.0
-    if chunk_duration_secs <= 0 and v > 3600:
-        return v / 1000.0
     return v
+
+
+def _validated_chunk_relative_range(
+    start: Any,
+    end: Any,
+    chunk_duration_secs: float,
+) -> Optional[tuple[float, float]]:
+    """Normalize and validate a segment range before exposing it publicly."""
+    start_secs = _to_chunk_relative_seconds(start)
+    end_secs = _to_chunk_relative_seconds(end)
+    if start_secs is None or end_secs is None:
+        return None
+    if not math.isfinite(start_secs) or not math.isfinite(end_secs):
+        return None
+
+    # ASR models can emit a small negative offset for a word at the beginning
+    # of a chunk. Keep public citations inside the chunk/source range.
+    start_secs = max(0.0, start_secs)
+    end_secs = max(0.0, end_secs)
+    if chunk_duration_secs > 0 and math.isfinite(chunk_duration_secs):
+        start_secs = min(start_secs, chunk_duration_secs)
+        end_secs = min(end_secs, chunk_duration_secs)
+    if end_secs <= start_secs:
+        return None
+    return start_secs, end_secs
 
 
 def _use_remote(params: ASRParams) -> bool:
@@ -249,32 +263,50 @@ class _ASRActorBase:
             chunk_start = float(metadata.get("chunk_start_seconds") or 0.0)
         except (TypeError, ValueError):
             chunk_start = 0.0
+        if not math.isfinite(chunk_start) or chunk_start < 0:
+            chunk_start = 0.0
         try:
             chunk_dur = float(duration) if duration is not None else 0.0
         except (TypeError, ValueError):
             chunk_dur = 0.0
+        if not math.isfinite(chunk_dur) or chunk_dur < 0:
+            chunk_dur = 0.0
 
         if self._params.segment_audio and segments:
             out_rows: List[Dict[str, Any]] = []
-            segment_count = len(segments)
-            for segment_index, segment in enumerate(segments):
+            valid_segments: List[tuple[str, float, float]] = []
+            for segment in segments:
                 if not isinstance(segment, dict):
                     continue
                 segment_text = str(segment.get("text") or "").strip()
                 if not segment_text:
                     continue
+                segment_range = _validated_chunk_relative_range(segment.get("start"), segment.get("end"), chunk_dur)
+                if segment_range is None:
+                    if chunk_dur <= 0:
+                        logger.warning(
+                            "Dropping invalid ASR segment range start=%r end=%r; " "chunk duration is unavailable",
+                            segment.get("start"),
+                            segment.get("end"),
+                        )
+                        continue
+                    logger.warning(
+                        "Replacing invalid ASR segment range start=%r end=%r " "with chunk bounds",
+                        segment.get("start"),
+                        segment.get("end"),
+                    )
+                    segment_range = (0.0, chunk_dur)
+                valid_segments.append((segment_text, *segment_range))
+
+            segment_count = len(valid_segments)
+            for segment_index, (segment_text, seg_s_secs, seg_e_secs) in enumerate(valid_segments):
                 segment_metadata = copy.deepcopy(metadata)
                 segment_metadata["segment_index"] = segment_index
                 segment_metadata["segment_count"] = segment_count
-                seg_s_secs = _to_chunk_relative_seconds(segment.get("start"), chunk_dur)
-                seg_e_secs = _to_chunk_relative_seconds(segment.get("end"), chunk_dur)
-                # Wall-clock span: chunk start + the chunk-relative times the ASR
-                # backend produced. Local Parakeet emits seconds; remote emits
-                # milliseconds — normalized above against the chunk duration.
-                if seg_s_secs is not None:
-                    segment_metadata["segment_start_seconds"] = seg_s_secs + chunk_start
-                if seg_e_secs is not None:
-                    segment_metadata["segment_end_seconds"] = seg_e_secs + chunk_start
+                # Wall-clock span: chunk start + the chunk-relative times the
+                # ASR backend produced. Both paths emit seconds at this point.
+                segment_metadata["segment_start_seconds"] = seg_s_secs + chunk_start
+                segment_metadata["segment_end_seconds"] = seg_e_secs + chunk_start
                 segment_metadata["_content_type"] = "audio"
                 segment_metadata.setdefault("modality", "audio_segment")
                 out_rows.append(

--- a/nemo_retriever/src/nemo_retriever/operators/extract/audio/asr_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/audio/asr_actor.py
@@ -275,20 +275,25 @@ class _ASRActorBase:
         if self._params.segment_audio and segments:
             out_rows: List[Dict[str, Any]] = []
             valid_segments: List[tuple[str, float, float]] = []
+            segment_texts: List[str] = []
+            combine_with_valid_range = False
             for segment in segments:
                 if not isinstance(segment, dict):
                     continue
                 segment_text = str(segment.get("text") or "").strip()
                 if not segment_text:
                     continue
+                segment_texts.append(segment_text)
                 segment_range = _validated_chunk_relative_range(segment.get("start"), segment.get("end"), chunk_dur)
                 if segment_range is None:
                     if chunk_dur <= 0:
                         logger.warning(
-                            "Dropping invalid ASR segment range start=%r end=%r; " "chunk duration is unavailable",
+                            "Combining transcript over valid ASR ranges because segment range "
+                            "start=%r end=%r is invalid and chunk duration is unavailable",
                             segment.get("start"),
                             segment.get("end"),
                         )
+                        combine_with_valid_range = True
                         continue
                     logger.warning(
                         "Replacing invalid ASR segment range start=%r end=%r " "with chunk bounds",
@@ -297,6 +302,12 @@ class _ASRActorBase:
                     )
                     segment_range = (0.0, chunk_dur)
                 valid_segments.append((segment_text, *segment_range))
+
+            if combine_with_valid_range and valid_segments:
+                combined_text = transcript.strip() or " ".join(segment_texts)
+                combined_start = min(start for _, start, _ in valid_segments)
+                combined_end = max(end for _, _, end in valid_segments)
+                valid_segments = [(combined_text, combined_start, combined_end)]
 
             segment_count = len(valid_segments)
             for segment_index, (segment_text, seg_s_secs, seg_e_secs) in enumerate(valid_segments):

--- a/nemo_retriever/tests/test_asr_actor.py
+++ b/nemo_retriever/tests/test_asr_actor.py
@@ -162,6 +162,45 @@ def test_asr_actor_remote_segment_audio():
         assert out["metadata"].iloc[1]["segment_end_seconds"] == 2.5
 
 
+def test_asr_actor_clamps_negative_boundary_and_replaces_invalid_ranges():
+    with patch("nemo_retriever.operators.extract.audio.asr_actor._get_client") as mock_get:
+        mock_client = MagicMock()
+        mock_client.infer.return_value = (
+            [
+                {"start": -0.08, "end": 4.0, "text": "Boundary sentence."},
+                {"start": float("nan"), "end": 5.0, "text": "Invalid sentence."},
+            ],
+            "Boundary sentence. Invalid sentence.",
+        )
+        mock_get.return_value = mock_client
+
+        actor = ASRActor(params=ASRParams(audio_endpoints=("localhost:50051", None), segment_audio=True))
+        out = actor(
+            pd.DataFrame(
+                [
+                    {
+                        "path": "/tmp/chunk.wav",
+                        "bytes": b"fake_audio",
+                        "source_path": "/tmp/source.wav",
+                        "duration": 10.0,
+                        "chunk_index": 0,
+                        "metadata": {"chunk_start_seconds": 0.0},
+                        "page_number": 0,
+                    }
+                ]
+            )
+        )
+
+        assert out["text"].tolist() == ["Boundary sentence.", "Invalid sentence."]
+        first_metadata = out["metadata"].iloc[0]
+        assert first_metadata["segment_start_seconds"] == 0.0
+        assert first_metadata["segment_end_seconds"] == 4.0
+        assert first_metadata["segment_count"] == 2
+        second_metadata = out["metadata"].iloc[1]
+        assert second_metadata["segment_start_seconds"] == 0.0
+        assert second_metadata["segment_end_seconds"] == 10.0
+
+
 def test_apply_asr_to_df_segment_audio():
     with patch("nemo_retriever.operators.extract.audio.asr_actor._get_client") as mock_get:
         mock_client = MagicMock()

--- a/nemo_retriever/tests/test_asr_actor.py
+++ b/nemo_retriever/tests/test_asr_actor.py
@@ -237,9 +237,9 @@ def test_asr_actor_preserves_transcript_for_mixed_ranges_without_duration():
 
         assert out["text"].tolist() == ["Valid sentence. Malformed sentence."]
         metadata = out["metadata"].iloc[0]
-        assert metadata["segment_start_seconds"] == 2.1
-        assert metadata["segment_end_seconds"] == 2.5
-        assert metadata["segment_count"] == 1
+        assert "segment_start_seconds" not in metadata
+        assert "segment_end_seconds" not in metadata
+        assert "segment_count" not in metadata
 
 
 def test_apply_asr_to_df_segment_audio():

--- a/nemo_retriever/tests/test_asr_actor.py
+++ b/nemo_retriever/tests/test_asr_actor.py
@@ -14,6 +14,7 @@ import base64
 import sys
 from unittest.mock import MagicMock
 from unittest.mock import patch
+from unittest.mock import create_autospec
 
 import pandas as pd
 
@@ -22,6 +23,7 @@ from nemo_retriever.operators.extract.audio.asr_actor import DEFAULT_NGC_ASR_FUN
 from nemo_retriever.operators.extract.audio.asr_actor import apply_asr_to_df
 from nemo_retriever.operators.extract.audio.asr_actor import asr_params_from_env
 from nemo_retriever.common.params import ASRParams
+from nemo_retriever.models.nim.primitives.model_interface.parakeet import ParakeetClient
 
 
 NVCF_GRPC_ENDPOINT = "grpc.nvcf.nvidia.com:443"
@@ -164,7 +166,7 @@ def test_asr_actor_remote_segment_audio():
 
 def test_asr_actor_clamps_negative_boundary_and_replaces_invalid_ranges():
     with patch("nemo_retriever.operators.extract.audio.asr_actor._get_client") as mock_get:
-        mock_client = MagicMock()
+        mock_client = create_autospec(ParakeetClient, instance=True)
         mock_client.infer.return_value = (
             [
                 {"start": -0.08, "end": 4.0, "text": "Boundary sentence."},
@@ -199,6 +201,45 @@ def test_asr_actor_clamps_negative_boundary_and_replaces_invalid_ranges():
         second_metadata = out["metadata"].iloc[1]
         assert second_metadata["segment_start_seconds"] == 0.0
         assert second_metadata["segment_end_seconds"] == 10.0
+        mock_client.infer.assert_called_once_with(
+            base64.b64encode(b"fake_audio").decode("ascii"), model_name="parakeet"
+        )
+
+
+def test_asr_actor_preserves_transcript_for_mixed_ranges_without_duration():
+    with patch("nemo_retriever.operators.extract.audio.asr_actor._get_client") as mock_get:
+        mock_client = create_autospec(ParakeetClient, instance=True)
+        mock_client.infer.return_value = (
+            [
+                {"start": 0.1, "end": 0.5, "text": "Valid sentence."},
+                {"start": float("nan"), "end": 0.8, "text": "Malformed sentence."},
+            ],
+            "Valid sentence. Malformed sentence.",
+        )
+        mock_get.return_value = mock_client
+
+        actor = ASRActor(params=ASRParams(audio_endpoints=("localhost:50051", None), segment_audio=True))
+        out = actor(
+            pd.DataFrame(
+                [
+                    {
+                        "path": "/tmp/chunk.wav",
+                        "bytes": b"fake_audio",
+                        "source_path": "/tmp/source.wav",
+                        "duration": None,
+                        "chunk_index": 0,
+                        "metadata": {"chunk_start_seconds": 2.0},
+                        "page_number": 0,
+                    }
+                ]
+            )
+        )
+
+        assert out["text"].tolist() == ["Valid sentence. Malformed sentence."]
+        metadata = out["metadata"].iloc[0]
+        assert metadata["segment_start_seconds"] == 2.1
+        assert metadata["segment_end_seconds"] == 2.5
+        assert metadata["segment_count"] == 1
 
 
 def test_apply_asr_to_df_segment_audio():

--- a/nemo_retriever/tests/test_parakeet_infer_mode.py
+++ b/nemo_retriever/tests/test_parakeet_infer_mode.py
@@ -5,12 +5,14 @@
 from __future__ import annotations
 
 import base64
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nemo_retriever.models.nim.primitives.model_interface.parakeet import (
     ParakeetClient,
+    process_transcription_response,
     resolve_audio_infer_mode,
 )
 from nemo_retriever.common.params import ASRParams
@@ -95,6 +97,19 @@ def test_parakeet_client_transcribe_uses_streaming_for_nvcf(mock_riva) -> None:
 
     mock_stream.assert_called_once()
     mock_asr.offline_recognize.assert_not_called()
+
+
+def test_process_transcription_response_normalizes_milliseconds_consistently() -> None:
+    words = [
+        SimpleNamespace(word="Boundary", start_time=-80, end_time=1200),
+        SimpleNamespace(word="sentence.", start_time=1200, end_time=4000),
+    ]
+    response = SimpleNamespace(results=[SimpleNamespace(alternatives=[SimpleNamespace(words=words)])])
+
+    segments, transcript = process_transcription_response(response)
+
+    assert transcript == "Boundary sentence."
+    assert segments == [{"start": -0.08, "end": 4.0, "text": "Boundary sentence."}]
 
 
 def test_asr_params_default_infer_mode_is_auto() -> None:


### PR DESCRIPTION
## Summary

- normalize Riva `WordInfo` timestamps from milliseconds to seconds at the Parakeet client boundary
- clamp segmented ASR timestamps to chunk bounds and validate finite, ordered public ranges
- preserve transcript content by using chunk bounds when a malformed segment range cannot be normalized
- add regressions for the reported `-80 ms` / `4000 ms` boundary case and invalid timestamp handling

## Root cause

Timestamp unit inference was performed independently using a positive-only duration threshold. The remote start value `-80` therefore remained unchanged while the end value `4000` became `4.0`, exposing `-80.0` as a seconds-valued public timestamp. The resulting range was not validated before publication.

## Impact

Segmented audio citations can no longer expose impossible negative or non-finite source ranges. The reported boundary now resolves to `0.0`–`4.0` seconds without disabling punctuation-based segmentation.

## Validation

- `pre-commit run --all-files`
- audio-focused pytest suite: 42 passed, 1 skipped
- GPG signature verified locally
- DCO `Signed-off-by` included
