### PR TITLE
Honor configured encoding for HTML extraction

### DIFF
--- a/nemo_retriever/src/nemo_retriever/common/modality/html/convert.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/html/convert.py
@@ -12,7 +12,6 @@ and the LanceDB row builder (text, path, page_number, metadata).
 from __future__ import annotations
 
 import io
-import tempfile
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -81,7 +80,7 @@ def html_to_markdown(html_content: Union[str, bytes, Path]) -> str:
     str
         Markdown text.
     """
-    from markitdown import MarkItDown
+    from markitdown import MarkItDown, StreamInfo
 
     md = MarkItDown()
     if isinstance(html_content, Path):
@@ -92,7 +91,14 @@ def html_to_markdown(html_content: Union[str, bytes, Path]) -> str:
             result = md.convert(html_content)
             fallback_text = _read_html_file(html_content)
         else:
-            result = md.convert_stream(io.BytesIO(html_content.encode("utf-8", errors="replace")))
+            result = md.convert_stream(
+                io.BytesIO(html_content.encode("utf-8", errors="replace")),
+                stream_info=StreamInfo(
+                    mimetype="text/html",
+                    extension=".html",
+                    charset="utf-8",
+                ),
+            )
             fallback_text = html_content
     elif isinstance(html_content, bytes):
         result = md.convert_stream(io.BytesIO(html_content))
@@ -113,6 +119,7 @@ def html_file_to_chunks_df(
     overlap_tokens = chunk_params.overlap_tokens
     tokenizer_model_id = chunk_params.tokenizer_model_id
     tokenizer_cache_dir = chunk_params.tokenizer_cache_dir
+    encoding = chunk_params.encoding
 
     """
     Read an .html file, convert to markdown via markitdown, chunk by tokens.
@@ -141,13 +148,8 @@ def html_file_to_chunks_df(
         Columns: text, path, page_number, metadata.
     """
     path = str(Path(path).resolve())
-    from markitdown import MarkItDown
-
-    md = MarkItDown()
-    result = md.convert(path)
-    markdown_text = result.text_content or ""
-    if not markdown_text.strip():
-        markdown_text = _html_plain_text_fallback(_read_html_file(path))
+    html_text = Path(path).read_text(encoding=encoding, errors="replace")
+    markdown_text = html_to_markdown(html_text)
     return _markdown_to_chunks_df(
         markdown_text,
         path,
@@ -168,6 +170,7 @@ def html_bytes_to_chunks_df(
     overlap_tokens = chunk_params.overlap_tokens
     tokenizer_model_id = chunk_params.tokenizer_model_id
     tokenizer_cache_dir = chunk_params.tokenizer_cache_dir
+    encoding = chunk_params.encoding
 
     """
     Convert HTML bytes to markdown and return a DataFrame of chunks (same shape as html_file_to_chunks_df).
@@ -175,20 +178,8 @@ def html_bytes_to_chunks_df(
     Used by batch HtmlSplitActor when input is bytes + path from read_binary_files.
     """
     path = str(Path(path).resolve())
-    # Use temp file so markitdown can detect HTML by extension
-    with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
-        f.write(content_bytes)
-        tmp_path = f.name
-    try:
-        from markitdown import MarkItDown
-
-        md = MarkItDown()
-        result = md.convert(tmp_path)
-        markdown_text = result.text_content or ""
-    finally:
-        Path(tmp_path).unlink(missing_ok=True)
-    if not markdown_text.strip():
-        markdown_text = _html_plain_text_fallback(content_bytes.decode("utf-8", errors="replace"))
+    html_text = content_bytes.decode(encoding, errors="replace")
+    markdown_text = html_to_markdown(html_text)
     return _markdown_to_chunks_df(
         markdown_text,
         path,

--- a/nemo_retriever/tests/test_html_convert.py
+++ b/nemo_retriever/tests/test_html_convert.py
@@ -112,6 +112,34 @@ def test_html_bytes_to_chunks_df(tmp_path: Path, monkeypatch):
     assert df["text"].iloc[0].strip()
 
 
+@pytest.mark.parametrize("source_kind", ["file", "bytes"])
+def test_html_chunk_params_encoding_controls_decoding(tmp_path: Path, monkeypatch, source_kind: str):
+    pytest.importorskip("markitdown")
+    monkeypatch.setattr(
+        "nemo_retriever.common.modality.html.convert._get_txt_tokenizer",
+        lambda model_id, cache_dir=None: _MockTokenizer(),
+    )
+    expected_text = "Café façade jalapeño año QA_LATIN1_268"
+    html_bytes = f"<html><body><h1>{expected_text}</h1></body></html>".encode("latin-1")
+    path = tmp_path / "latin1.html"
+    path.write_bytes(html_bytes)
+
+    def convert(encoding: str) -> str:
+        params = HtmlChunkParams(max_tokens=512, overlap_tokens=0, encoding=encoding)
+        if source_kind == "file":
+            result = html_file_to_chunks_df(str(path), params=params)
+        else:
+            result = html_bytes_to_chunks_df(html_bytes, str(path), params=params)
+        return result["text"].iloc[0]
+
+    latin1_text = convert("latin-1")
+    utf8_text = convert("utf-8")
+
+    assert "Café façade jalapeño año" in latin1_text
+    assert "Café façade jalapeño año" not in utf8_text
+    assert "jalape�o a�o" in utf8_text
+
+
 def test_html_bytes_to_chunks_df_falls_back_when_markitdown_returns_empty(tmp_path: Path, monkeypatch):
     pytest.importorskip("markitdown")
     monkeypatch.setattr(
@@ -123,7 +151,7 @@ def test_html_bytes_to_chunks_df_falls_back_when_markitdown_returns_empty(tmp_pa
         text_content = ""
 
     class _EmptyMarkItDown:
-        def convert(self, _source):
+        def convert_stream(self, _source, **_kwargs):
             return _EmptyResult()
 
     monkeypatch.setattr("markitdown.MarkItDown", _EmptyMarkItDown)
@@ -147,7 +175,7 @@ def test_html_to_markdown_fallback_ignores_noncontent_blocks(monkeypatch):
         text_content = ""
 
     class _EmptyMarkItDown:
-        def convert_stream(self, _source):
+        def convert_stream(self, _source, **_kwargs):
             return _EmptyResult()
 
     monkeypatch.setattr("markitdown.MarkItDown", _EmptyMarkItDown)


### PR DESCRIPTION
## Summary

- decode HTML files and byte payloads using `HtmlChunkParams.encoding`
- pass decoded HTML to MarkItDown with explicit UTF-8 stream metadata
- remove temporary-file charset autodetection from the batch bytes path
- add regression coverage for both file and bytes conversion

## Root cause

The HTML extraction paths read tokenizer fields from `HtmlChunkParams` but ignored `encoding`. Raw HTML bytes were passed to MarkItDown directly (or through a temporary file), allowing `charset-normalizer` to select cp1250 for Latin-1 input and silently change `ñ` to `ń`.

## Impact

The public SDK now honors the configured HTML encoding consistently in in-process and batch paths. Latin-1 content is preserved before chunking, embedding, retrieval, and persistence.

## Validation

- `pre-commit run --all-files`
- `python -m pytest nemo_retriever/tests/test_html_convert.py -q` (`10 passed`)
- ran the reported public SDK reproduction end to end:
  - Latin-1 TXT and HTML preserve `Café façade jalapeño año`
  - UTF-8 controls produce replacement characters and do not match the successful Latin-1 output
