### PR TITLE
Enable hybrid pdf extraction for explicit OCR options

### DIFF
--- a/nemo_retriever/src/nemo_retriever/common/stage_errors.py
+++ b/nemo_retriever/src/nemo_retriever/common/stage_errors.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared detection of structured row-level stage errors."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+ERROR_FIELD_KEYS = ("error", "errors", "exception", "traceback", "failed")
+
+
+def is_populated_error_field(key: str, value: Any) -> bool:
+    """Return whether a conventional stage-error field contains a failure."""
+    if value is None:
+        return False
+    if key == "failed" and isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) > 0
+    return bool(value)
+
+
+def iter_stage_errors_from_value(value: Any, *, path: str = "") -> Iterator[dict[str, Any]]:
+    """Yield populated error fields recursively with their value paths."""
+    if isinstance(value, dict):
+        for key in ERROR_FIELD_KEYS:
+            if key in value and is_populated_error_field(key, value.get(key)):
+                yield {
+                    "path": f"{path}.{key}" if path else key,
+                    "error": value.get(key),
+                }
+        for key, child in value.items():
+            if key in ERROR_FIELD_KEYS and is_populated_error_field(key, child):
+                continue
+            child_path = f"{path}.{key}" if path else str(key)
+            yield from iter_stage_errors_from_value(child, path=child_path)
+        return
+    if isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            child_path = f"{path}[{index}]" if path else f"[{index}]"
+            yield from iter_stage_errors_from_value(child, path=child_path)

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -396,7 +396,8 @@ def to_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
     no row survives conversion.
     """
     if isinstance(rows, list) and all(isinstance(batch, list) for batch in rows):
-        return rows
+        nonempty_batches = [batch for batch in rows if batch]
+        return rows if len(nonempty_batches) == len(rows) else nonempty_batches
     if hasattr(rows, "to_pandas"):
         rows = rows.to_pandas()
     if hasattr(rows, "to_dict"):

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -15,7 +15,7 @@ from typing import Any, TypedDict
 from pydantic import ValidationError
 
 from nemo_retriever.common.schemas.collections import QueryHit
-from nemo_retriever.common.stage_errors import iter_stage_errors_from_value
+from nemo_retriever.common.stage_errors import ERROR_FIELD_KEYS, iter_stage_errors_from_value
 
 _CONTENT_TYPE_ALIASES: dict[str, str] = {
     "chart_caption": "chart",
@@ -342,24 +342,23 @@ def _row_has_uploadable_content_without_embedding(row: dict[str, Any]) -> bool:
     return bool(_text_from_graph_row(row, metadata)) or _is_image_backed_row(row)
 
 
-def _format_stage_error(path: str, error: Any) -> str:
-    if isinstance(error, dict):
-        details = [error.get(key) for key in ("stage", "type", "message")]
-        message = ": ".join(str(value).strip() for value in details if value is not None and str(value).strip())
-        if message:
-            return f"{path}: {message}"
-    return f"{path}: {error}"
+def _stage_error_field(path: Any) -> str:
+    text = str(path or "")
+    for field in ERROR_FIELD_KEYS:
+        if text == field or text.endswith(f".{field}"):
+            return field
+    return "error"
 
 
 def _raise_for_empty_vdb_conversion(graph_rows: list[dict[str, Any]]) -> None:
     upstream_errors = [error for row in graph_rows for error in iter_stage_errors_from_value(row)]
     if upstream_errors:
-        rendered = "; ".join(_format_stage_error(str(error["path"]), error["error"]) for error in upstream_errors[:3])
-        remaining = len(upstream_errors) - 3
-        suffix = f"; and {remaining} more" if remaining > 0 else ""
+        error_fields = Counter(_stage_error_field(error.get("path")) for error in upstream_errors)
+        summary = ", ".join(f"{field}={count}" for field, count in sorted(error_fields.items()))
         raise VdbUploadError(
             f"vdb_upload received {len(graph_rows)} row(s), but none were uploadable because upstream stages "
-            f"reported errors: {rendered}{suffix}"
+            f"reported {len(upstream_errors)} structured row error(s) ({summary}); "
+            "error payloads are omitted because they may contain sensitive data."
         )
 
     reasons = Counter(

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, TypedDict
@@ -14,6 +15,7 @@ from typing import Any, TypedDict
 from pydantic import ValidationError
 
 from nemo_retriever.common.schemas.collections import QueryHit
+from nemo_retriever.common.stage_errors import iter_stage_errors_from_value
 
 _CONTENT_TYPE_ALIASES: dict[str, str] = {
     "chart_caption": "chart",
@@ -32,6 +34,10 @@ def normalize_content_type(value: Any) -> str | None:
 
 class RetrievalContractError(RuntimeError):
     """A backend retrieval result cannot satisfy the canonical hit contract."""
+
+
+class VdbUploadError(ValueError):
+    """A nonempty graph batch cannot produce any canonical VDB records."""
 
 
 def validate_collection_retrieval_results(
@@ -336,16 +342,58 @@ def _row_has_uploadable_content_without_embedding(row: dict[str, Any]) -> bool:
     return bool(_text_from_graph_row(row, metadata)) or _is_image_backed_row(row)
 
 
+def _format_stage_error(path: str, error: Any) -> str:
+    if isinstance(error, dict):
+        details = [error.get(key) for key in ("stage", "type", "message")]
+        message = ": ".join(str(value).strip() for value in details if value is not None and str(value).strip())
+        if message:
+            return f"{path}: {message}"
+    return f"{path}: {error}"
+
+
+def _raise_for_empty_vdb_conversion(graph_rows: list[dict[str, Any]]) -> None:
+    upstream_errors = [error for row in graph_rows for error in iter_stage_errors_from_value(row)]
+    if upstream_errors:
+        rendered = "; ".join(_format_stage_error(str(error["path"]), error["error"]) for error in upstream_errors[:3])
+        remaining = len(upstream_errors) - 3
+        suffix = f"; and {remaining} more" if remaining > 0 else ""
+        raise VdbUploadError(
+            f"vdb_upload received {len(graph_rows)} row(s), but none were uploadable because upstream stages "
+            f"reported errors: {rendered}{suffix}"
+        )
+
+    reasons = Counter(
+        (
+            "missing embedding"
+            if _row_has_uploadable_content_without_embedding(row)
+            else "missing searchable text or image backing"
+        )
+        for row in graph_rows
+    )
+    if "missing embedding" in reasons:
+        summary = ", ".join(f"{reason}={count}" for reason, count in sorted(reasons.items()))
+        raise VdbUploadError(
+            "vdb_upload requires embedded records, but no embeddings were found. "
+            f"Received {len(graph_rows)} nonempty row(s); rejection reasons: {summary}. "
+            "Add an embed stage or provide a supported embedding column."
+        )
+    summary = ", ".join(f"{reason}={count}" for reason, count in sorted(reasons.items()))
+    raise VdbUploadError(
+        f"vdb_upload received {len(graph_rows)} row(s), but none were uploadable; rejection reasons: {summary}."
+    )
+
+
 def to_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
     """Convert graph-ingest rows into the nested record shape expected by client VDBs.
 
     Dense rows require an embedding and either nonblank text or concrete image backing.
-    When no row survives conversion, returns ``[]`` — a falsy value so
-    ``if not records`` skips :meth:`~nemo_retriever.vdb.adt_vdb.VDB.run`.
+    Genuinely empty input returns ``[]`` so Ray can process empty partitions.
+    A nonempty graph batch that produces zero records raises
+    :class:`VdbUploadError` before a backend write is attempted.
     When at least one row converts, returns ``[batch]`` with a single non-empty inner list
     (never ``[[]]``, which would be truthy and could trip backends on an empty insert).
-    Uploadable graph content without an embedding raises ``ValueError`` when no
-    row survives conversion. Genuinely empty input continues to return ``[]``.
+    Uploadable graph content without an embedding raises ``VdbUploadError`` when
+    no row survives conversion.
     """
     if isinstance(rows, list) and all(isinstance(batch, list) for batch in rows):
         return rows
@@ -358,11 +406,8 @@ def to_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
     # would call _client_record_from_graph_row twice per row on large datasets.
     # isinstance(row, dict): plain lists are not normalized like DataFrame rows; skip None/Series/etc.
     inner = [record for row in graph_rows if (record := _client_record_from_graph_row(row)) is not None]
-    if not inner and any(_row_has_uploadable_content_without_embedding(row) for row in graph_rows):
-        raise ValueError(
-            "vdb_upload requires embedded records, but no embeddings were found. "
-            "Add an embed stage or provide a supported embedding column."
-        )
+    if not inner and graph_rows:
+        _raise_for_empty_vdb_conversion(graph_rows)
     # Preserve legacy contract: no uploadable rows → [], not [[]].
     return [inner] if inner else []
 

--- a/nemo_retriever/src/nemo_retriever/ingest/plan.py
+++ b/nemo_retriever/src/nemo_retriever/ingest/plan.py
@@ -604,6 +604,15 @@ def resolve_ingest_plan(request: IngestPlanRequest) -> ResolvedIngestPlan:
     _validate_profile_manifest(validated_profile, branches)
 
     extract_kwargs = profile_extract_defaults(validated_profile)
+    if (
+        validated_profile == "auto"
+        and extract.method is None
+        and (extract.ocr_version is not None or extract.ocr_lang is not None)
+    ):
+        # An explicit OCR selector is an opt-in to scanned-page OCR. The
+        # default pdfium method only reads a native text layer, so select the
+        # hybrid method unless the caller chose a method explicitly.
+        extract_kwargs["method"] = "pdfium_hybrid"
     extract_kwargs.update(
         {
             key: value

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -84,9 +84,14 @@ from nemo_retriever.common.input_files import (
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 from nemo_retriever.common.ray_runtime import ensure_local_ray_runtime
 from nemo_retriever.common.ray_resource_hueristics import gather_cluster_resources
+from nemo_retriever.common.stage_errors import (
+    ERROR_FIELD_KEYS,
+    is_populated_error_field,
+    iter_stage_errors_from_value,
+)
 from nemo_retriever.common.modality.txt.split import empty_text_chunks_df
 
-_ERROR_FIELD_KEYS = ("error", "errors", "exception", "traceback", "failed")
+_ERROR_FIELD_KEYS = ERROR_FIELD_KEYS
 _REMOTE_EMBED_ENDPOINT_FIELDS = ("embedding_endpoint", "embed_invoke_url")
 _DEFAULT_PAGE_ELEMENTS_COLUMN = "page_elements_v3"
 _DEFAULT_EMBED_COLUMN = "text_embeddings_1b_v2"
@@ -1104,35 +1109,11 @@ class GraphIngestor(ingestor):
 
     @staticmethod
     def _is_populated_error_field(key: str, value: Any) -> bool:
-        if value is None:
-            return False
-        if key == "failed" and isinstance(value, bool):
-            return value
-        if isinstance(value, str):
-            return bool(value.strip())
-        if isinstance(value, (list, tuple, set, dict)):
-            return len(value) > 0
-        return bool(value)
+        return is_populated_error_field(key, value)
 
     @classmethod
     def _iter_stage_errors_from_value(cls, value: Any, *, path: str = "") -> Iterator[dict[str, Any]]:
-        if isinstance(value, dict):
-            for key in _ERROR_FIELD_KEYS:
-                if key in value and cls._is_populated_error_field(key, value.get(key)):
-                    yield {
-                        "path": f"{path}.{key}" if path else key,
-                        "error": value.get(key),
-                    }
-            for key, child in value.items():
-                if key in _ERROR_FIELD_KEYS and cls._is_populated_error_field(key, child):
-                    continue
-                child_path = f"{path}.{key}" if path else str(key)
-                yield from cls._iter_stage_errors_from_value(child, path=child_path)
-            return
-        if isinstance(value, (list, tuple)):
-            for i, child in enumerate(value):
-                child_path = f"{path}[{i}]" if path else f"[{i}]"
-                yield from cls._iter_stage_errors_from_value(child, path=child_path)
+        yield from iter_stage_errors_from_value(value, path=path)
 
     @staticmethod
     def _row_value(row: Any, key: str) -> Any:

--- a/nemo_retriever/tests/test_ingest_manifest.py
+++ b/nemo_retriever/tests/test_ingest_manifest.py
@@ -202,6 +202,34 @@ def test_ingest_plan_auto_profile_preserves_manifest_defaults(tmp_path) -> None:
     assert plan.create_kwargs == {"run_mode": "inprocess"}
 
 
+@pytest.mark.parametrize(
+    "extract",
+    [
+        pytest.param(IngestExtractOptions(ocr_version="v2"), id="version"),
+        pytest.param(IngestExtractOptions(ocr_lang="english"), id="language"),
+    ],
+)
+def test_ingest_plan_ocr_selector_enables_hybrid_pdf_extraction(tmp_path, extract) -> None:
+    pdf = tmp_path / "scanned.pdf"
+    pdf.write_bytes(b"pdf")
+
+    plan = _resolve_plan([str(pdf)], extract=extract)
+
+    assert plan.extract_params.method == "pdfium_hybrid"
+
+
+def test_ingest_plan_explicit_pdf_method_wins_over_ocr_selector(tmp_path) -> None:
+    pdf = tmp_path / "scanned.pdf"
+    pdf.write_bytes(b"pdf")
+
+    plan = _resolve_plan(
+        [str(pdf)],
+        extract=IngestExtractOptions(method="pdfium", ocr_version="v2"),
+    )
+
+    assert plan.extract_params.method == "pdfium"
+
+
 def test_ingest_plan_fast_text_profile_is_pdf_text_only(tmp_path) -> None:
     pdf = tmp_path / "manual.pdf"
     pdf.write_bytes(b"pdf")

--- a/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
+++ b/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
@@ -15,7 +15,7 @@ from nemo_retriever.common.vdb.adt_vdb import (
     CollectionWriteResult,
     VDB,
 )
-from nemo_retriever.common.vdb.records import RetrievalContractError
+from nemo_retriever.common.vdb.records import RetrievalContractError, VdbUploadError
 from nemo_retriever.operators.vdb import IngestVdbOperator, RetrieveVdbOperator
 from nemo_retriever.operators import vdb as vdb_operator_module
 from nemo_retriever.operators.vdb import PutVdbOperator
@@ -301,7 +301,7 @@ def test_ingest_operator_retains_embedded_blank_image_row_without_text_fidelity(
         pytest.param(np.ones((2, 2), dtype=np.uint8), id="numpy"),
     ],
 )
-def test_ingest_operator_noncanonical_image_payload_fails_closed_without_truthiness(
+def test_ingest_operator_rejects_noncanonical_image_payload_without_truthiness(
     image_payload: Any,
 ) -> None:
     vdb = FakeVDB()
@@ -316,7 +316,11 @@ def test_ingest_operator_noncanonical_image_payload_fails_closed_without_truthin
         }
     ]
 
-    assert operator(data) is data
+    with pytest.raises(
+        VdbUploadError,
+        match=r"none were uploadable; .*missing searchable text or image backing=1",
+    ):
+        operator(data)
     assert vdb.run_calls == []
 
 
@@ -346,7 +350,7 @@ def test_ingest_operator_retains_image_only_row_with_stored_image_uri(
     }
 
 
-def test_ingest_operator_drops_embedded_blank_row_without_image_backing() -> None:
+def test_ingest_operator_rejects_nonempty_batch_with_zero_uploadable_records() -> None:
     vdb = FakeVDB()
     operator = IngestVdbOperator(vdb=vdb)
     data = [
@@ -358,7 +362,37 @@ def test_ingest_operator_drops_embedded_blank_row_without_image_backing() -> Non
         }
     ]
 
-    assert operator(data) is data
+    with pytest.raises(
+        VdbUploadError,
+        match=r"received 1 row\(s\), but none were uploadable; .*missing searchable text or image backing=1",
+    ):
+        operator(data)
+    assert vdb.run_calls == []
+
+
+def test_ingest_operator_surfaces_upstream_row_errors_before_vdb_write() -> None:
+    vdb = FakeVDB()
+    operator = IngestVdbOperator(vdb=vdb)
+    data = pd.DataFrame(
+        [
+            {
+                "text": "",
+                "metadata": {
+                    "source_path": "/tmp/scanned.pdf",
+                    "error": {"stage": "ocr", "type": "RuntimeError", "message": "model failed"},
+                },
+            }
+        ]
+    )
+
+    with pytest.raises(
+        VdbUploadError,
+        match=(
+            r"none were uploadable because upstream stages reported errors: "
+            r"metadata\.error: ocr: RuntimeError: model failed"
+        ),
+    ):
+        operator.process(data)
     assert vdb.run_calls == []
 
 

--- a/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
+++ b/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
@@ -370,7 +370,7 @@ def test_ingest_operator_rejects_nonempty_batch_with_zero_uploadable_records() -
     assert vdb.run_calls == []
 
 
-def test_ingest_operator_surfaces_upstream_row_errors_before_vdb_write() -> None:
+def test_ingest_operator_reports_upstream_error_counts_without_payloads() -> None:
     vdb = FakeVDB()
     operator = IngestVdbOperator(vdb=vdb)
     data = pd.DataFrame(
@@ -379,7 +379,13 @@ def test_ingest_operator_surfaces_upstream_row_errors_before_vdb_write() -> None
                 "text": "",
                 "metadata": {
                     "source_path": "/tmp/scanned.pdf",
-                    "error": {"stage": "ocr", "type": "RuntimeError", "message": "model failed"},
+                    "error": {
+                        "stage": "ocr-nvapi-secret",
+                        "type": "CustomerDocumentText",
+                        "message": "private document content Authorization: Bearer token-secret",
+                    },
+                    "exception": "password=credential-secret",
+                    "traceback": "Traceback containing private customer text",
                 },
             }
         ]
@@ -387,12 +393,17 @@ def test_ingest_operator_surfaces_upstream_row_errors_before_vdb_write() -> None
 
     with pytest.raises(
         VdbUploadError,
-        match=(
-            r"none were uploadable because upstream stages reported errors: "
-            r"metadata\.error: ocr: RuntimeError: model failed"
-        ),
-    ):
+        match=r"reported 3 structured row error\(s\) \(error=1, exception=1, traceback=1\)",
+    ) as exc_info:
         operator.process(data)
+    rendered = str(exc_info.value)
+    assert "payloads are omitted because they may contain sensitive data" in rendered
+    assert "nvapi-secret" not in rendered
+    assert "CustomerDocumentText" not in rendered
+    assert "private document content" not in rendered
+    assert "token-secret" not in rendered
+    assert "credential-secret" not in rendered
+    assert "private customer text" not in rendered
     assert vdb.run_calls == []
 
 

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -655,6 +655,7 @@ def test_root_ingest_passes_ocr_lang_option(monkeypatch, tmp_path) -> None:
     assert result.exit_code == 0
     extract_params = fake_ingestor.extract.call_args.args[0]
     assert isinstance(extract_params, ExtractParams)
+    assert extract_params.method == "pdfium_hybrid"
     assert extract_params.ocr_version == "v2"
     assert extract_params.ocr_lang == "english"
 

--- a/nemo_retriever/tests/test_vdb_records.py
+++ b/nemo_retriever/tests/test_vdb_records.py
@@ -129,6 +129,25 @@ def test_canonical_record_batches_pass_through_without_reconversion() -> None:
     assert to_client_vdb_records(records) is records
 
 
+@pytest.mark.parametrize(
+    ("records", "expected"),
+    [
+        pytest.param([[]], [], id="single-empty-batch"),
+        pytest.param([[], []], [], id="multiple-empty-batches"),
+        pytest.param(
+            [[], [{"metadata": {"content": "canonical"}}], []],
+            [[{"metadata": {"content": "canonical"}}]],
+            id="mixed",
+        ),
+    ],
+)
+def test_canonical_record_batches_remove_empty_inner_batches(
+    records: list[list[dict]],
+    expected: list[list[dict]],
+) -> None:
+    assert to_client_vdb_records(records) == expected
+
+
 def test_graph_record_conversion_preserves_service_provenance() -> None:
     records = to_client_vdb_records(
         [


### PR DESCRIPTION
## Description

Previously, the auto profile retained the text-only pdfium extraction method even when an OCR option was supplied. Scanned PDFs could therefore reach the VDB stage without extracted text or embeddings. The VDB adapter silently skipped those rows, allowing Ray execution to finish before the CLI reported a misleading LanceDB verification failure.

The ingest planner now selects pdfium_hybrid when an OCR option is explicitly provided and no extraction method is specified. An explicit `--method` continues to take precedence.

The VDB adapter also now raises `VdbUploadError` when a nonempty batch produces zero uploadable records. The error reports rejection reasons and surfaces structured upstream stage errors before attempting the backend write. Truly empty batches remain valid no-ops. Shared stage-error detection keeps this behavior consistent with `GraphIngestor` diagnostics.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
