### PR TITLE
docs: align batch resource override docs with implemented controls (NVBug 5962930)

### DIFF
--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -14,13 +14,15 @@ Use this guide to document practical recommendations for:
 
 ## Batch resource sizing
 
-In batch mode, NeMo Retriever Library sizes unspecified Ray actor pools from the CPU and GPU resources that Ray reports as available immediately before the pipeline is submitted. This prevents default extraction, OCR, and embedding pools from reserving more resources than the cluster can schedule.
+In batch mode, NeMo Retriever Library sizes unspecified Ray actor pools from Ray CPU and GPU resources. The library uses the resources that Ray reports as available immediately before it submits the pipeline. This prevents default extraction, OCR, and embedding pools from reserving more resources than the cluster can schedule.
 
 For filesystem inputs, the library reserves CPU capacity for each Ray Data `ReadBinary` source task before it sizes actor pools. This reservation lets the input stage start instead of being blocked by persistent extraction actors. Inputs that are already Ray datasets, such as inline text rows, do not require this reservation.
 
 If you set `BatchTuningParams` worker counts or direct `node_overrides`, those requests and required source-task reservations must fit the available Ray CPU and GPU budget. The library validates the final plan before submitting work and raises an error when it is infeasible. Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity before retrying.
 
-Environment variables do not override CPU or GPU counts or per-stage worker pools. To limit how many GPUs Ray can use, start a Ray cluster with a restricted GPU set, for example `CUDA_VISIBLE_DEVICES=0 ray start --head --num-gpus=1`.
+### Override worker counts
+
+The library does not read environment variables to set worker counts or CPU and GPU totals. `CUDA_VISIBLE_DEVICES` still controls which GPUs Ray can see. To limit GPU count, start a Ray cluster with a restricted GPU set, for example `CUDA_VISIBLE_DEVICES=0 ray start --head --num-gpus=1`.
 
 Set explicit worker counts with batch-mode CLI flags or with `BatchTuningParams` on `.extract()` and `.embed()`.
 

--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -20,6 +20,51 @@ For filesystem inputs, the library reserves CPU capacity for each Ray Data `Read
 
 If you set `BatchTuningParams` worker counts or direct `node_overrides`, those requests and required source-task reservations must fit the available Ray CPU and GPU budget. The library validates the final plan before submitting work and raises an error when it is infeasible. Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity before retrying.
 
+Environment variables do not override CPU or GPU counts or per-stage worker pools. To limit how many GPUs Ray can use, start a Ray cluster with a restricted GPU set, for example `CUDA_VISIBLE_DEVICES=0 ray start --head --num-gpus=1`.
+
+Set explicit worker counts with batch-mode CLI flags or with `BatchTuningParams` on `.extract()` and `.embed()`.
+
+The following CLI example sets worker counts for a batch ingest:
+
+```bash
+retriever ingest batch ./data/pdf_corpus \
+  --pdf-extract-workers 4 \
+  --page-elements-workers 3 \
+  --ocr-workers 3 \
+  --embed-workers 2
+```
+
+The following Python example passes the same worker counts through `BatchTuningParams`:
+
+```python
+from pathlib import Path
+
+from nemo_retriever import create_ingestor
+from nemo_retriever.common.params import BatchTuningParams
+
+documents = [str(Path("data/multimodal_test.pdf"))]
+
+chunks = (
+    create_ingestor(run_mode="batch")
+    .files(documents)
+    .extract(
+        batch_tuning=BatchTuningParams(
+            pdf_extract_workers=4,
+            page_elements_workers=3,
+            ocr_workers=3,
+        )
+    )
+    .embed(
+        batch_tuning=BatchTuningParams(
+            embed_workers=2,
+        )
+    )
+    .ingest()
+)
+```
+
+Related batch-size, CPU, and GPU-per-actor flags are documented in the [CLI ingest options](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md).
+
 Use the Ray dashboard to verify the available-resource snapshot and the planned worker allocation when you tune throughput.
 
 ## Shared preflight for custom Ray Data graphs

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -718,11 +718,9 @@ CUDA_VISIBLE_DEVICES=0 ray start --head --num-gpus=1
 ```
 Then run your pipeline as before with `--ray-address auto` so it connects to this single‑GPU Ray cluster. [NeMo Ray run guide](https://docs.nvidia.com/nemo/run/latest/guides/ray.html)
 
-## Multi-GPU resource heuristics (library batch mode)
+## Multi-GPU resource heuristics for library batch mode
 
-### Resource heuristics (batch mode)
-
-In batch mode, NeMo Retriever Library sizes unspecified Ray actor pools from the CPU and GPU resources that Ray reports as available immediately before the pipeline is submitted.
+In batch mode, NeMo Retriever Library sizes unspecified Ray actor pools from Ray CPU and GPU resources. The library uses the resources that Ray reports as available immediately before it submits the pipeline.
 
 The default sizing order is:
 
@@ -730,15 +728,15 @@ The default sizing order is:
 2. Scale unspecified worker pools from the available GPU count using built-in per-stage heuristic constants.
 3. Apply explicit `BatchTuningParams` values and `node_overrides`. These take precedence over the heuristic defaults.
 
-Environment variables do not override CPU or GPU counts or per-stage worker pools. To limit how many GPUs Ray can use, start a Ray cluster with a restricted GPU set as shown in the previous section.
+The library does not read environment variables to set worker counts or CPU and GPU totals. `CUDA_VISIBLE_DEVICES` still controls which GPUs Ray can see. To limit GPU count, start a Ray cluster with a restricted GPU set as shown in the previous section.
 
-### Override worker counts and GPU reservations
+### Override worker counts
 
 Set explicit worker counts when you need a fixed allocation. Unspecified fields still use the heuristic defaults.
 
-The following table lists the primary batch-mode worker controls.
+The following table lists the primary batch-mode worker controls:
 
-| CLI flag | `BatchTuningParams` field | Meaning |
+| CLI Flag | BatchTuningParams Field | Meaning |
 |---|---|---|
 | `--pdf-extract-workers` | `pdf_extract_workers` | Maximum Ray tasks for PDF extraction |
 | `--page-elements-workers` | `page_elements_workers` | Ray actors for page-element detection |

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -722,31 +722,73 @@ Then run your pipeline as before with `--ray-address auto` so it connects to thi
 
 ### Resource heuristics (batch mode)
 
-By default, batch mode computes resources using this order:
+In batch mode, NeMo Retriever Library sizes unspecified Ray actor pools from the CPU and GPU resources that Ray reports as available immediately before the pipeline is submitted.
 
-1. Auto-detected resources (Ray cluster if connected, otherwise local machine)
-2. Environment variables
-3. Explicit function arguments (highest precedence)
+The default sizing order is:
 
-This means defaults are deterministic but easy to override when you need fixed behavior.
+1. Detect CPU and GPU counts from the Ray cluster after the batch runtime starts (`cluster_resources` / `available_resources`).
+2. Scale unspecified worker pools from the available GPU count using built-in per-stage heuristic constants.
+3. Apply explicit `BatchTuningParams` values and `node_overrides`. These take precedence over the heuristic defaults.
 
-### Default behavior
+Environment variables do not override CPU or GPU counts or per-stage worker pools. To limit how many GPUs Ray can use, start a Ray cluster with a restricted GPU set as shown in the previous section.
 
-- `cpu_count` / `gpu_count` are detected from Ray (`cluster_resources`) or local host.
-- Worker heuristics:
-  - `page_elements_workers = gpu_count * page_elements_per_gpu`
-  - `detect_workers = gpu_count * ocr_per_gpu`
-  - `embed_workers = gpu_count * embed_per_gpu`
-  - minimum of `1` per stage
-- Stage GPU defaults:
-  - If `gpu_count >= 2` and `concurrent_gpu_stage_count == 3`, uses high-overlap values for page-elements/OCR/embed.
-  - Otherwise uses `min(max_gpu_per_stage, gpu_count / concurrent_gpu_stage_count)`.
+### Override worker counts and GPU reservations
 
-### Override variables
+Set explicit worker counts when you need a fixed allocation. Unspecified fields still use the heuristic defaults.
 
-| Variable | Where to set | Meaning |
+The following table lists the primary batch-mode worker controls.
+
+| CLI flag | `BatchTuningParams` field | Meaning |
 |---|---|---|
-| `override_cpu_count`, `override_gpu_count` | function args | Highest-priority CPU/GPU override |
+| `--pdf-extract-workers` | `pdf_extract_workers` | Maximum Ray tasks for PDF extraction |
+| `--page-elements-workers` | `page_elements_workers` | Ray actors for page-element detection |
+| `--ocr-workers` | `ocr_workers` | Ray actors for OCR inference |
+| `--embed-workers` | `embed_workers` | Ray actors for embedding |
+
+Related batch-size, CPU, and GPU-per-actor flags are documented in the [CLI ingest options](docs/cli/README.md).
+
+For the CLI, pass the batch-mode flags on `retriever ingest batch`:
+
+```bash
+retriever ingest batch ./data/pdf_corpus \
+  --pdf-extract-workers 4 \
+  --page-elements-workers 3 \
+  --ocr-workers 3 \
+  --embed-workers 2
+```
+
+For the Python API, pass `BatchTuningParams` on `.extract()` and `.embed()`:
+
+```python
+from pathlib import Path
+
+from nemo_retriever import create_ingestor
+from nemo_retriever.common.params import BatchTuningParams
+
+documents = [str(Path("../data/multimodal_test.pdf"))]
+
+chunks = (
+  create_ingestor(run_mode="batch")
+  .files(documents)
+  .extract(
+    batch_tuning=BatchTuningParams(
+      pdf_extract_workers=4,
+      page_elements_workers=3,
+      ocr_workers=3,
+    )
+  )
+  .embed(
+    batch_tuning=BatchTuningParams(
+      embed_workers=2,
+    )
+  )
+  .ingest()
+)
+```
+
+If explicit worker counts or `node_overrides` exceed the available Ray CPU or GPU budget, the library raises an error before it submits work. Reduce `*_workers` or per-node concurrency, or wait for shared-cluster capacity.
+
+For source-task CPU reservations and custom Ray Data graphs, refer to the [performance guide](https://docs.nvidia.com/nemo/retriever/latest/extraction/performance_guide/).
 
 ## NIM containers
 


### PR DESCRIPTION
## Summary
- Completes the remaining NVBug 5962930 docs gap after PR 1515: the 10 `NEMO_RETRIEVER_BATCH_*` env vars were already removed, but the README still documented `override_cpu_count`, `override_gpu_count`, and an env-var / function-argument precedence model that is not implemented.
- Replaces that stale guidance with the actual batch-mode controls: Ray cluster resource detection, CLI worker flags (`--pdf-extract-workers`, `--ocr-workers`, `--embed-workers`, and related flags), and `BatchTuningParams` on `.extract()` / `.embed()`.
- Adds matching CLI and Python examples to the published performance guide so library-mode users are not sent to nonfunctional override APIs.

## Test plan
- [x] Confirm `override_cpu_count`, `override_gpu_count`, and `NEMO_RETRIEVER_BATCH_*` no longer appear in the README or published extraction docs.
- [x] Confirm documented CLI flags and `BatchTuningParams` fields exist in `nemo_retriever/src/nemo_retriever/cli/ingest/options.py` and `BatchTuningParams`.
- [x] `git diff --name-only upstream/main..HEAD` is docs-only: `nemo_retriever/README.md` and `docs/docs/extraction/performance_guide.md`.
- [ ] Reviewer: skim the README resource-heuristics section and the performance guide examples for accuracy.
