### PR TITLE
Fix uploaded image URI metadata propagation

### DIFF
--- a/docs/docs/extraction/content-metadata.md
+++ b/docs/docs/extraction/content-metadata.md
@@ -65,7 +65,7 @@ The following is the metadata for images.
 | Text | Extracted text from a structured chart | Extracted | Pending Research |
 | Image location | Location (x,y) of chart within an image | Extracted |
 | Image location max dimensions | Max dimensions (x\_max,y\_max) of location (x,y) | Extracted |
-| uploaded\_image\_uri | Mirrors source\_metadata.source\_location | — |
+| uploaded\_image\_uri | URI of the stored image when image storage is configured. | Generated |
 
 
 ## Table Metadata
@@ -85,7 +85,7 @@ The following is the metadata for tables within documents.
 | Title | The title of the table. | Extracted |
 | Subtitle | The subtitle of the table. | Extracted |
 | Axis | Axis information for the table. | Extracted |
-| uploaded\_image\_uri | A mirror of source\_metadata.source\_location. | Generated |
+| uploaded\_image\_uri | URI of the stored table, chart, or infographic image when image storage is configured. | Generated |
 
 
 
@@ -206,6 +206,7 @@ Specific metadata for image content.
 | `image_location`                  | `tuple`                            | `(0, 0, 0, 0)`             | Bounding box or coordinates of the image within its source.                                             |
 | `image_location_max_dimensions`   | `tuple`                            | `(0, 0)`                   | Maximum dimensions of the space where `image_location` is defined.                                      |
 | `uploaded_image_url`              | `str`                              | `""`                       | URL of the image if it has been uploaded to a separate storage location.                                |
+| `uploaded_image_uri`              | `str`                              | `""`                       | URI of the stored image when image storage is configured.                                               |
 | `width`                           | `int`                              | `0`                        | Width of the image in pixels. Clamped to be non-negative.                                               |
 | `height`                          | `int`                              | `0`                        | Height of the image in pixels. Clamped to be non-negative.                                              |
 
@@ -220,7 +221,7 @@ Specific metadata for tabular content.
 | `table_content_format`            | `Union[TableFormatEnum, str]`         | `""`                | Specific format of `table_content`.                                                                     |
 | `table_location`                  | `tuple`                               | `(0, 0, 0, 0)`      | Bounding box or coordinates of the table within its source.                                             |
 | `table_location_max_dimensions`   | `tuple`                               | `(0, 0)`            | Maximum dimensions of the space where `table_location` is defined.                                      |
-| `uploaded_image_uri`              | `str`                                 | `""`                | URI of an image representation of the table, if applicable.                                             |
+| `uploaded_image_uri`              | `str`                                 | `""`                | URI of the stored table image when image storage is configured.                                         |
 
 ### `ChartMetadataSchema`
 Metadata for table content extracted from charts.
@@ -233,7 +234,7 @@ Metadata for table content extracted from charts.
 | `table_content_format`            | `Union[TableFormatEnum, str]`         | `""`                | Specific format of `table_content`.                                                                     |
 | `table_location`                  | `tuple`                               | `(0, 0, 0, 0)`      | Bounding box or coordinates of the chart within its source.                                             |
 | `table_location_max_dimensions`   | `tuple`                               | `(0, 0)`            | Maximum dimensions of the space where `table_location` is defined.                                      |
-| `uploaded_image_uri`              | `str`                                 | `""`                | URI of an image representation of the chart, if applicable.                                             |
+| `uploaded_image_uri`              | `str`                                 | `""`                | URI of the stored chart image when image storage is configured.                                         |
 
 ### `AudioMetadataSchema`
 Specific metadata for audio content.

--- a/nemo_retriever/src/nemo_retriever/common/api/internal/schemas/meta/metadata_schema.py
+++ b/nemo_retriever/src/nemo_retriever/common/api/internal/schemas/meta/metadata_schema.py
@@ -189,6 +189,9 @@ class ImageMetadataSchema(BaseModelNoExt):
     uploaded_image_url: str = ""
     """A mirror of source_metadata.source_location."""
 
+    uploaded_image_uri: str = ""
+    """The URI of the stored image asset, when image storage is configured."""
+
     width: int = 0
     """The width of the image."""
 

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -240,6 +240,16 @@ def _is_image_backed_row(row: dict[str, Any]) -> bool:
     )
 
 
+def _is_inherited_page_uri(row: dict[str, Any], stored_image_uri: str, content_type: str | None) -> bool:
+    """Return whether a structured row only carries its page image URI."""
+    if content_type not in {"table", "chart", "infographic"}:
+        return False
+
+    page_image = row.get("page_image")
+    page_uri = page_image.get("stored_image_uri") if isinstance(page_image, dict) else None
+    return bool(_first_str(page_uri) == stored_image_uri)
+
+
 def _derive_fidelity(content_type: Any, metadata: dict[str, Any], content_metadata: dict[str, Any]) -> str | None:
     """Map a chunk's modality + real provenance signals to a trust tier.
 
@@ -290,7 +300,8 @@ def _client_record_from_graph_row(row: dict[str, Any], *, require_embedding: boo
     stored_image_uri = _first_str(row.get("_stored_image_uri"), row.get("stored_image_uri"))
     if stored_image_uri:
         content_metadata.setdefault("stored_image_uri", stored_image_uri)
-        content_metadata.setdefault("uploaded_image_uri", stored_image_uri)
+        if not _is_inherited_page_uri(row, stored_image_uri, content_type):
+            content_metadata.setdefault("uploaded_image_uri", stored_image_uri)
     bbox = _bbox_from_graph_row(row)
     if bbox is not None:
         content_metadata.setdefault("bbox_xyxy_norm", bbox)

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -290,6 +290,7 @@ def _client_record_from_graph_row(row: dict[str, Any], *, require_embedding: boo
     stored_image_uri = _first_str(row.get("_stored_image_uri"), row.get("stored_image_uri"))
     if stored_image_uri:
         content_metadata.setdefault("stored_image_uri", stored_image_uri)
+        content_metadata.setdefault("uploaded_image_uri", stored_image_uri)
     bbox = _bbox_from_graph_row(row)
     if bbox is not None:
         content_metadata.setdefault("bbox_xyxy_norm", bbox)

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
@@ -198,6 +198,21 @@ def _ensure_object_column(df: pd.DataFrame, column: str) -> None:
         df[column] = df[column].astype(object)
 
 
+def _with_uploaded_image_uri(metadata: Any, stored_uri: str) -> Any:
+    """Return metadata with the public structured-image URI synchronized."""
+    if not isinstance(metadata, dict):
+        return metadata
+
+    out = dict(metadata)
+    for key in ("content_metadata", "image_metadata", "table_metadata", "chart_metadata"):
+        structured_metadata = out.get(key)
+        if isinstance(structured_metadata, dict):
+            updated = dict(structured_metadata)
+            updated["uploaded_image_uri"] = stored_uri
+            out[key] = updated
+    return out
+
+
 def _store_row_images(
     df: pd.DataFrame,
     *,
@@ -216,13 +231,14 @@ def _store_row_images(
         return df
 
     out = df.copy()
-    for column in (*image_columns, *row_image_columns, "_stored_image_uri"):
+    for column in (*image_columns, *row_image_columns, "_stored_image_uri", "metadata"):
         _ensure_object_column(out, column)
     fallback_format = _normalize_image_format(image_format)
     fsspec_options = dict(storage_options or {})
 
     for idx, row in out.iterrows():
         image_b64, image_source = _row_image_b64_with_source(row)
+        stored_uri = row.get("_stored_image_uri")
         raw = _decode_image_b64(image_b64)
         if raw is not None:
             stored_uri = _write_image_b64(
@@ -245,6 +261,9 @@ def _store_row_images(
                 if strip_base64:
                     if image_source in row_image_columns and image_source in out.columns:
                         out.at[idx, image_source] = None
+
+        if isinstance(stored_uri, str) and stored_uri.strip() and "metadata" in out.columns:
+            out.at[idx, "metadata"] = _with_uploaded_image_uri(row.get("metadata"), stored_uri)
 
         for column in image_columns:
             if column not in out.columns:

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
@@ -213,6 +213,28 @@ def _with_uploaded_image_uri(metadata: Any, stored_uri: str) -> Any:
     return out
 
 
+def _is_inherited_page_uri(row: pd.Series, stored_uri: Any, *, image_source: str | None, raw: bytes | None) -> bool:
+    """Return whether a structured row only carries its page image URI."""
+    content_type = row.get("_content_type")
+    if not isinstance(content_type, str) or not content_type.strip() or content_type == "text":
+        return False
+
+    # A valid row-level payload will be stored as the structured asset below,
+    # even when the row initially inherited the page URI during explosion.
+    if raw is not None and image_source in {"_image_b64", "image_b64"}:
+        return False
+
+    page_image = row.get("page_image")
+    page_uri = page_image.get("stored_image_uri") if isinstance(page_image, dict) else None
+    return (
+        isinstance(stored_uri, str)
+        and stored_uri.strip()
+        and isinstance(page_uri, str)
+        and page_uri.strip()
+        and stored_uri == page_uri
+    )
+
+
 def _store_row_images(
     df: pd.DataFrame,
     *,
@@ -240,6 +262,7 @@ def _store_row_images(
         image_b64, image_source = _row_image_b64_with_source(row)
         stored_uri = row.get("_stored_image_uri")
         raw = _decode_image_b64(image_b64)
+        inherited_page_uri = _is_inherited_page_uri(row, stored_uri, image_source=image_source, raw=raw)
         if raw is not None:
             stored_uri = _write_image_b64(
                 image_b64,
@@ -262,7 +285,7 @@ def _store_row_images(
                     if image_source in row_image_columns and image_source in out.columns:
                         out.at[idx, image_source] = None
 
-        if isinstance(stored_uri, str) and stored_uri.strip() and "metadata" in out.columns:
+        if isinstance(stored_uri, str) and stored_uri.strip() and not inherited_page_uri and "metadata" in out.columns:
             out.at[idx, "metadata"] = _with_uploaded_image_uri(row.get("metadata"), stored_uri)
 
         for column in image_columns:

--- a/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
+++ b/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
@@ -343,6 +343,7 @@ def test_ingest_operator_retains_image_only_row_with_stored_image_uri(
         "type": "image",
         "page_number": 7,
         "stored_image_uri": "file:///tmp/scanned-page-7.png",
+        "uploaded_image_uri": "file:///tmp/scanned-page-7.png",
     }
 
 

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -920,6 +920,7 @@ def test_run_pipeline_posts_canonical_pdf_table_image_provenance(
         "type": "table",
         "fidelity": "ocr",
         "stored_image_uri": "s3://artifacts/table.png",
+        "uploaded_image_uri": "s3://artifacts/table.png",
         "bbox_xyxy_norm": [0.1, 0.2, 0.8, 0.9],
         "category": "Finance_Investment",
         "source_path": "Finance_Investment/report.pdf",

--- a/nemo_retriever/tests/test_store_pipeline_stages.py
+++ b/nemo_retriever/tests/test_store_pipeline_stages.py
@@ -70,6 +70,37 @@ class TestStoreOperatorInGraph:
         assert stored_uri.startswith("file://")
         assert Path(urlparse(stored_uri).path).exists()
 
+    @pytest.mark.parametrize("metadata_key", ["image_metadata", "table_metadata", "chart_metadata"])
+    def test_store_operator_exposes_uploaded_image_uri_in_structured_metadata(self, tmp_path: Path, metadata_key: str):
+        b64 = _make_tiny_png_b64()
+        df = _make_embedded_df(b64)
+        df.at[0, "_content_type"] = metadata_key.removesuffix("_metadata")
+        df["metadata"] = [
+            {
+                "content_metadata": {"type": "structured"},
+                metadata_key: {"table_format": "image", "uploaded_image_uri": ""},
+            }
+        ]
+
+        result = StoreOperator(params=StoreParams(storage_uri=str(tmp_path))).process(df)
+
+        stored_uri = result.iloc[0]["_stored_image_uri"]
+        assert result.iloc[0]["metadata"]["content_metadata"]["uploaded_image_uri"] == stored_uri
+        assert result.iloc[0]["metadata"][metadata_key]["uploaded_image_uri"] == stored_uri
+
+    def test_store_operator_synchronizes_existing_stored_uri_into_public_metadata(self, tmp_path: Path):
+        df = _make_embedded_df(None)
+        df["_stored_image_uri"] = ["file:///stored/table.png"]
+        df["metadata"] = [
+            {
+                "table_metadata": {"table_format": "image", "uploaded_image_uri": ""},
+            }
+        ]
+
+        result = StoreOperator(params=StoreParams(storage_uri=str(tmp_path))).process(df)
+
+        assert result.iloc[0]["metadata"]["table_metadata"]["uploaded_image_uri"] == "file:///stored/table.png"
+
     def test_store_operator_clears_row_and_page_payloads_after_write(self, tmp_path: Path):
         b64 = _make_tiny_png_b64()
         df = _make_embedded_df(b64)

--- a/nemo_retriever/tests/test_store_pipeline_stages.py
+++ b/nemo_retriever/tests/test_store_pipeline_stages.py
@@ -101,6 +101,26 @@ class TestStoreOperatorInGraph:
 
         assert result.iloc[0]["metadata"]["table_metadata"]["uploaded_image_uri"] == "file:///stored/table.png"
 
+    def test_store_operator_does_not_publish_inherited_page_uri_as_table_asset(self, tmp_path: Path):
+        df = _make_embedded_df(None)
+        df["_content_type"] = ["table"]
+        df["_stored_image_uri"] = ["file:///stored/page.png"]
+        df["page_image"] = [{"image_b64": None, "stored_image_uri": "file:///stored/page.png"}]
+        df["metadata"] = [
+            {
+                "content_metadata": {"type": "structured", "uploaded_image_uri": ""},
+                "table_metadata": {
+                    "table_format": "image",
+                    "uploaded_image_uri": "file:///stored/table.png",
+                },
+            }
+        ]
+
+        result = StoreOperator(params=StoreParams(storage_uri=str(tmp_path))).process(df)
+
+        assert result.iloc[0]["metadata"]["content_metadata"]["uploaded_image_uri"] == ""
+        assert result.iloc[0]["metadata"]["table_metadata"]["uploaded_image_uri"] == "file:///stored/table.png"
+
     def test_store_operator_clears_row_and_page_payloads_after_write(self, tmp_path: Path):
         b64 = _make_tiny_png_b64()
         df = _make_embedded_df(b64)

--- a/nemo_retriever/tests/test_vdb_records.py
+++ b/nemo_retriever/tests/test_vdb_records.py
@@ -179,6 +179,25 @@ def test_graph_record_conversion_preserves_service_provenance() -> None:
     }
 
 
+@pytest.mark.parametrize("content_type", ["table", "chart_caption", "infographic"])
+def test_graph_record_conversion_does_not_publish_inherited_page_uri(content_type: str) -> None:
+    records = to_client_vdb_records(
+        [
+            {
+                "text": "structured content",
+                "text_embeddings_1b_v2": {"embedding": [0.1, 0.2]},
+                "_content_type": content_type,
+                "_stored_image_uri": "s3://artifacts/page.png",
+                "page_image": {"stored_image_uri": "s3://artifacts/page.png"},
+            }
+        ]
+    )
+
+    content_metadata = records[0][0]["metadata"]["content_metadata"]
+    assert content_metadata["stored_image_uri"] == "s3://artifacts/page.png"
+    assert "uploaded_image_uri" not in content_metadata
+
+
 def test_graph_record_conversion_normalizes_arrow_backed_bbox_array() -> None:
     records = to_client_vdb_records(
         [

--- a/nemo_retriever/tests/test_vdb_records.py
+++ b/nemo_retriever/tests/test_vdb_records.py
@@ -167,6 +167,7 @@ def test_graph_record_conversion_preserves_service_provenance() -> None:
         "type": "table",
         "fidelity": "ocr",
         "stored_image_uri": "s3://artifacts/table.png",
+        "uploaded_image_uri": "s3://artifacts/table.png",
         "bbox_xyxy_norm": [0.1, 0.2, 0.8, 0.9],
         "page_elements_v3_num_detections": 3,
         "page_elements_v3_counts_by_label": {"table": 2, "chart": 1},


### PR DESCRIPTION
## Description
This PR fixes image URI metadata propagation when `--store-images-uri` is configured. Stored image assets were written successfully, but returned and persisted rows did not expose the documented `uploaded_image_uri` field. The store stage now synchronizes the stored asset URI into image, table, chart, and content metadata, and the VDB adapter preserves the field during persistence. Existing `stored_image_uri` fields remain available for compatibility.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
