### PR TITLE
fix(helm): require internalAuth for split scope-token auth

### DIFF
--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -954,8 +954,12 @@ configured key. `nrl-internal-vdb-auth` must contain a distinct, high-entropy
 credential. Internal authentication is opt-in for local compatibility; enable
 it for production deployments. When enabled, a missing Secret or key prevents
 the pods from starting instead of falling back to unauthenticated VectorDB
-access. Inline `serviceConfig.auth.apiToken` is rejected unless
-`allowInsecureInlineApiToken=true`, and must never be used for production.
+access. In `topology.mode=split`, `serviceConfig.auth.scopeTokenSecret.name`
+also requires `serviceConfig.vectordb.internalAuth.enabled=true`: pull workers
+never mount the public scope-token Secret, so they need the dedicated internal
+credential to claim `/v1/internal/work/claim`. Inline `serviceConfig.auth.apiToken`
+is rejected unless `allowInsecureInlineApiToken=true`, and must never be used
+for production.
 
 ### Disable one NIM and supply an external URL for it
 

--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -41,6 +41,15 @@ inherits the NIMService resource name, so the mapping is fixed:
 {{- if and $internalAuth.enabled (not $internalAuth.existingSecret.key) -}}
 {{- fail "serviceConfig.vectordb.internalAuth.enabled=true requires serviceConfig.vectordb.internalAuth.existingSecret.key." -}}
 {{- end -}}
+{{- /*
+  Split pull workers mount only the dedicated internal credential. Public
+  scope-token Secrets stay on the gateway, and auth_headers() only knows
+  api_token. Without internalAuth, workers claim /v1/internal/work/claim with
+  empty headers while the gateway still requires a public bearer token.
+*/ -}}
+{{- if and (eq $ctx.Values.topology.mode "split") $auth.enabled $scopeTokenSecret.name (not $internalAuth.enabled) -}}
+{{- fail "topology.mode=split with serviceConfig.auth.scopeTokenSecret.name requires serviceConfig.vectordb.internalAuth.enabled=true so pull workers can authenticate to /v1/internal/work/claim." -}}
+{{- end -}}
 {{- $pageElementsURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "page_elements" "serviceName" "nemotron-page-elements-v3" "configKey" "pageElementsInvokeUrl" "invokePath" "/v1/page-elements") -}}
 {{- $tableStructureURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "table_structure" "serviceName" "nemotron-table-structure-v1" "configKey" "tableStructureInvokeUrl" "invokePath" "/v1/table-structure") -}}
 {{- $ocrURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "ocr" "serviceName" $ctx.Values.nimOperator.ocr.nimServiceName "configKey" "ocrInvokeUrl" "invokePath" "/v1/ocr") -}}

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -707,6 +707,8 @@ serviceConfig:
     # Optional dedicated gateway/worker-to-VectorDB authentication. When
     # enabled, all Retriever and VectorDB pods read the same existing Secret
     # key and VectorDB rejects missing or invalid internal credentials.
+    # Required in topology.mode=split when auth.scopeTokenSecret.name is set,
+    # because pull workers authenticate claims with this credential only.
     internalAuth:
       enabled: false
       existingSecret:
@@ -716,6 +718,8 @@ serviceConfig:
   # Public bearer-token authentication. Production deployments should mount
   # a Secret-backed scope-token JSON file. It is disabled by default so a
   # standalone deployment accepts gateway requests without a bearer token.
+  # In split mode the scope-token Secret mounts on the gateway only; pair it
+  # with vectordb.internalAuth so workers can claim internal work.
   # Inline apiToken is retained only as an explicitly enabled insecure
   # development fallback.
   auth:

--- a/nemo_retriever/tests/test_helm_auth.py
+++ b/nemo_retriever/tests/test_helm_auth.py
@@ -117,6 +117,24 @@ def test_split_mounts_public_secret_only_on_gateway_and_internal_secret_everywhe
         assert all(item["name"] != "scope-token" for item in pod_spec.get("volumes", []))
 
 
+def test_split_scope_token_auth_requires_internal_auth() -> None:
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        _render(
+            "--set",
+            "topology.mode=split",
+            "--set",
+            "serviceMonitor.autoEnableInSplitMode=false",
+            "--set",
+            "serviceConfig.auth.enabled=true",
+            "--set",
+            "serviceConfig.auth.scopeTokenSecret.name=nrl-public-auth",
+            "--set",
+            "serviceConfig.vectordb.internalAuth.enabled=false",
+        )
+    assert "internalAuth.enabled=true" in error.value.stderr
+    assert "/v1/internal/work/claim" in error.value.stderr
+
+
 def test_internal_auth_requires_existing_secret_name() -> None:
     with pytest.raises(subprocess.CalledProcessError) as error:
         _render("--set", "serviceConfig.vectordb.internalAuth.enabled=true")


### PR DESCRIPTION
## Summary
- In split topology, public `scopeTokenSecret` auth without `vectordb.internalAuth` lets the gateway accept work while pull workers send empty claim headers to `/v1/internal/work/claim` (HTTP 401), causing a processing outage.
- Helm now fails that unsupported combination at render time and documents that split + scope-token auth requires `internalAuth.enabled=true`.
- Adds a regression test covering the rejected values combination.

## Test plan
- [x] `helm template` with `topology.mode=split` + `auth.scopeTokenSecret` + `internalAuth.enabled=false` fails with the new message
- [x] Supported combo (`split` + scope-token + `internalAuth.enabled=true` + existing secret) still renders
- [ ] CI: `tests/test_helm_auth.py` (especially `test_split_scope_token_auth_requires_internal_auth`)