### PR TITLE
docs: add OrcaRouter as an OpenAI-compatible gateway example

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -37,7 +37,7 @@ Persisted pipeline graphs never contain literal API keys. Configure a graph with
 api_key="os.environ/NVIDIA_API_KEY"
 ```
 
-Use the provider's own variable name, for example `os.environ/OPENAI_API_KEY` for an OpenAI model. The reference is stored in graph JSON and resolved only when the operator is constructed or invoked on the worker.
+Use the provider's own variable name, for example `os.environ/OPENAI_API_KEY` for an OpenAI model. For an OpenAI-compatible gateway such as [OrcaRouter](https://www.orcarouter.ai), use `os.environ/ORCAROUTER_API_KEY`. The reference is stored in graph JSON and resolved only when the operator is constructed or invoked on the worker.
 
 Literal keys remain available for non-persisted local execution, but attempting to serialize one raises an error. This prevents graph persistence from silently substituting an NVIDIA credential for another provider's key.
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -212,6 +212,27 @@ titles = GenericGenerationOperator(
 ).run(pd.DataFrame({"style": ["concise"], "document": ["Quarterly results"]}))
 ```
 
+To use a different OpenAI-compatible gateway, set `model` to an `openai/`-prefixed
+model ID and pass the gateway base URL as `api_base`. For example, route through
+[OrcaRouter](https://www.orcarouter.ai) with an `ORCAROUTER_API_KEY` (keys start
+with `sk-orca-`):
+
+```python
+orcarouter_params = TextGenerationParams.from_kwargs(
+    model="openai/orcarouter/auto",
+    api_base="https://api.orcarouter.ai/v1",
+    api_key="os.environ/ORCAROUTER_API_KEY",
+    temperature=0.0,
+    max_tokens=512,
+)
+summaries = SummarizationOperator(orcarouter_params).run(
+    pd.DataFrame({"text": ["A long document to summarize."]})
+)
+```
+
+Any OrcaRouter model ID works in the `openai/`-prefixed form, for example
+`openai/anthropic/claude-sonnet-4.6` or `openai/deepseek/deepseek-v4-pro`.
+
 `SummarizationOperator` defaults to `text`, `summary`, `summary_latency_s`, `summary_model`, and `summary_error`. `GenericGenerationOperator` maps each named prompt placeholder to a physical DataFrame column and derives the metadata column names from `output_column`. Prompt contracts are validated when the operator is constructed, before any provider request runs.
 
 To define another one-request/one-text-result task, subclass `TextGenerationTask`, declare `required_inputs`, and implement `build_request()`. Then construct it from a `TextGenerationOperator` subclass with explicit logical-input-to-DataFrame-column mappings. This abstraction is intentionally text-only; use a separate operator family for embeddings, captioning, tools, streaming, or structured domain results.

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -64,6 +64,26 @@ agentic:
   request_timeout_s: 1800
 ```
 
+For example, to route the agentic LLM through an OpenAI-compatible gateway such
+as [OrcaRouter](https://www.orcarouter.ai), set `llm_model` to a model on that
+gateway, point `invoke_url` at its chat-completions endpoint, and export the
+gateway key in the service process environment. OrcaRouter uses the
+`ORCAROUTER_API_KEY` environment variable, and its keys start with `sk-orca-`.
+
+```yaml
+agentic:
+  enabled: true
+  llm_model: orcarouter/auto
+  invoke_url: https://api.orcarouter.ai/v1/chat/completions
+  reasoning_effort: high
+  backend_top_k: 20
+  react_max_steps: 50
+  request_timeout_s: 1800
+```
+
+You can use any OrcaRouter model ID as `llm_model`, for example
+`anthropic/claude-sonnet-4.6` or `deepseek/deepseek-v4-pro`.
+
 The VectorDB process owns the LanceDB volume and executes the agentic workflow.
 Start it with matching `--agentic`, `--agentic-llm-model`, and
 `--agentic-invoke-url` options. The LLM and embedding credentials are resolved


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a named OpenAI-compatible gateway example in the documentation. With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint. Because NeMo Retriever's OpenAI-compatible client paths are a thin base-URL swap, any NeMo Retriever pipeline or agent that uses them also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents — with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys** — bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails** — screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall** — tool allow-lists with per-argument validation.
- **Audit trail** — a record of every match, verdict, and approval decision.

### What changed

Documentation only — three pages under `docs/docs/extraction/`:

- **`workflow-agentic-retrieval.md`** — added a named agentic-service configuration example routing `llm_model` / `invoke_url` through OrcaRouter, plus the `ORCAROUTER_API_KEY` environment note.
- **`nemo-retriever-api-reference.md`** — added a `TextGenerationParams.from_kwargs(...)` example using `openai/orcarouter/auto` with `api_base="https://api.orcarouter.ai/v1"`.
- **`api-keys.md`** — noted `os.environ/ORCAROUTER_API_KEY` as the credential reference for OpenAI-compatible gateways.

No code, configuration, or dependency changes. The examples follow the existing OpenAI-compatible wiring already documented: LiteLLM `openai/<model>` + `api_base` for the Python library, and `invoke_url` + `llm_model` for agentic service mode.

### Verification

Both documented patterns were exercised live against `https://api.orcarouter.ai/v1` before writing the examples:

- LiteLLM `openai/orcarouter/auto` (and the namespaced `openai/anthropic/claude-sonnet-4.6`, `openai/deepseek/deepseek-v4-pro`) returned successful completions.
- A direct OpenAI-compatible client pointed at the same endpoint (the agentic service pattern) returned successful completions.

I'm an engineer on the OrcaRouter team.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
