### PR TITLE
fix(service): report release version in OpenAPI info.version

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -65,6 +65,8 @@ jobs:
             --build-arg HF_ACCESS_TOKEN=${{ secrets.HF_ACCESS_TOKEN }} \
             --build-arg DOWNLOAD_DEFAULT_TOKENIZER=True \
             --build-arg GIT_COMMIT=${GITHUB_SHA} \
+            --build-arg RETRIEVER_VERSION=${{ needs.determine-version.outputs.version }} \
+            --build-arg RETRIEVER_RELEASE_TYPE=release \
             -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ needs.determine-version.outputs.version }} \
             .
 

--- a/.github/workflows/scheduled-nightly.yml
+++ b/.github/workflows/scheduled-nightly.yml
@@ -68,6 +68,8 @@ jobs:
             --build-arg HF_ACCESS_TOKEN=${{ secrets.HF_ACCESS_TOKEN }} \
             --build-arg DOWNLOAD_DEFAULT_TOKENIZER=True \
             --build-arg GIT_COMMIT=${GITHUB_SHA} \
+            --build-arg RETRIEVER_VERSION=${{ needs.determine-version.outputs.version }} \
+            --build-arg RETRIEVER_RELEASE_TYPE=dev \
             -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ needs.determine-version.outputs.docker-tag }} \
             .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,16 @@ CMD ["/bin/bash"]
 # ---------------------------------------------------------------------------
 FROM install AS service
 
+# Optional release metadata for OpenAPI ``info.version`` and package version helpers.
+# Release builds should pass matching values, for example:
+#   --build-arg RETRIEVER_VERSION=26.08-RC4 --build-arg RETRIEVER_RELEASE_TYPE=release
+ARG RETRIEVER_VERSION=
+ARG RETRIEVER_RELEASE_TYPE=dev
+ENV RETRIEVER_VERSION=${RETRIEVER_VERSION}
+ENV RETRIEVER_RELEASE_TYPE=${RETRIEVER_RELEASE_TYPE}
+ENV RETRIEVER_BUILD_NUMBER=0
+ENV RETRIEVER_SERVICE_VERSION=${RETRIEVER_VERSION}
+
 ENV NEMO_RETRIEVER_SERVICE_CONFIG=/etc/nemo-retriever/retriever-service.yaml
 ENV HF_HUB_OFFLINE=1
 
@@ -211,6 +221,13 @@ CMD ["retriever", "service", "start", "--config", "/etc/nemo-retriever/retriever
 #     nemo-retriever-service-gpu
 # ---------------------------------------------------------------------------
 FROM install-service-gpu AS service-gpu
+
+ARG RETRIEVER_VERSION=
+ARG RETRIEVER_RELEASE_TYPE=dev
+ENV RETRIEVER_VERSION=${RETRIEVER_VERSION}
+ENV RETRIEVER_RELEASE_TYPE=${RETRIEVER_RELEASE_TYPE}
+ENV RETRIEVER_BUILD_NUMBER=0
+ENV RETRIEVER_SERVICE_VERSION=${RETRIEVER_VERSION}
 
 ENV NEMO_RETRIEVER_SERVICE_CONFIG=/etc/nemo-retriever/retriever-service.yaml
 

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -33,6 +33,7 @@ Highlights for the 26.08 release include:
 - Retriever Service v2 adds a scalable multi-pod architecture with gateway, process isolation, and VectorDB integration  
 - OpenTelemetry basic support for pipeline and service observability  
 - Expanded air-gapped deployment guidance in [deployment options](deployment-options.md) and the Helm chart README  
+- Fixed Retriever Service OpenAPI `info.version` reporting a stale `26.5.0` value. The service now reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.  
 
 ### Models, OCR, and captioning { #models-ocr-and-captioning }
 

--- a/nemo_retriever/docker.md
+++ b/nemo_retriever/docker.md
@@ -14,6 +14,18 @@ docker build \
   .
 ```
 
+For a release-tagged image whose OpenAPI document should report a specific version, pass matching build arguments:
+
+```bash
+docker build \
+  -f Dockerfile \
+  --target service \
+  --build-arg RETRIEVER_VERSION=26.08-RC4 \
+  --build-arg RETRIEVER_RELEASE_TYPE=release \
+  -t nemo-retriever-service:26.08-RC4 \
+  .
+```
+
 The `service` target installs `nemo_retriever[service]`, copies the packaged `retriever-service.yaml`, and starts the service with:
 
 ```bash

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -178,6 +178,8 @@ then override `service.image.repository` / `service.image.tag`:
 docker build \
     --target service \
     --build-arg DOWNLOAD_DEFAULT_TOKENIZER=True \
+    --build-arg RETRIEVER_VERSION=<TAG> \
+    --build-arg RETRIEVER_RELEASE_TYPE=release \
     -t <YOUR_REGISTRY>/nemo-retriever-service:<TAG> .
 docker push <YOUR_REGISTRY>/nemo-retriever-service:<TAG>
 ```
@@ -397,7 +399,8 @@ short list of knobs you'll touch first.
 | Path                          | Default                            | Notes |
 |-------------------------------|------------------------------------|-------|
 | `service.image.repository`    | `nvcr.io/nvidia/nemo-microservices/nrl-service` | NGC image; override to pin a different build or use a local registry. |
-| `service.image.tag`           | `26.5.0`                           |       |
+| `service.image.tag`           | `26.5.0`                           | Also injected as `RETRIEVER_SERVICE_VERSION` so `/openapi.json` `info.version` matches the running image tag. |
+
 | `service.replicas`            | `1`                                | Keep at 1 because standalone job and scheduler state are process-local. |
 | `service.installFfmpeg`       | `false`                            | Install `ffmpeg`/`ffprobe` at container startup by setting `INSTALL_FFMPEG=true`. Requires network egress, writable root filesystem, and sudo/setuid allowed. Not for air-gapped clusters — use a custom image instead. |
 | `service.resources.requests`  | `16 / 16Gi`                        | Tune in tandem with `serviceConfig.pipeline.*Workers`. |
@@ -954,8 +957,12 @@ configured key. `nrl-internal-vdb-auth` must contain a distinct, high-entropy
 credential. Internal authentication is opt-in for local compatibility; enable
 it for production deployments. When enabled, a missing Secret or key prevents
 the pods from starting instead of falling back to unauthenticated VectorDB
-access. Inline `serviceConfig.auth.apiToken` is rejected unless
-`allowInsecureInlineApiToken=true`, and must never be used for production.
+access. In `topology.mode=split`, `serviceConfig.auth.scopeTokenSecret.name`
+also requires `serviceConfig.vectordb.internalAuth.enabled=true`: pull workers
+never mount the public scope-token Secret, so they need the dedicated internal
+credential to claim `/v1/internal/work/claim`. Inline `serviceConfig.auth.apiToken`
+is rejected unless `allowInsecureInlineApiToken=true`, and must never be used
+for production.
 
 ### Disable one NIM and supply an external URL for it
 

--- a/nemo_retriever/helm/templates/deployment.yaml
+++ b/nemo_retriever/helm/templates/deployment.yaml
@@ -110,6 +110,8 @@ spec:
           env:
             - name: NEMO_RETRIEVER_SERVICE_CONFIG
               value: /etc/nemo-retriever/retriever-service.yaml
+            - name: RETRIEVER_SERVICE_VERSION
+              value: {{ include "nemo-retriever.runtime.image.tag" . | quote }}
             {{- if $internalAuth.enabled }}
             - name: NRL_INTERNAL_VDB_TOKEN
               valueFrom:
@@ -310,6 +312,8 @@ spec:
           env:
             - name: NEMO_RETRIEVER_SERVICE_CONFIG
               value: /etc/nemo-retriever/retriever-service.yaml
+            - name: RETRIEVER_SERVICE_VERSION
+              value: {{ include "nemo-retriever.runtime.image.tag" $ | quote }}
             {{- if $internalAuth.enabled }}
             - name: NRL_INTERNAL_VDB_TOKEN
               valueFrom:

--- a/nemo_retriever/src/nemo_retriever/service/app.py
+++ b/nemo_retriever/src/nemo_retriever/service/app.py
@@ -268,6 +268,7 @@ def create_app(config: ServiceConfig) -> FastAPI:
 
     from nemo_retriever.service.metrics_otel import configure_metrics, instrument_app as instrument_otel_metrics
     from nemo_retriever.service.tracing import configure_tracing
+    from nemo_retriever.version import get_service_api_version
 
     configure_metrics(service_role=config.mode)
     configure_tracing(service_role=config.mode)
@@ -275,7 +276,7 @@ def create_app(config: ServiceConfig) -> FastAPI:
     app = FastAPI(
         title="Retriever Service",
         description="Low-latency document ingestion service powered by nemo-retriever",
-        version="26.5.0",
+        version=get_service_api_version(),
         docs_url="/docs",
         lifespan=lifespan,
     )

--- a/nemo_retriever/src/nemo_retriever/version.py
+++ b/nemo_retriever/src/nemo_retriever/version.py
@@ -173,4 +173,17 @@ def get_version() -> str:
     return get_version_info()["version"]
 
 
+def get_service_api_version() -> str:
+    """Return the version string exposed by the Retriever Service OpenAPI document.
+
+    Prefer an explicit service override so container and Helm deployments can
+    report the running image or release tag. Otherwise fall back to the package
+    version used by the CLI and library.
+    """
+    override = (os.getenv("RETRIEVER_SERVICE_VERSION") or "").strip()
+    if override:
+        return override
+    return get_version()
+
+
 __version__ = _installed_version() or get_build_version()

--- a/nemo_retriever/tests/test_helm_service_openapi_version.py
+++ b/nemo_retriever/tests/test_helm_service_openapi_version.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helm must inject RETRIEVER_SERVICE_VERSION from the service image tag."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Sequence
+from unittest import SkipTest, TestCase, main
+
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHART_DIR = _REPO_ROOT / "nemo_retriever/helm"
+
+
+def _helm_template(extra_args: Sequence[str] = ()) -> subprocess.CompletedProcess[str]:
+    helm = shutil.which("helm")
+    if helm is None:
+        raise SkipTest("`helm` binary not available in this environment.")
+    if not _CHART_DIR.is_dir():
+        raise SkipTest(f"Chart directory missing: {_CHART_DIR}")
+    cmd = [
+        helm,
+        "template",
+        "nrl-openapi-version",
+        str(_CHART_DIR),
+        "--set",
+        "ngcImagePullSecret.create=false",
+        "--set",
+        "ngcApiSecret.create=false",
+        "--set",
+        "serviceConfig.vectordb.enabled=false",
+        *extra_args,
+    ]
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def _deployments(docs: list[dict]) -> list[dict]:
+    return [doc for doc in docs if doc and doc.get("kind") == "Deployment"]
+
+
+def _nemo_retriever_containers(docs: list[dict]) -> list[dict]:
+    containers: list[dict] = []
+    for deployment in _deployments(docs):
+        for container in deployment["spec"]["template"]["spec"]["containers"]:
+            if container.get("name") == "nemo-retriever":
+                containers.append(container)
+    return containers
+
+
+def _env_value(container: dict, name: str) -> str | None:
+    for item in container.get("env") or []:
+        if item.get("name") == name:
+            return item.get("value")
+    return None
+
+
+class TestHelmServiceOpenApiVersion(TestCase):
+    def test_standalone_injects_image_tag_as_service_version(self) -> None:
+        proc = _helm_template(
+            (
+                "--set",
+                "topology.mode=standalone",
+                "--set",
+                "service.image.tag=26.08-RC4",
+            )
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"`helm template` failed:\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}",
+        )
+        docs = list(yaml.safe_load_all(proc.stdout))
+        containers = _nemo_retriever_containers(docs)
+        self.assertEqual(len(containers), 1)
+        self.assertEqual(_env_value(containers[0], "RETRIEVER_SERVICE_VERSION"), "26.08-RC4")
+
+    def test_split_injects_image_tag_on_gateway_and_workers(self) -> None:
+        proc = _helm_template(
+            (
+                "--set",
+                "topology.mode=split",
+                "--set",
+                "service.image.tag=26.08-RC4",
+            )
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"`helm template` failed:\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}",
+        )
+        docs = list(yaml.safe_load_all(proc.stdout))
+        containers = _nemo_retriever_containers(docs)
+        self.assertGreaterEqual(len(containers), 2)
+        for container in containers:
+            self.assertEqual(_env_value(container, "RETRIEVER_SERVICE_VERSION"), "26.08-RC4")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_retriever/tests/test_service_openapi_version.py
+++ b/nemo_retriever/tests/test_service_openapi_version.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAPI ``info.version`` must track the running service release."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from nemo_retriever.service.app import create_app
+from nemo_retriever.service.config import ServiceConfig
+from nemo_retriever.version import get_service_api_version
+
+
+def test_openapi_version_matches_service_api_version() -> None:
+    app = create_app(ServiceConfig(mode="gateway"))
+
+    with TestClient(app) as client:
+        schema = client.get("/openapi.json").json()
+
+    assert schema["info"]["version"] == get_service_api_version()
+    assert schema["info"]["version"] != "26.5.0"
+
+
+def test_openapi_version_respects_service_version_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RETRIEVER_SERVICE_VERSION", "26.08-RC4")
+    app = create_app(ServiceConfig(mode="gateway"))
+
+    with TestClient(app) as client:
+        schema = client.get("/openapi.json").json()
+
+    assert schema["info"]["version"] == "26.08-RC4"
+    assert get_service_api_version() == "26.08-RC4"


### PR DESCRIPTION
## Summary
- Stop hardcoding OpenAPI `info.version` as stale `26.5.0` in the Retriever Service FastAPI app; use `get_service_api_version()` (package version, overridable via `RETRIEVER_SERVICE_VERSION`).
- Helm injects `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches deployed tags such as `26.08-RC4`.
- Bake optional `RETRIEVER_VERSION` / `RETRIEVER_RELEASE_TYPE` build args into the service image and pass them from release/nightly Docker workflows.

## Test plan
- [x] Helm template checks: standalone and split modes emit `RETRIEVER_SERVICE_VERSION=<image.tag>`
- [x] Unit helper check: `get_service_api_version()` honors `RETRIEVER_SERVICE_VERSION` and is not `26.5.0`
- [ ] CI: `tests/test_service_openapi_version.py` and `tests/test_helm_service_openapi_version.py`
- [ ] After rebuilding/republishing an RC image (or deploying with this Helm chart), `curl .../openapi.json | jq .info.version` matches the image tag