### PR TITLE
docs(helm): storage preflight and default NIM image alignment

### DIFF
--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -18,7 +18,7 @@ Build and run the NeMo Retriever service image with the [Docker service image gu
 ### I want a Kubernetes / Helm deployment
 
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) — sources in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub. Before you install, confirm a working persistent-volume binding strategy. The default chart creates seven PersistentVolumeClaims. Refer to [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements).
+2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) — sources in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub. Before you install, confirm a working persistent-volume binding strategy. The default chart creates seven PersistentVolumeClaims. Refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements).
 3. **Published Library Helm charts (supported):** cluster install and upgrade procedures are covered in [About getting started](getting-started-about.md) — use alongside the NeMo Retriever chart README for your release
 4. [Environment variables](environment-config.md) and [Troubleshoot](troubleshoot.md) as needed
 

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -18,7 +18,7 @@ Build and run the NeMo Retriever service image with the [Docker service image gu
 ### I want a Kubernetes / Helm deployment
 
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) — sources in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub
+2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) — sources in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub. Before you install, confirm a working persistent-volume binding strategy. The default chart creates seven PersistentVolumeClaims. Refer to [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements).
 3. **Published Library Helm charts (supported):** cluster install and upgrade procedures are covered in [About getting started](getting-started-about.md) — use alongside the NeMo Retriever chart README for your release
 4. [Environment variables](environment-config.md) and [Troubleshoot](troubleshoot.md) as needed
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -63,13 +63,13 @@ you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as 
 Nemotron Parse does not produce chart modality rows. For chart detection and chart-filtered retrieval, use the default **pdfium** layout path instead (refer to [Charts and infographics](multimodal-extraction.md#charts-and-infographics)).
 For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
 
-## Why does Helm report deployed while pods stay Pending? { #helm-deployed-pending-pvcs }
+## Why does Helm report deployed while PersistentVolumeClaims stay Pending? { #helm-deployed-pending-pvcs }
 
 `STATUS: deployed` means Helm rendered the release. It does not mean PersistentVolumeClaims bound or that pods can schedule.
 
 The default chart creates seven PersistentVolumeClaims. If the cluster has no default StorageClass and no compatible static persistent volumes, those claims stay `Pending` and the retriever service, VectorDB, and core NIM workloads remain unschedulable.
 
-A common claim event is `no persistent volumes available for this claim and no storage class is set`. Confirm storage before you install, or set the documented `storageClass` values. Refer to [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
+A common claim event is `no persistent volumes available for this claim and no storage class is set`. Confirm storage before you install, or set the documented `storageClass` values. Refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
 
 ## Why are the environment variables different between library mode and self-hosted mode? { #library-vs-self-hosted-env-vars }
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -63,6 +63,14 @@ you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as 
 Nemotron Parse does not produce chart modality rows. For chart detection and chart-filtered retrieval, use the default **pdfium** layout path instead (refer to [Charts and infographics](multimodal-extraction.md#charts-and-infographics)).
 For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
 
+## Why does Helm report deployed while pods stay Pending? { #helm-deployed-pending-pvcs }
+
+`STATUS: deployed` means Helm rendered the release. It does not mean PersistentVolumeClaims bound or that pods can schedule.
+
+The default chart creates seven PersistentVolumeClaims. If the cluster has no default StorageClass and no compatible static persistent volumes, those claims stay `Pending` and the retriever service, VectorDB, and core NIM workloads remain unschedulable.
+
+A common claim event is `no persistent volumes available for this claim and no storage class is set`. Confirm storage before you install, or set the documented `storageClass` values. Refer to [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
+
 ## Why are the environment variables different between library mode and self-hosted mode? { #library-vs-self-hosted-env-vars }
 
 ### Self-Hosted Deployments { #self-hosted-deployments }

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -5,8 +5,8 @@ This section walks you from **access and prerequisites** through **first deploym
 Typical order:
 
 1. [Get your API key](api-keys.md) (NGC / API access as required by your workflow).
-2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, and software stack. Local GPU inference requires Linux; remote NIM workflows can use the base package on Windows x64 and macOS Apple Silicon (arm64) as well. macOS Intel (x86_64) is not supported.
-3. Choose a path in [Deployment options](deployment-options.md) — local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service.
+2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, software stack, and Kubernetes persistent storage if you use Helm. Local GPU inference requires Linux; remote NIM workflows can use the base package on Windows x64 and macOS Apple Silicon (arm64) as well. macOS Intel (x86_64) is not supported.
+3. Choose a path in [Deployment options](deployment-options.md) — local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service. For Helm, complete the [persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite) before `helm install`.
 4. Explore [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md) for end-to-end examples.
 
 The NeMo Retriever Library and its Helm chart are not supported under NVIDIA AI Enterprise (NVAIE). For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -105,15 +105,17 @@ The production Helm chart reconciles NIM microservices through `nimOperator.<key
 
 | Helm flag | NIM | Default image (`repository:tag`) | Role | Enabled by default |
 |-----------|-----|----------------------------------|------|--------------------|
-| `page_elements` | [nemotron-page-elements-v3](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) | `nvcr.io/nim/nvidia/nemotron-page-elements-v3:1.8.0` | Page layout and element detection | Yes |
-| `table_structure` | [nemotron-table-structure-v1](https://build.nvidia.com/nvidia/nemotron-table-structure-v1) | `nvcr.io/nim/nvidia/nemotron-table-structure-v1:1.8.0` | Table structure extraction | Yes |
-| `ocr` | [nemotron-ocr-v2](https://build.nvidia.com/nvidia/nemotron-ocr-v2) | `nvcr.io/nim/nvidia/nemotron-ocr-v2:1.4.0` | Image OCR | Yes |
+| `page_elements` | [nemotron-page-elements-v3](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1` | Page layout and element detection | Yes |
+| `table_structure` | [nemotron-table-structure-v1](https://build.nvidia.com/nvidia/nemotron-table-structure-v1) | `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1` | Table structure extraction | Yes |
+| `ocr` | [nemotron-ocr-v2](https://build.nvidia.com/nvidia/nemotron-ocr-v2) | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` | Image OCR | Yes |
 | `vlm_embed` | [llama-nemotron-embed-vl-1b-v2](https://build.nvidia.com/nvidia/llama-nemotron-embed-vl-1b-v2) | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0` | Multimodal (VL) embedding | Yes |
 | `rerankqa` | [llama-nemotron-rerank-vl-1b-v2](https://build.nvidia.com/nvidia/llama-nemotron-rerank-vl-1b-v2) | `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0` | Reranking for improved retrieval accuracy | No |
 | `nemotron_parse` | [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) | `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant` | Optional PDF `method="nemotron_parse"` (default PDF extraction uses **pdfium**) | No |
 | `nemotron_3_nano_omni_30b_a3b_reasoning` | [nemotron-3-nano-omni-30b-a3b-reasoning](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) | `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` | Image captioning when you enable the caption stage | No |
 | `audio` | [parakeet-1-1b-ctc-en-us](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/index.html) | `nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0` | [Audio and video](audio-video.md) transcription | No |
 | `answer_llm` | [llama-3.3-nemotron-super-49b-v1.5](https://build.nvidia.com/nvidia/llama-3.3-nemotron-super-49b-v1.5) | `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5` | Optional `/v1/answer` generation LLM (not part of the default extraction pipeline) | No |
+
+The `page_elements` and `table_structure` services share the combined `nemotron-object-detection:2.0.1` image and select distinct models. For air-gapped, mirrored, or allowlisted deployments, pull that image once. Do not treat the older standalone `nemotron-page-elements-v3` or `nemotron-table-structure-v1` container images as the current Helm defaults.
 
 <a id="nemotron-ocr-v2-language-mode"></a>
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -1,6 +1,6 @@
 # Pre-Requisites & Support Matrix
 
-Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, and—if you use them—advanced features (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance on this page.
+Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, Kubernetes persistent storage if you use Helm, and advanced features you plan to enable (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance on this page.
 
 **Platform summary:** Supported **local GPU inference** requires **Linux** and CUDA 13. For **remote NIM inference**, the base Python package also installs on **Windows x64** and **macOS Apple Silicon (arm64)**; local GPU inference is not supported on those platforms. **macOS Intel (x86_64) is not supported** — `pip`/`uv` installs fail because Ray no longer publishes Intel Mac wheels.
 
@@ -27,6 +27,27 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 > **Note**
 >
 > When you use UV, create the environment with Python 3.12 — for example, `uv venv --python 3.12`. This matches the `requires-python` metadata in the library packages.
+
+## Kubernetes Helm storage requirements { #kubernetes-helm-storage-requirements }
+
+The production Helm chart requires a working persistent-volume provisioning and binding strategy. A default install creates **seven** PersistentVolumeClaims: three chart-managed service claims and four NIM Operator NIMCache claims for the core NIMs.
+
+Before you run `helm install`, confirm that the cluster can bind those claims. Use one of the following strategies:
+
+- A default StorageClass backed by a working provisioner.
+- Explicit `storageClass` values for every default claim, each backed by a working provisioner or matching persistent volumes.
+- Compatible static persistent volumes, or pre-created claims where the chart supports `existingClaim`.
+
+Run the following preflight commands:
+
+```bash
+kubectl get storageclass
+kubectl get pv
+```
+
+If the cluster has no StorageClass and no compatible Available persistent volumes, stop and add a binding strategy before you install. `helm install` can report `STATUS: deployed` while every claim remains `Pending`, which leaves the retriever service, VectorDB, and core NIM workloads unschedulable.
+
+For claim names, Helm value paths, and example `--set` flags, refer to [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite) in the Helm chart README. For Helm success with Pending claims, refer to [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
 
 ## Hardware Requirements { #hardware-requirements }
 
@@ -181,6 +202,7 @@ and run only the embedder, reranker, and your vector database.
 - [Release Notes](releasenotes.md)
 - [Deployment options](deployment-options.md) (local Python, hosted NIMs, and Kubernetes)
 - [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
+- [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite)
 - [NVIDIA NIM for Object Detection (support matrix)](https://docs.nvidia.com/nim/ingestion/object-detection/latest/support-matrix.html)
 - [NVIDIA NIM for Image OCR (support matrix)](https://docs.nvidia.com/nim/ingestion/image-ocr/latest/support-matrix.html)
 - [NVIDIA NIM for Vision Language Models (support matrix)](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html)

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -28,7 +28,7 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 >
 > When you use UV, create the environment with Python 3.12 — for example, `uv venv --python 3.12`. This matches the `requires-python` metadata in the library packages.
 
-## Kubernetes Helm storage requirements { #kubernetes-helm-storage-requirements }
+## Kubernetes Helm Storage Requirements { #kubernetes-helm-storage-requirements }
 
 The production Helm chart requires a working persistent-volume provisioning and binding strategy. A default install creates **seven** PersistentVolumeClaims: three chart-managed service claims and four NIM Operator NIMCache claims for the core NIMs.
 
@@ -45,7 +45,7 @@ kubectl get storageclass
 kubectl get pv
 ```
 
-If the cluster has no StorageClass and no compatible Available persistent volumes, stop and add a binding strategy before you install. `helm install` can report `STATUS: deployed` while every claim remains `Pending`, which leaves the retriever service, VectorDB, and core NIM workloads unschedulable.
+If the cluster has no StorageClass and no compatible `Available` persistent volumes, stop and add a binding strategy before you install. `helm install` can report `STATUS: deployed` while every claim remains `Pending`, which leaves the retriever service, VectorDB, and core NIM workloads unschedulable.
 
 For claim names, Helm value paths, and example `--set` flags, refer to [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite) in the Helm chart README. For Helm success with Pending claims, refer to [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -411,9 +411,32 @@ ERROR 2025-04-24 22:49:44.434 nimutils.py:68] }
 
 
 
+## Helm install succeeds but PersistentVolumeClaims stay Pending { #helm-pending-pvcs }
+
+`helm install` can report `STATUS: deployed` while every default PersistentVolumeClaim stays `Pending`. That status means Helm rendered the release. It does not mean the retriever service, VectorDB, or core NIM workloads can schedule.
+
+A representative claim event looks like the following:
+
+```text
+Type    Reason         From                          Message
+Normal  FailedBinding  persistentvolume-controller   no persistent volumes available for this claim and no storage class is set
+```
+
+This event means the claim omitted `storageClassName` and the cluster has neither a default StorageClass nor a compatible classless persistent volume.
+
+Complete the following checks:
+
+1. Run `kubectl get storageclass` and `kubectl get pv`. Confirm a default StorageClass, a named class you set on every default claim, or compatible Available persistent volumes.
+2. Run `kubectl get pvc --namespace <namespace>`. A default install creates seven claims. All seven must reach `Bound` before the functional workloads can start.
+3. If you intended a named StorageClass, set the three chart-managed paths and the four per-NIM `nimOperator.<key>.storage.pvc.storageClass` paths. Do not set only `nimOperator.nimCache.pvc.storageClass`. That chart-level value is not applied to the core NIMCache resources.
+4. After you add a default StorageClass or compatible volumes, confirm the claims become `Bound`. If they remain `Pending`, uninstall and reinstall after the storage strategy is in place.
+
+For the default claim list, Helm value paths, and preflight commands, refer to [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite).
+
 ## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
+- [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements)
 - [Deployment options](deployment-options.md)
 - [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
 - [About getting started](getting-started-about.md) (prerequisites and deployment)

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -426,17 +426,17 @@ This event means the claim omitted `storageClassName` and the cluster has neithe
 
 Complete the following checks:
 
-1. Run `kubectl get storageclass` and `kubectl get pv`. Confirm a default StorageClass, a named class you set on every default claim, or compatible Available persistent volumes.
+1. Run `kubectl get storageclass` and `kubectl get pv`. Confirm a default StorageClass, a named class you set on every default claim, or compatible `Available` persistent volumes.
 2. Run `kubectl get pvc --namespace <namespace>`. A default install creates seven claims. All seven must reach `Bound` before the functional workloads can start.
 3. If you intended a named StorageClass, set the three chart-managed paths and the four per-NIM `nimOperator.<key>.storage.pvc.storageClass` paths. Do not set only `nimOperator.nimCache.pvc.storageClass`. That chart-level value is not applied to the core NIMCache resources.
 4. After you add a default StorageClass or compatible volumes, confirm the claims become `Bound`. If they remain `Pending`, uninstall and reinstall after the storage strategy is in place.
 
-For the default claim list, Helm value paths, and preflight commands, refer to [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite).
+For the default claim list, Helm value paths, and preflight commands, refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite).
 
 ## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-- [Kubernetes Helm storage requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements)
+- [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements)
 - [Deployment options](deployment-options.md)
 - [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
 - [About getting started](getting-started-about.md) (prerequisites and deployment)

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -81,6 +81,83 @@ nemo_retriever/helm/
 
 ## Quick start
 
+### Persistent storage prerequisite { #persistent-storage-prerequisite }
+
+The default chart creates **seven** PersistentVolumeClaims: three
+chart-managed service claims and four NIM Operator NIMCache claims for
+the core NIMs. `helm install` reports `STATUS: deployed` when the
+release is rendered, even if every claim stays `Pending`. Confirm a
+working persistent-volume binding strategy before you install.
+
+Run the following preflight commands:
+
+```bash
+kubectl get storageclass
+kubectl get pv
+```
+
+Use one of the following strategies:
+
+- A default StorageClass (`(default)` in `kubectl get storageclass`)
+  backed by a working provisioner.
+- Explicit `storageClass` values for every default claim, each backed
+  by a working provisioner or matching persistent volumes.
+- Compatible static persistent volumes, or pre-created claims where
+  the chart supports `existingClaim`.
+
+When a `storageClass` value is empty, the chart omits
+`storageClassName`. Kubernetes then assigns the default StorageClass
+if one exists. If none exists, the claim binds only to a compatible
+classless persistent volume that matches the requested size and
+`ReadWriteOnce` access mode.
+
+The following table lists the default claims for a release named
+`retriever`:
+
+| Example claim name | Default size | Helm value path |
+| --- | --- | --- |
+| `retriever-nemo-retriever-data` | `50Gi` | `persistence.storageClass` |
+| `retriever-nemo-retriever-retriever-results` | `50Gi` | `retrieverResults.storageClass` |
+| `retriever-nemo-retriever-vectordb-data` | `50Gi` | `topology.vectordb.persistence.storageClass` |
+| `nemotron-page-elements-v3-pvc` | `25Gi` | `nimOperator.page_elements.storage.pvc.storageClass` |
+| `nemotron-table-structure-v1-pvc` | `25Gi` | `nimOperator.table_structure.storage.pvc.storageClass` |
+| `nemotron-ocr-v2-pvc` | `25Gi` | `nimOperator.ocr.storage.pvc.storageClass` |
+| `llama-nemotron-embed-vl-1b-v2-pvc` | `50Gi` | `nimOperator.vlm_embed.storage.pvc.storageClass` |
+
+When `nims.enabled=false`, the four NIMCache claims are not created.
+The three chart-managed claims still are, unless you disable those
+persistence blocks. Enabling an optional NIM adds another NIMCache
+claim for that key.
+
+To pin a named StorageClass on every default claim, pass the following
+`--set` flags with your cluster class name:
+
+```bash
+helm install retriever ./nemo_retriever/helm \
+  --set persistence.storageClass=<STORAGE_CLASS> \
+  --set retrieverResults.storageClass=<STORAGE_CLASS> \
+  --set topology.vectordb.persistence.storageClass=<STORAGE_CLASS> \
+  --set nimOperator.page_elements.storage.pvc.storageClass=<STORAGE_CLASS> \
+  --set nimOperator.table_structure.storage.pvc.storageClass=<STORAGE_CLASS> \
+  --set nimOperator.ocr.storage.pvc.storageClass=<STORAGE_CLASS> \
+  --set nimOperator.vlm_embed.storage.pvc.storageClass=<STORAGE_CLASS> \
+  --set ngcImagePullSecret.create=true \
+  --set ngcImagePullSecret.password=$NGC_API_KEY \
+  --set ngcApiSecret.create=true \
+  --set ngcApiSecret.password=$NGC_API_KEY
+```
+
+Set each per-NIM `nimOperator.<key>.storage.pvc.storageClass` path.
+The chart-level `nimOperator.nimCache.pvc.storageClass` value is not
+applied to the four core NIMCache resources.
+
+`persistence.existingClaim` and `retrieverResults.existingClaim` skip
+chart PVC creation and mount the named claim. The VectorDB claim does
+not have an `existingClaim` path.
+
+If `helm install` already succeeded and claims stay `Pending`, refer
+to [Helm install succeeds but PersistentVolumeClaims stay Pending](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/troubleshoot.md#helm-pending-pvcs).
+
 ### 1. Service image { #1-service-image }
 
 The chart defaults to the image published to NGC:
@@ -160,6 +237,10 @@ USER nemo
 
 ### 2. Install with external NIM endpoints (operator not required)
 
+Complete the [persistent storage prerequisite](#persistent-storage-prerequisite)
+before you install. With `nims.enabled=false`, the chart still creates
+the three service claims unless you disable those persistence blocks.
+
 If you already have NIM endpoints reachable from the cluster (e.g. another
 namespace, or NVIDIA Build), turn the master switch off and supply the
 URLs directly:
@@ -184,6 +265,9 @@ the secret is absent (useful for fully local NIM endpoints).
 
 ### 3. Install with the NIM Operator (in-cluster NIMs)
 
+Complete the [persistent storage prerequisite](#persistent-storage-prerequisite)
+before you install. The default path creates all seven claims.
+
 Install the [NIM Operator](https://docs.nvidia.com/nim-operator/) first so
 the `NIMCache` / `NIMService` CRDs (`apps.nvidia.com/v1alpha1`) are
 registered. A plain `helm install` reconciles the four core NIMs
@@ -204,6 +288,9 @@ helm install retriever ./nemo_retriever/helm \
 ```
 
 ### Recommended minimal install (26.08) { #recommended-minimal-install-2608 }
+
+Complete the [persistent storage prerequisite](#persistent-storage-prerequisite)
+before you install.
 
 Deploy only the four core NIMs that the retriever service auto-wires (`page_elements`, `table_structure`, `ocr`, `vlm_embed`):
 
@@ -492,6 +579,7 @@ gated on three conditions ALL holding:
 | `nimOperator.<key>.image.pullSecrets`  | `[ngc-secret]` | Referenced by the NIMService CR. |
 | `nimOperator.<key>.authSecret`         | `ngc-api`      | NIM auth Secret name. |
 | `nimOperator.<key>.storage.pvc.size`   | `25Gi` (50Gi for vlm_embed/rerankqa, 100Gi parse, 300Gi VL) | NIMCache PVC size. |
+| `nimOperator.<key>.storage.pvc.storageClass` | `""` | Per-NIM NIMCache StorageClass. An empty value renders an empty class on the NIMCache CR, so the operator-created claim uses the cluster default when one exists. Set this path for each enabled NIM. `nimOperator.nimCache.pvc.storageClass` is not applied to per-NIM caches. |
 | `nimOperator.<key>.replicas`           | `1`     | Per-NIMService replica count. |
 | `nimOperator.nimServiceGpuLimit`       | `1`     | Default `nvidia.com/gpu` limit on every NIMService when per-NIM `resources` is `{}`. Set to `null` for operator-only reconciliation (not reliable on all NIM Operator versions — refer to [GPU limits and `helm upgrade`](#gpu-limits-and-helm-upgrade)). |
 | `nimOperator.<key>.resources`          | `{}`    | Per-NIM override of the whole `resources` block. Empty uses `nimServiceGpuLimit`; non-empty replaces the chart default (may require `--force-conflicts` on later `helm upgrade`). |
@@ -701,13 +789,24 @@ when the OCR service runs outside the operator sub-stack.
 
 ### Persistence
 
+Complete the [persistent storage prerequisite](#persistent-storage-prerequisite)
+before a default install. Empty `storageClass` values omit
+`storageClassName` and rely on a default StorageClass or a compatible
+classless persistent volume.
+
 | Path                       | Default                       | Notes |
 |----------------------------|-------------------------------|-------|
 | `persistence.enabled`      | `true`                        | Mount the pre-existing general PVC for logs and other non-scheduler uses. |
 | `persistence.size`         | `50Gi`                        |       |
 | `persistence.accessModes`  | `[ReadWriteOnce]`             | Access mode for the general PVC. |
 | `persistence.storageClass` | `""`                          | Use cluster default unless set. Use `"-"` to disable a `storageClassName`. |
+| `persistence.existingClaim` | `""`                         | When set, skip PVC creation and mount this claim. |
 | `persistence.mountPath`    | `/var/lib/nemo-retriever`     | General persistent files only; scheduler state and payloads are never stored here. |
+| `retrieverResults.enabled` | `true`                        | Create the results PVC unless `existingClaim` is set. |
+| `retrieverResults.storageClass` | `""`                     | Use cluster default unless set. Use `"-"` to disable a `storageClassName`. |
+| `retrieverResults.existingClaim` | `""`                     | When set, skip PVC creation and mount this claim. |
+| `topology.vectordb.persistence.enabled` | `true`           | Create the VectorDB PVC when `serviceConfig.vectordb.enabled` is `true`. |
+| `topology.vectordb.persistence.storageClass` | `""`        | Use cluster default unless set. Use `"-"` to disable a `storageClassName`. No `existingClaim` path. |
 
 The gateway enforces active-lease budgets independently of worker replicas.
 `serviceConfig.workQueue.maxActiveLeases.realtime` defaults to `8` and


### PR DESCRIPTION
## Summary

1. **Prerequisites** - Require a working persistent-volume binding strategy before the default Helm install.
2. **Helm quickstart** - Add preflight commands, the seven default PVC paths, and per-NIM StorageClass values.
3. **Troubleshooting** - Explain Helm `STATUS: deployed` with Pending claims and the `no storage class is set` event.
4. **Support matrix images** - Align the Default NIMs table with the packaged chart: `nemotron-object-detection:2.0.1` for page_elements and table_structure, and `nemotron-ocr-v2:2.0.1` for OCR.

**2 commits** on branch `docs/6609936-helm-storage-prereq`.

Fixes NVBug 6609936 and NVBug 6609873. Docs-only. Does not change chart defaults, templates, or NIM Operator behavior.

### What changed

The 26.08 default Helm path creates seven PersistentVolumeClaims. On a cluster with NIM Operator installed but no default or named StorageClass and no compatible static PVs, `helm install` reports `STATUS: deployed` while all seven claims stay `Pending`. That blocks the retriever service, VectorDB, and the four core NIM workloads.

The public support matrix also listed stale Helm default images (`nemotron-page-elements-v3:1.8.0`, `nemotron-table-structure-v1:1.8.0`, `nemotron-ocr-v2:1.4.0`). The chart and Helm README already use the combined object-detection image and OCR 2.0.1. Air-gapped, mirrored, or allowlisted installs that follow the matrix can pull the wrong images.

This PR documents the missing storage prerequisite on the public support matrix and Helm README, adds first-response troubleshooting, and aligns the Default NIMs image rows with `values.yaml`.

| Area | Change |
|------|--------|
| Support matrix | New Kubernetes Helm storage requirements section and preflight commands |
| Support matrix Default NIMs | `page_elements` / `table_structure` -> `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1`; `ocr` -> `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` |
| Helm README | Persistent storage prerequisite before install; claim table; named-class `--set` example; Persistence and NIM Operator value paths |
| Troubleshoot / FAQ / getting started / deployment options | Pending-PVC guidance and pointers |

Documented Helm value paths (verified against `values.yaml` and templates on current `main`):

- Chart-managed: `persistence.storageClass`, `retrieverResults.storageClass`, `topology.vectordb.persistence.storageClass`
- Core NIMCache: `nimOperator.<key>.storage.pvc.storageClass` for `page_elements`, `table_structure`, `ocr`, and `vlm_embed`
- `nimOperator.nimCache.pvc.storageClass` is documented as not applied to per-NIM caches
- `existingClaim` is documented only for `persistence` and `retrieverResults` (VectorDB has no such path)

Default NIM images (verified against `nimOperator.<key>.image` in `values.yaml` and the Helm README):

- `page_elements` / `table_structure`: `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1`
- `ocr`: `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`
- Remaining six rows already matched the chart and were left unchanged

<details>
<summary><h3>Commit summary</h3></summary>

### Commits

| SHA | Description |
|-----|-------------|
| `5ae33c1f3` | docs(helm): add storage preflight for default PVC claims |
| `f60e5f34c` | docs(helm): align support matrix default NIM images with chart |

**Commit `5ae33c1f3` -- add storage preflight for default PVC claims:**
- Add the seven default claims, preflight commands, and named StorageClass example to the Helm README
- Add Kubernetes Helm storage requirements to the support matrix
- Add Pending-PVC troubleshooting and a matching FAQ

**Commit `f60e5f34c` -- align support matrix default NIM images with chart:**
- Replace stale standalone 1.8.0 / 1.4.0 Default image rows with the current chart images
- Note that page_elements and table_structure share the combined object-detection image

</details>

---

Checklist
---

- [x] Links to a ticket (NVBug 6609936, NVBug 6609873)
- [ ] Has an assignee
- [ ] Has reviewers
- [ ] Has tests
- [ ] Pipeline passes
- [ ] All discussions resolved
- [x] Documentation updated

## Test plan

- [ ] Confirm the support matrix requires a PV binding strategy and shows `kubectl get storageclass` / `kubectl get pv` before Helm install
- [ ] Confirm the Helm README prerequisite lists all seven default claims and the three chart-managed plus four per-NIM StorageClass paths
- [ ] Confirm the README tells users not to rely on `nimOperator.nimCache.pvc.storageClass`
- [ ] Confirm install sections 2, 3, and the 26.08 minimal install point at the storage prerequisite
- [ ] Confirm troubleshoot covers Helm success with Pending PVCs and the `no storage class is set` event
- [ ] Confirm FAQ and deployment-options / getting-started pages point to the new guidance
- [ ] Confirm the Default NIMs table lists `nemotron-object-detection:2.0.1` for page_elements and table_structure and `nemotron-ocr-v2:2.0.1` for OCR
- [ ] Confirm those three rows match `nimOperator.<key>.image` in `values.yaml` and the Helm README
- [ ] Confirm `git diff --name-only upstream/main..HEAD` is docs-only (the six files in this PR)