### PR TITLE
fix: route AVI files through video ingestion

### DIFF
--- a/nemo_retriever/src/nemo_retriever/common/input_files.py
+++ b/nemo_retriever/src/nemo_retriever/common/input_files.py
@@ -29,6 +29,7 @@ INPUT_TYPE_PATTERNS: dict[str, tuple[str, ...]] = {
         "*.mp4",
         "*.mov",
         "*.mkv",
+        "*.avi",
     ),
     "pdf": ("*.pdf",),
     "txt": ("*.txt", "*.md", "*.json", "*.sh"),
@@ -36,7 +37,7 @@ INPUT_TYPE_PATTERNS: dict[str, tuple[str, ...]] = {
     "doc": ("*.docx", "*.pptx"),
     "image": ("*.jpg", "*.jpeg", "*.png", "*.tiff", "*.tif", "*.bmp", "*.svg"),
     "audio": ("*.mp3", "*.wav", "*.m4a"),
-    "video": ("*.mp4", "*.mov", "*.mkv"),
+    "video": ("*.mp4", "*.mov", "*.mkv", "*.avi"),
 }
 INPUT_TYPE_EXTENSIONS: dict[str, frozenset[str]] = {
     input_type: frozenset(pattern[1:].lower() for pattern in patterns if pattern.startswith("*."))

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -1220,6 +1220,42 @@ def test_root_ingest_dry_run_prints_plan_without_creating_ingestor(monkeypatch, 
     assert payload["extract"]["extract_tables"] is False
 
 
+def test_root_ingest_dry_run_routes_avi_to_video(monkeypatch, tmp_path) -> None:
+    document = tmp_path / "sample.avi"
+    document.write_bytes(b"AVI")
+
+    def fail_create_ingestor(**_kwargs: Any) -> Any:
+        raise AssertionError("create_ingestor should not be called for --dry-run")
+
+    monkeypatch.setattr(ingest_execution, "create_ingestor", fail_create_ingestor)
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(document), "--dry-run"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["documents"] == [str(document)]
+    assert payload["branch_summary"] == "video:1"
+
+
+def test_root_ingest_dry_run_discovers_avi_in_mixed_directory(monkeypatch, tmp_path) -> None:
+    avi_document = tmp_path / "sample.avi"
+    avi_document.write_bytes(b"AVI")
+    pdf_document = tmp_path / "sample.pdf"
+    pdf_document.write_bytes(b"%PDF-1.4\n")
+
+    def fail_create_ingestor(**_kwargs: Any) -> Any:
+        raise AssertionError("create_ingestor should not be called for --dry-run")
+
+    monkeypatch.setattr(ingest_execution, "create_ingestor", fail_create_ingestor)
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(tmp_path), "--dry-run"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["documents"] == sorted((str(avi_document), str(pdf_document)))
+    assert payload["branch_summary"] == "pdf:1, video:1"
+
+
 def test_dry_run_secret_redaction_covers_common_credential_names() -> None:
     payload = {
         "api_key": "nvapi-test",


### PR DESCRIPTION
## Summary

- add `.avi` to shared automatic and video input routing
- route direct AVI inputs to the video extraction branch
- include AVI files when resolving mixed input directories
- add CLI regression coverage for both cases

## Root cause

The public extraction documentation, media decoder, and service classifier support AVI, but the shared CLI input-routing patterns omitted `*.avi`. Direct AVI inputs were rejected before extraction, while mixed directories silently skipped AVI files.

## Impact

Documented AVI inputs are now selected consistently by the CLI. Mixed-directory ingest plans no longer silently omit AVI files.

## Validation

- `221 passed, 2 subtests passed` across:
  - `test_root_cli_workflow.py`
  - `test_pipeline_graph.py`
  - `test_media_dependency_availability.py`
- generated a valid AVI containing MPEG-4 video and MP3 audio with FFmpeg
- verified `retriever ingest sample.avi --dry-run` reports `video:1`
- `git diff --check`
