### PR TITLE
fix(service): proxy split gateway calls with internal credentials

### DIFF
--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -27,6 +27,13 @@ The Helm chart uses `GET /v1/live` for startup and liveness probes and
 topology, `/v1/health` returns HTTP `503` when the required realtime or batch
 worker is unavailable, so Kubernetes removes the gateway from Service endpoints.
 Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes).
+
+In split topology, the gateway authenticates public requests. When internal
+service authentication is configured, the gateway uses it for restricted worker
+handoffs instead of forwarding public credentials. Without internal service
+authentication, the gateway forwards the configured public authentication header
+to workers, which must share the same public-authentication configuration.
+
 **Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are auto-wired into the retriever service. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, and **Parakeet ASR** are optional and not auto-wired. For a minimal GPU footprint, disable optional keys you do not need (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims) and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 
 For audio and video extraction in Kubernetes, refer to [Audio and video](audio-video.md).

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -889,7 +889,7 @@ custom service configuration files.
 | `ngcApiSecret.name`               | `ngc-api`      | Name referenced by NIMCache/NIMService `authSecret`. |
 | `ngcApiSecret.password`           | `""`           | NGC API key (populates `NGC_API_KEY` + `NGC_CLI_API_KEY`). |
 | `imagePullSecrets`                | `[]`           | Extra pre-existing pull secrets appended to every Pod. |
-| `serviceConfig.vectordb.internalAuth.enabled` | `false` | Enable dedicated Secret-backed Retriever-to-VectorDB authentication. |
+| `serviceConfig.vectordb.internalAuth.enabled` | `false` | Enable the Secret-backed credential for VectorDB traffic and restricted gateway-to-worker handoffs. |
 | `serviceConfig.vectordb.internalAuth.existingSecret.name` | `""` | Existing Secret shared by Retriever and VectorDB pods. |
 | `serviceConfig.auth.scopeTokenSecret.name` | `""` | Existing Secret containing the public scope-token JSON file. |
 | `serviceConfig.auth.enabled` | `false` | Require bearer authentication for the public gateway. |
@@ -930,7 +930,7 @@ The chart will skip Secret creation. Make sure `my-org-ngc-pull` exists
 as `kubernetes.io/dockerconfigjson` and `my-org-ngc-api` as `Opaque` with
 an `NGC_API_KEY` key, in the release namespace.
 
-Protect the public gateway and its dedicated VectorDB hop with two separate
+Protect the public gateway and internal service calls with separate
 pre-existing Secrets:
 
 ```yaml
@@ -951,10 +951,13 @@ serviceConfig:
 `nrl-public-auth` must contain a JSON document such as
 `{"tokens":[{"token":"<secret>","scopes":["workspace-123"]}]}` under the
 configured key. `nrl-internal-vdb-auth` must contain a distinct, high-entropy
-credential. Internal authentication is opt-in for local compatibility; enable
-it for production deployments. When enabled, a missing Secret or key prevents
-the pods from starting instead of falling back to unauthenticated VectorDB
-access. Inline `serviceConfig.auth.apiToken` is rejected unless
+credential. In split topology, the public token file mounts only on the
+gateway. The gateway authenticates public requests, then uses the internal
+credential for restricted worker handoffs. Workers do not receive or validate
+the public bearer token. Internal authentication is opt-in for local
+compatibility; enable it for production deployments. When enabled, a missing
+Secret or key prevents the pods from starting instead of falling back to
+unauthenticated VectorDB access. Inline `serviceConfig.auth.apiToken` is rejected unless
 `allowInsecureInlineApiToken=true`, and must never be used for production.
 
 ### Disable one NIM and supply an external URL for it

--- a/nemo_retriever/helm/templates/deployment.yaml
+++ b/nemo_retriever/helm/templates/deployment.yaml
@@ -414,7 +414,7 @@ spec:
             {{- if eq $role "gateway" }}
             sizeLimit: {{ int64 $.Values.serviceConfig.workQueue.spoolLimitBytes | quote }}
             {{- end }}
-        {{- if and (eq $role "gateway") $scopeTokenSecret.name }}
+        {{- if and $scopeTokenSecret.name (or (eq $role "gateway") (not $internalAuth.enabled)) }}
         - name: scope-token
           secret:
             secretName: {{ $scopeTokenSecret.name | quote }}

--- a/nemo_retriever/helm/templates/deployment.yaml
+++ b/nemo_retriever/helm/templates/deployment.yaml
@@ -318,7 +318,7 @@ spec:
                   key: {{ $internalAuth.existingSecret.key | quote }}
                   optional: false
             {{- end }}
-            {{- if and (eq $role "gateway") $scopeTokenSecret.name }}
+            {{- if and $scopeTokenSecret.name (or (eq $role "gateway") (not $internalAuth.enabled)) }}
             - name: NRL_SCOPE_TOKEN_FILE
               value: {{ printf "%s/scope-tokens.json" $scopeTokenMountPath | quote }}
             {{- end }}
@@ -388,7 +388,7 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
-            {{- if and (eq $role "gateway") $scopeTokenSecret.name }}
+            {{- if and $scopeTokenSecret.name (or (eq $role "gateway") (not $internalAuth.enabled)) }}
             - name: scope-token
               mountPath: {{ $scopeTokenMountPath | quote }}
               readOnly: true

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -704,9 +704,10 @@ serviceConfig:
     tableName: "nemo_retriever"
     embedModel: "nvidia/llama-nemotron-embed-vl-1b-v2"
     embedModelProviderPrefix: ""
-    # Optional dedicated gateway/worker-to-VectorDB authentication. When
-    # enabled, all Retriever and VectorDB pods read the same existing Secret
-    # key and VectorDB rejects missing or invalid internal credentials.
+    # Optional service-internal authentication. When enabled, Retriever and
+    # VectorDB pods read the same existing Secret key. In split topology, the
+    # gateway also uses this credential for restricted gateway-to-worker
+    # handoffs. Public bearer credentials are never forwarded to workers.
     internalAuth:
       enabled: false
       existingSecret:
@@ -715,7 +716,8 @@ serviceConfig:
 
   # Public bearer-token authentication. Production deployments should mount
   # a Secret-backed scope-token JSON file. It is disabled by default so a
-  # standalone deployment accepts gateway requests without a bearer token.
+  # standalone deployment accepts gateway requests without a bearer token. In
+  # split topology, the public token file mounts only on the gateway.
   # Inline apiToken is retained only as an explicitly enabled insecure
   # development fallback.
   auth:

--- a/nemo_retriever/src/nemo_retriever/service/app.py
+++ b/nemo_retriever/src/nemo_retriever/service/app.py
@@ -166,7 +166,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.sidecar_store = init_sidecar_store()
 
     if mode == "gateway":
-        app.state.proxy = init_proxy(config.gateway)
+        app.state.proxy = init_proxy(
+            config.gateway,
+            internal_api_token=config.vectordb.internal_api_token,
+            public_auth_header=config.auth.header_name,
+        )
         app.state.work_broker = await init_work_broker(config.work_queue, config.pipeline)
         app.state.pipeline_pool = None
     else:
@@ -289,6 +293,7 @@ def create_app(config: ServiceConfig) -> FastAPI:
         BearerAuthMiddleware,
         config=config.auth,
         internal_api_token=config.vectordb.internal_api_token,
+        service_mode=config.mode,
     )
     logger.info(
         "Scope authorization configured (enabled=%s, header=%s, secret_file=%s, allow_unscoped_dev=%s)",

--- a/nemo_retriever/src/nemo_retriever/service/auth.py
+++ b/nemo_retriever/src/nemo_retriever/service/auth.py
@@ -74,7 +74,9 @@ def caller_fingerprint(request: Request) -> str | None:
     return str(value) if value else None
 
 
-def gateway_handoff_headers(*, internal_api_token: str | None, scope: str, caller_fingerprint: str | None) -> dict[str, str]:
+def gateway_handoff_headers(
+    *, internal_api_token: str | None, scope: str, caller_fingerprint: str | None
+) -> dict[str, str]:
     """Build gateway-controlled worker authentication headers.
 
     Args:

--- a/nemo_retriever/src/nemo_retriever/service/auth.py
+++ b/nemo_retriever/src/nemo_retriever/service/auth.py
@@ -31,6 +31,11 @@ _GATEWAY_HANDOFF_VALUE = "v1"
 _GATEWAY_PROXY_PATHS = frozenset({"/v1/ingest/sidecar", "/v1/ingest/pipeline-config"})
 
 
+def _is_gateway_proxy_path(path: str) -> bool:
+    """Return whether *path* is a gateway-to-worker sidecar or config route."""
+    return path in _GATEWAY_PROXY_PATHS or path.startswith("/v1/ingest/sidecar/")
+
+
 def _strip_bearer(value: str) -> str:
     if value.lower().startswith(_BEARER_PREFIX):
         return value[len(_BEARER_PREFIX) :].strip()
@@ -60,13 +65,27 @@ def authorized_scope(request: Request) -> str:
 
 
 def caller_fingerprint(request: Request) -> str | None:
-    """Return the authenticated caller fingerprint, never a raw bearer token."""
+    """Return the authenticated caller fingerprint, or ``None`` when unavailable.
+
+    The returned value is derived from the bearer token and never contains the
+    raw bearer token.
+    """
     value = getattr(request.state, "caller_fingerprint", None)
     return str(value) if value else None
 
 
 def gateway_handoff_headers(*, internal_api_token: str | None, scope: str, caller_fingerprint: str | None) -> dict[str, str]:
-    """Build the gateway-controlled authentication context for worker proxy calls."""
+    """Build gateway-controlled worker authentication headers.
+
+    Args:
+        internal_api_token: Shared credential used to authenticate the worker.
+        scope: Scope previously authorized by the gateway.
+        caller_fingerprint: Optional non-secret caller identity fingerprint.
+
+    Returns:
+        Headers for a restricted gateway-to-worker handoff, or an empty
+        dictionary when no internal credential is configured.
+    """
     headers = internal_auth_headers(internal_api_token)
     if not headers:
         return {}
@@ -181,7 +200,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
 
         if (
             self._service_mode in ("realtime", "batch")
-            and path in _GATEWAY_PROXY_PATHS
+            and _is_gateway_proxy_path(path)
             and self._internal_api_token
             and request.headers.get(_GATEWAY_HANDOFF_HEADER) == _GATEWAY_HANDOFF_VALUE
         ):

--- a/nemo_retriever/src/nemo_retriever/service/auth.py
+++ b/nemo_retriever/src/nemo_retriever/service/auth.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 _BEARER_PREFIX = "bearer "
 _INTERNAL_TOKEN_HEADER = "X-NRL-Internal-Token"
+_GATEWAY_HANDOFF_HEADER = "X-NRL-Gateway-Handoff"
+_AUTHORIZED_SCOPE_HEADER = "X-NRL-Authorized-Scope"
+_CALLER_FINGERPRINT_HEADER = "X-NRL-Caller-Fingerprint"
+_GATEWAY_HANDOFF_VALUE = "v1"
+
+_GATEWAY_PROXY_PATHS = frozenset({"/v1/ingest/sidecar", "/v1/ingest/pipeline-config"})
 
 
 def _strip_bearer(value: str) -> str:
@@ -41,7 +47,7 @@ def auth_headers(config: AuthConfig) -> dict[str, str]:
 
 
 def internal_auth_headers(token: str | None) -> dict[str, str]:
-    """Build headers for gateway/worker calls to the VectorDB service."""
+    """Build headers for service-internal calls protected by the shared token."""
     token = (token or "").strip()
     if not token:
         return {}
@@ -51,6 +57,24 @@ def internal_auth_headers(token: str | None) -> dict[str, str]:
 def authorized_scope(request: Request) -> str:
     """Return the middleware-authorized scope; never trust a raw header here."""
     return str(getattr(request.state, "authorized_scope", "default"))
+
+
+def caller_fingerprint(request: Request) -> str | None:
+    """Return the authenticated caller fingerprint, never a raw bearer token."""
+    value = getattr(request.state, "caller_fingerprint", None)
+    return str(value) if value else None
+
+
+def gateway_handoff_headers(*, internal_api_token: str | None, scope: str, caller_fingerprint: str | None) -> dict[str, str]:
+    """Build the gateway-controlled authentication context for worker proxy calls."""
+    headers = internal_auth_headers(internal_api_token)
+    if not headers:
+        return {}
+    headers[_GATEWAY_HANDOFF_HEADER] = _GATEWAY_HANDOFF_VALUE
+    headers[_AUTHORIZED_SCOPE_HEADER] = scope
+    if caller_fingerprint:
+        headers[_CALLER_FINGERPRINT_HEADER] = caller_fingerprint
+    return headers
 
 
 class ScopeAuthorizer:
@@ -118,12 +142,22 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         *,
         config: AuthConfig,
         internal_api_token: str | None = None,
+        service_mode: str = "standalone",
     ) -> None:
         super().__init__(app)
         self._header = config.header_name
         self._bypass = tuple(config.bypass_paths)
         self._authorizer = ScopeAuthorizer(config)
         self._internal_api_token = (internal_api_token or "").strip()
+        self._service_mode = service_mode
+
+    def _set_public_identity(self, request: Request, provided_token: str, scope: str) -> None:
+        request.state.authorized_scope = scope
+        request.state.caller_fingerprint = (
+            hmac.new(self._internal_api_token.encode("utf-8"), provided_token.encode("utf-8"), "sha256").hexdigest()
+            if self._internal_api_token and provided_token
+            else None
+        )
 
     async def dispatch(self, request: Request, call_next):
         """Authenticate the request and attach its authorized logical scope."""
@@ -131,6 +165,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         if any(path == p or path.startswith(p.rstrip("/") + "/") for p in self._bypass):
             request.state.authorized_scope = self._authorizer.default_scope
+            request.state.caller_fingerprint = None
             return await call_next(request)
 
         if path.startswith("/v1/internal/") and self._internal_api_token:
@@ -141,7 +176,22 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
                     content={"detail": "Missing or invalid internal credential."},
                 )
             request.state.authorized_scope = self._authorizer.default_scope
+            request.state.caller_fingerprint = None
             return await call_next(request)
+
+        if (
+            self._service_mode in ("realtime", "batch")
+            and path in _GATEWAY_PROXY_PATHS
+            and self._internal_api_token
+            and request.headers.get(_GATEWAY_HANDOFF_HEADER) == _GATEWAY_HANDOFF_VALUE
+        ):
+            supplied = request.headers.get(_INTERNAL_TOKEN_HEADER, "").strip()
+            scope = request.headers.get(_AUTHORIZED_SCOPE_HEADER, "").strip()
+            if supplied and scope and hmac.compare_digest(supplied, self._internal_api_token):
+                request.state.authorized_scope = scope
+                request.state.caller_fingerprint = request.headers.get(_CALLER_FINGERPRINT_HEADER, "").strip() or None
+                return await call_next(request)
+            return JSONResponse(status_code=401, content={"detail": "Missing or invalid internal credential."})
 
         provided = request.headers.get(self._header, "")
         provided_token = _strip_bearer(provided)
@@ -153,5 +203,5 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        request.state.authorized_scope = scope
+        self._set_public_identity(request, provided_token, scope)
         return await call_next(request)

--- a/nemo_retriever/src/nemo_retriever/service/services/proxy.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/proxy.py
@@ -113,14 +113,17 @@ class GatewayProxy:
         reserved = {
             "host",
             "transfer-encoding",
-            self._public_auth_header,
             "x-nrl-scope",
             "x-nrl-internal-token",
             "x-nrl-gateway-handoff",
             "x-nrl-authorized-scope",
             "x-nrl-caller-fingerprint",
         }
+        if self._internal_api_token:
+            reserved.add(self._public_auth_header)
         headers = {key: value for key, value in request.headers.items() if key.lower() not in reserved}
+        if not self._internal_api_token:
+            headers["X-NRL-Scope"] = authorized_scope(request)
         headers.update(
             gateway_handoff_headers(
                 internal_api_token=self._internal_api_token,

--- a/nemo_retriever/src/nemo_retriever/service/services/proxy.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/proxy.py
@@ -28,6 +28,7 @@ import httpx
 from fastapi import Request
 from fastapi.responses import Response
 
+from nemo_retriever.service.auth import authorized_scope, caller_fingerprint, gateway_handoff_headers
 from nemo_retriever.service.config import GatewayConfig
 from nemo_retriever.service.services.pipeline_pool import PoolType
 from nemo_retriever.service import tracing as tracing_module
@@ -71,8 +72,16 @@ _PATH_TO_POOL: dict[str, PoolType] = {
 class GatewayProxy:
     """Forwards ingest requests to backend worker Services."""
 
-    def __init__(self, config: GatewayConfig) -> None:
+    def __init__(
+        self,
+        config: GatewayConfig,
+        *,
+        internal_api_token: str | None = None,
+        public_auth_header: str = "Authorization",
+    ) -> None:
         self._config = config
+        self._internal_api_token = (internal_api_token or "").strip()
+        self._public_auth_header = public_auth_header.lower()
         limits = httpx.Limits(
             max_connections=config.max_connections,
             max_keepalive_connections=config.max_connections,
@@ -100,6 +109,27 @@ class GatewayProxy:
             return self._realtime
         return self._batch
 
+    def _forward_headers(self, request: Request) -> dict[str, str]:
+        reserved = {
+            "host",
+            "transfer-encoding",
+            self._public_auth_header,
+            "x-nrl-scope",
+            "x-nrl-internal-token",
+            "x-nrl-gateway-handoff",
+            "x-nrl-authorized-scope",
+            "x-nrl-caller-fingerprint",
+        }
+        headers = {key: value for key, value in request.headers.items() if key.lower() not in reserved}
+        headers.update(
+            gateway_handoff_headers(
+                internal_api_token=self._internal_api_token,
+                scope=authorized_scope(request),
+                caller_fingerprint=caller_fingerprint(request),
+            )
+        )
+        return headers
+
     async def forward(
         self,
         request: Request,
@@ -126,7 +156,7 @@ class GatewayProxy:
                 target_path,
             )
 
-        fwd_headers = {k: v for k, v in request.headers.items() if k.lower() not in ("host", "transfer-encoding")}
+        fwd_headers = self._forward_headers(request)
         if extra_headers:
             fwd_headers.update(extra_headers)
         _inject_trace_context(fwd_headers)
@@ -187,7 +217,7 @@ class GatewayProxy:
         """Forward a GET request to the backend for *pool_type*."""
         client = self._client_for(pool_type)
         backend_label = pool_type.value
-        fwd_headers = {k: v for k, v in request.headers.items() if k.lower() not in ("host",)}
+        fwd_headers = self._forward_headers(request)
         _inject_trace_context(fwd_headers)
 
         try:
@@ -230,10 +260,19 @@ class GatewayProxy:
 _instance: GatewayProxy | None = None
 
 
-def init_proxy(config: GatewayConfig) -> GatewayProxy:
+def init_proxy(
+    config: GatewayConfig,
+    *,
+    internal_api_token: str | None = None,
+    public_auth_header: str = "Authorization",
+) -> GatewayProxy:
     """Create the global gateway proxy (call once at startup in gateway mode)."""
     global _instance
-    _instance = GatewayProxy(config)
+    _instance = GatewayProxy(
+        config,
+        internal_api_token=internal_api_token,
+        public_auth_header=public_auth_header,
+    )
     return _instance
 
 

--- a/nemo_retriever/tests/test_helm_auth.py
+++ b/nemo_retriever/tests/test_helm_auth.py
@@ -130,7 +130,12 @@ def test_split_without_internal_auth_mounts_public_secret_on_workers() -> None:
     )
 
     for component in ("gateway", "realtime", "batch"):
-        assert "NRL_SCOPE_TOKEN_FILE" in _container_env(deployments[component])
+        deployment = deployments[component]
+        assert "NRL_SCOPE_TOKEN_FILE" in _container_env(deployment)
+        scope_token_volume = next(
+            volume for volume in deployment["spec"]["template"]["spec"]["volumes"] if volume["name"] == "scope-token"
+        )
+        assert scope_token_volume["secret"]["secretName"] == "nrl-public-auth"
 
 
 def test_internal_auth_requires_existing_secret_name() -> None:

--- a/nemo_retriever/tests/test_helm_auth.py
+++ b/nemo_retriever/tests/test_helm_auth.py
@@ -117,6 +117,22 @@ def test_split_mounts_public_secret_only_on_gateway_and_internal_secret_everywhe
         assert all(item["name"] != "scope-token" for item in pod_spec.get("volumes", []))
 
 
+def test_split_without_internal_auth_mounts_public_secret_on_workers() -> None:
+    deployments = _deployments(
+        _render(
+            "--set",
+            "topology.mode=split",
+            "--set",
+            "serviceConfig.auth.enabled=true",
+            "--set",
+            "serviceConfig.auth.scopeTokenSecret.name=nrl-public-auth",
+        )
+    )
+
+    for component in ("gateway", "realtime", "batch"):
+        assert "NRL_SCOPE_TOKEN_FILE" in _container_env(deployments[component])
+
+
 def test_internal_auth_requires_existing_secret_name() -> None:
     with pytest.raises(subprocess.CalledProcessError) as error:
         _render("--set", "serviceConfig.vectordb.internalAuth.enabled=true")

--- a/nemo_retriever/tests/test_internal_auth.py
+++ b/nemo_retriever/tests/test_internal_auth.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nemo_retriever.service.auth import internal_auth_headers
+from nemo_retriever.service.auth import _is_gateway_proxy_path, internal_auth_headers
 from nemo_retriever.service.config import load_config
 from nemo_retriever.service.services.pipeline_executor import _post_records_to_vectordb
 from nemo_retriever.service.services.pipeline_pool import DocumentWriteContext
@@ -21,6 +21,12 @@ from nemo_retriever.service.services.pipeline_pool import DocumentWriteContext
 def test_internal_auth_headers_strip_secret_whitespace() -> None:
     assert internal_auth_headers("  internal-secret\n") == {"X-NRL-Internal-Token": "internal-secret"}
     assert internal_auth_headers(" \n\t") == {}
+
+
+def test_gateway_handoff_includes_parameterized_sidecar_delete() -> None:
+    assert _is_gateway_proxy_path("/v1/ingest/sidecar")
+    assert _is_gateway_proxy_path("/v1/ingest/sidecar/sidecar-id")
+    assert not _is_gateway_proxy_path("/v1/ingest/sidecars")
 
 
 def test_load_config_strips_internal_token_environment(

--- a/nemo_retriever/tests/test_service_proxy_tracing.py
+++ b/nemo_retriever/tests/test_service_proxy_tracing.py
@@ -252,13 +252,14 @@ def _make_proxy(
     *,
     realtime: _RecordingClient | None = None,
     batch: _RecordingClient | None = None,
+    internal_api_token: str | None = "test-internal-auth-value",
 ) -> GatewayProxy:
     proxy = GatewayProxy.__new__(GatewayProxy)
     proxy._config = GatewayConfig(  # noqa: SLF001
         realtime_url="http://realtime.test",
         batch_url="http://batch.test",
     )
-    proxy._internal_api_token = "internal-secret"  # noqa: SLF001
+    proxy._internal_api_token = internal_api_token  # noqa: SLF001
     proxy._public_auth_header = "authorization"  # noqa: SLF001
     proxy._realtime = realtime or _RecordingClient()  # noqa: SLF001
     proxy._batch = batch or _RecordingClient()  # noqa: SLF001
@@ -311,7 +312,34 @@ def test_forward_replaces_public_auth_with_gateway_context() -> None:
     assert response.status_code == 202
     headers = backend.calls[0]["headers"]
     assert "authorization" not in {key.lower() for key in headers}
-    assert headers["X-NRL-Internal-Token"] == "internal-secret"
+    assert headers["X-NRL-Internal-Token"] == "test-internal-auth-value"
     assert headers["X-NRL-Gateway-Handoff"] == "v1"
     assert headers["X-NRL-Authorized-Scope"] == "approved"
     assert headers["X-NRL-Caller-Fingerprint"] == "fingerprint"
+
+
+def test_forward_preserves_public_auth_without_internal_auth() -> None:
+    backend = _RecordingClient()
+    proxy = _make_proxy(batch=backend, internal_api_token=None)
+    request = _make_request(
+        method="DELETE",
+        path="/v1/ingest/sidecar/sidecar-id",
+        headers={
+            "Authorization": "Bearer public-token",
+            "X-NRL-Scope": "forged",
+            "X-NRL-Internal-Token": "forged",
+            "X-NRL-Gateway-Handoff": "forged",
+        },
+    )
+    request.state.authorized_scope = "approved"
+    request.state.caller_fingerprint = "fingerprint"
+
+    response = asyncio.run(proxy.forward(request, PoolType.BATCH))
+
+    assert response.status_code == 202
+    headers = backend.calls[0]["headers"]
+    normalized_headers = {key.lower(): value for key, value in headers.items()}
+    assert normalized_headers["authorization"] == "Bearer public-token"
+    assert headers["X-NRL-Scope"] == "approved"
+    assert "X-NRL-Internal-Token" not in headers
+    assert "X-NRL-Gateway-Handoff" not in headers

--- a/nemo_retriever/tests/test_service_proxy_tracing.py
+++ b/nemo_retriever/tests/test_service_proxy_tracing.py
@@ -258,6 +258,8 @@ def _make_proxy(
         realtime_url="http://realtime.test",
         batch_url="http://batch.test",
     )
+    proxy._internal_api_token = "internal-secret"  # noqa: SLF001
+    proxy._public_auth_header = "authorization"  # noqa: SLF001
     proxy._realtime = realtime or _RecordingClient()  # noqa: SLF001
     proxy._batch = batch or _RecordingClient()  # noqa: SLF001
     return proxy
@@ -285,3 +287,31 @@ def _make_request(
         "client": ("testclient", 123),
     }
     return Request(scope, _receive)
+
+
+def test_forward_replaces_public_auth_with_gateway_context() -> None:
+    backend = _RecordingClient()
+    proxy = _make_proxy(batch=backend)
+    request = _make_request(
+        method="POST",
+        path="/v1/ingest/sidecar",
+        headers={
+            "Authorization": "Bearer public-token",
+            "X-NRL-Scope": "forged",
+            "X-NRL-Internal-Token": "forged",
+            "X-NRL-Gateway-Handoff": "forged",
+        },
+        body=b"payload",
+    )
+    request.state.authorized_scope = "approved"
+    request.state.caller_fingerprint = "fingerprint"
+
+    response = asyncio.run(proxy.forward(request, PoolType.BATCH))
+
+    assert response.status_code == 202
+    headers = backend.calls[0]["headers"]
+    assert "authorization" not in {key.lower() for key in headers}
+    assert headers["X-NRL-Internal-Token"] == "internal-secret"
+    assert headers["X-NRL-Gateway-Handoff"] == "v1"
+    assert headers["X-NRL-Authorized-Scope"] == "approved"
+    assert headers["X-NRL-Caller-Fingerprint"] == "fingerprint"


### PR DESCRIPTION
## Description

Fixes nvbugs/6622853. In split topology, the gateway removes caller-controlled authorization context before proxying to workers, then authenticates the restricted handoff with the configured internal credential and propagates the resolved scope in gateway-controlled headers.

The public scope-token Secret remains mounted only on the gateway.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.