### PR TITLE
fix(service): share sidecars across split workers

### DIFF
--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -27,6 +27,14 @@ The Helm chart uses `GET /v1/live` for startup and liveness probes and
 topology, `/v1/health` returns HTTP `503` when the required realtime or batch
 worker is unavailable, so Kubernetes removes the gateway from Service endpoints.
 Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes).
+
+In split topology, send public requests only to the gateway Service. The
+gateway validates public bearer tokens and authenticates restricted worker
+handoffs with the configured internal credential. Public scope-token records
+remain on the gateway. If you upload sidecar metadata for `vdb_upload`,
+configure the externally managed Redis sidecar store. The in-memory sidecar
+store is supported only for standalone deployments. Refer to the Helm chart
+[authentication and shared-sidecar configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets).
 **Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are auto-wired into the retriever service. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, and **Parakeet ASR** are optional and not auto-wired. For a minimal GPU footprint, disable optional keys you do not need (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims) and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 
 For audio and video extraction in Kubernetes, refer to [Audio and video](audio-video.md).

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -33,7 +33,10 @@ gateway validates public bearer tokens and authenticates restricted worker
 handoffs with the configured internal credential. Public scope-token records
 remain on the gateway. If you upload sidecar metadata for `vdb_upload`,
 configure the externally managed Redis sidecar store. The in-memory sidecar
-store is supported only for standalone deployments. Refer to the Helm chart
+store is supported only for standalone deployments. Set
+`serviceConfig.sidecarStore.maxPayloadBytes` no higher than
+`serviceConfig.resources.maxUploadBytes`; sidecar uploads larger than the
+sidecar limit receive HTTP 413. Refer to the Helm chart
 [authentication and shared-sidecar configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets).
 **Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are auto-wired into the retriever service. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, and **Parakeet ASR** are optional and not auto-wired. For a minimal GPU footprint, disable optional keys you do not need (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims) and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -889,11 +889,15 @@ custom service configuration files.
 | `ngcApiSecret.name`               | `ngc-api`      | Name referenced by NIMCache/NIMService `authSecret`. |
 | `ngcApiSecret.password`           | `""`           | NGC API key (populates `NGC_API_KEY` + `NGC_CLI_API_KEY`). |
 | `imagePullSecrets`                | `[]`           | Extra pre-existing pull secrets appended to every Pod. |
-| `serviceConfig.vectordb.internalAuth.enabled` | `false` | Enable dedicated Secret-backed Retriever-to-VectorDB authentication. |
+| `serviceConfig.vectordb.internalAuth.enabled` | `false` | Enable the Secret-backed credential for VectorDB traffic and restricted gateway-to-worker handoffs. |
 | `serviceConfig.vectordb.internalAuth.existingSecret.name` | `""` | Existing Secret shared by Retriever and VectorDB pods. |
 | `serviceConfig.auth.scopeTokenSecret.name` | `""` | Existing Secret containing the public scope-token JSON file. |
 | `serviceConfig.auth.enabled` | `false` | Require bearer authentication for the public gateway. |
 | `serviceConfig.auth.allowInsecureInlineApiToken` | `false` | Explicit development-only gate for ConfigMap-backed `apiToken`. |
+| `serviceConfig.sidecarStore.backend` | `memory` | Sidecar metadata store. Use `redis` for split topology. |
+| `serviceConfig.sidecarStore.redis.existingSecret.name` | `""` | Existing Secret containing the Redis connection URL. Required when the backend is `redis`. |
+| `serviceConfig.sidecarStore.redis.existingSecret.key` | `url` | Key in the existing Secret that contains the Redis connection URL. |
+| `serviceConfig.sidecarStore.maxPayloadBytes` | `33554432` | Maximum sidecar payload size in bytes. The value cannot exceed `serviceConfig.resources.maxUploadBytes`. |
 
 ### Optional features
 
@@ -930,7 +934,7 @@ The chart will skip Secret creation. Make sure `my-org-ngc-pull` exists
 as `kubernetes.io/dockerconfigjson` and `my-org-ngc-api` as `Opaque` with
 an `NGC_API_KEY` key, in the release namespace.
 
-Protect the public gateway and its dedicated VectorDB hop with two separate
+Protect the public gateway and internal service calls with separate
 pre-existing Secrets:
 
 ```yaml
@@ -946,16 +950,34 @@ serviceConfig:
       existingSecret:
         name: nrl-internal-vdb-auth
         key: token
+  sidecarStore:
+    backend: redis
+    maxPayloadBytes: 33554432
+    redis:
+      existingSecret:
+        name: nrl-sidecar-redis
+        key: url
 ```
 
 `nrl-public-auth` must contain a JSON document such as
 `{"tokens":[{"token":"<secret>","scopes":["workspace-123"]}]}` under the
 configured key. `nrl-internal-vdb-auth` must contain a distinct, high-entropy
-credential. Internal authentication is opt-in for local compatibility; enable
-it for production deployments. When enabled, a missing Secret or key prevents
-the pods from starting instead of falling back to unauthenticated VectorDB
-access. Inline `serviceConfig.auth.apiToken` is rejected unless
+credential. In split topology, the public token file mounts only on the
+gateway. The gateway authenticates public requests, then uses the internal
+credential for restricted worker handoffs. Workers do not receive or validate
+the public bearer token. Internal authentication is opt-in for local
+compatibility; enable it for production deployments. When enabled, a missing
+Secret or key prevents the pods from starting instead of falling back to
+unauthenticated VectorDB access. Inline `serviceConfig.auth.apiToken` is rejected unless
 `allowInsecureInlineApiToken=true`, and must never be used for production.
+
+`nrl-sidecar-redis` must contain a `redis://` or `rediss://` connection URL
+under the configured key. The chart does not deploy Redis. In split topology,
+use the Redis sidecar store so the gateway writes one sidecar ID that every
+worker pool and replica can resolve. The `memory` backend remains suitable for
+standalone deployments. In split topology with `backend: memory`, sidecar
+upload and delete requests return HTTP `503`. The sidecar payload limit defaults
+to 33,554,432 bytes and cannot exceed `serviceConfig.resources.maxUploadBytes`.
 
 ### Disable one NIM and supply an external URL for it
 

--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -20,6 +20,8 @@ inherits the NIMService resource name, so the mapping is fixed:
 {{- $auth := $ctx.Values.serviceConfig.auth -}}
 {{- $scopeTokenSecret := $auth.scopeTokenSecret -}}
 {{- $internalAuth := $ctx.Values.serviceConfig.vectordb.internalAuth -}}
+{{- $sidecarStore := $ctx.Values.serviceConfig.sidecarStore -}}
+{{- $sidecarRedisSecret := $sidecarStore.redis.existingSecret -}}
 {{- if and $auth.enabled (not $auth.apiToken) (not $scopeTokenSecret.name) -}}
 {{- fail "serviceConfig.auth.enabled=true requires serviceConfig.auth.scopeTokenSecret.name or serviceConfig.auth.apiToken." -}}
 {{- end -}}
@@ -40,6 +42,12 @@ inherits the NIMService resource name, so the mapping is fixed:
 {{- end -}}
 {{- if and $internalAuth.enabled (not $internalAuth.existingSecret.key) -}}
 {{- fail "serviceConfig.vectordb.internalAuth.enabled=true requires serviceConfig.vectordb.internalAuth.existingSecret.key." -}}
+{{- end -}}
+{{- if and (eq $sidecarStore.backend "redis") (not $sidecarRedisSecret.name) -}}
+{{- fail "serviceConfig.sidecarStore.backend=redis requires serviceConfig.sidecarStore.redis.existingSecret.name." -}}
+{{- end -}}
+{{- if and (eq $sidecarStore.backend "redis") (not $sidecarRedisSecret.key) -}}
+{{- fail "serviceConfig.sidecarStore.backend=redis requires serviceConfig.sidecarStore.redis.existingSecret.key." -}}
 {{- end -}}
 {{- $pageElementsURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "page_elements" "serviceName" "nemotron-page-elements-v3" "configKey" "pageElementsInvokeUrl" "invokePath" "/v1/page-elements") -}}
 {{- $tableStructureURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "table_structure" "serviceName" "nemotron-table-structure-v1" "configKey" "tableStructureInvokeUrl" "invokePath" "/v1/table-structure") -}}
@@ -195,6 +203,10 @@ resources:
   max_cpu_cores: {{ .Values.serviceConfig.resources.maxCpuCores | default "null" }}
   gpu_devices: {{ toJson .Values.serviceConfig.resources.gpuDevices }}
   max_upload_bytes: {{ $maxUploadBytes }}
+
+sidecar_store:
+  backend: {{ .Values.serviceConfig.sidecarStore.backend | quote }}
+  max_payload_bytes: {{ .Values.serviceConfig.sidecarStore.maxPayloadBytes }}
 
 auth:
   enabled: {{ .Values.serviceConfig.auth.enabled }}

--- a/nemo_retriever/helm/templates/deployment.yaml
+++ b/nemo_retriever/helm/templates/deployment.yaml
@@ -19,6 +19,8 @@
 {{- end -}}
 {{- $svc := .Values.service -}}
 {{- $internalAuth := .Values.serviceConfig.vectordb.internalAuth -}}
+{{- $sidecarStore := .Values.serviceConfig.sidecarStore -}}
+{{- $sidecarRedisSecret := $sidecarStore.redis.existingSecret -}}
 {{- $scopeTokenSecret := .Values.serviceConfig.auth.scopeTokenSecret -}}
 {{- $scopeTokenMountPath := "/var/run/secrets/nemo-retriever/auth" -}}
 {{- if and (eq .Values.topology.mode "split") (ne (int .Values.topology.gateway.replicas) 1) -}}
@@ -116,6 +118,14 @@ spec:
                 secretKeyRef:
                   name: {{ $internalAuth.existingSecret.name | quote }}
                   key: {{ $internalAuth.existingSecret.key | quote }}
+                  optional: false
+            {{- end }}
+            {{- if eq $sidecarStore.backend "redis" }}
+            - name: NRL_SIDECAR_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $sidecarRedisSecret.name | quote }}
+                  key: {{ $sidecarRedisSecret.key | quote }}
                   optional: false
             {{- end }}
             {{- if $scopeTokenSecret.name }}
@@ -316,6 +326,14 @@ spec:
                 secretKeyRef:
                   name: {{ $internalAuth.existingSecret.name | quote }}
                   key: {{ $internalAuth.existingSecret.key | quote }}
+                  optional: false
+            {{- end }}
+            {{- if eq $sidecarStore.backend "redis" }}
+            - name: NRL_SIDECAR_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $sidecarRedisSecret.name | quote }}
+                  key: {{ $sidecarRedisSecret.key | quote }}
                   optional: false
             {{- end }}
             {{- if and (eq $role "gateway") $scopeTokenSecret.name }}

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -695,6 +695,16 @@ serviceConfig:
     gpuDevices: []
     maxUploadBytes: 500000000
 
+  # Split sidecar uploads need shared storage. Redis URL stays in an existing
+  # Secret; memory is supported only for standalone sidecar operations.
+  sidecarStore:
+    backend: memory
+    maxPayloadBytes: 33554432
+    redis:
+      existingSecret:
+        name: ""
+        key: url
+
   # VectorDB pod configuration.  When enabled, a dedicated LanceDB pod
   # is deployed.  Workers POST embeddings to it; the gateway proxies
   # /v1/query to it for retrieval.
@@ -704,9 +714,10 @@ serviceConfig:
     tableName: "nemo_retriever"
     embedModel: "nvidia/llama-nemotron-embed-vl-1b-v2"
     embedModelProviderPrefix: ""
-    # Optional dedicated gateway/worker-to-VectorDB authentication. When
-    # enabled, all Retriever and VectorDB pods read the same existing Secret
-    # key and VectorDB rejects missing or invalid internal credentials.
+    # Optional service-internal authentication. When enabled, Retriever and
+    # VectorDB pods read the same existing Secret key. In split topology, the
+    # gateway also uses this credential for restricted gateway-to-worker
+    # handoffs. Public bearer credentials are never forwarded to workers.
     internalAuth:
       enabled: false
       existingSecret:

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -104,6 +104,7 @@ dependencies = [
   # tokens that tokenizers 0.23 rejects with DuplicatePatternError.
   "tokenizers>=0.21.1,<0.23",
   "huggingface-hub>=0.34.0",
+  "redis>=5,<6",
 ]
 
 [project.optional-dependencies]

--- a/nemo_retriever/src/nemo_retriever/service/app.py
+++ b/nemo_retriever/src/nemo_retriever/service/app.py
@@ -163,7 +163,10 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         tracker.add_terminal_observer(app.state.metrics.record_terminal_transition)
     event_bus = init_event_bus()
     tracker.set_event_bus(event_bus)
-    app.state.sidecar_store = init_sidecar_store()
+    app.state.sidecar_store = init_sidecar_store(
+        redis_url=config.sidecar_store.redis_url if config.sidecar_store.backend == "redis" else None,
+        max_payload_bytes=config.sidecar_store.max_payload_bytes,
+    )
 
     if mode == "gateway":
         app.state.proxy = init_proxy(config.gateway)

--- a/nemo_retriever/src/nemo_retriever/service/auth.py
+++ b/nemo_retriever/src/nemo_retriever/service/auth.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import hmac
 import json
 import logging
@@ -154,4 +155,8 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             )
 
         request.state.authorized_scope = scope
+        if provided_token:
+            # Persist only a non-reversible caller identity; sidecar ownership
+            # must never retain or expose the bearer token itself.
+            request.state.caller_fingerprint = hashlib.sha256(provided_token.encode()).hexdigest()
         return await call_next(request)

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -304,6 +304,22 @@ class ResourceLimitsConfig(RichModel):
     )
 
 
+class SidecarStoreConfig(RichModel):
+    """Backend shared by split-sidecar gateway and worker processes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    backend: Literal["memory", "redis"] = "memory"
+    redis_url: str | None = None
+    max_payload_bytes: int = Field(default=33_554_432, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_redis_url(self) -> "SidecarStoreConfig":
+        if self.backend == "redis" and not (self.redis_url or "").strip():
+            raise ValueError("sidecar_store.redis_url must be set when sidecar_store.backend is redis")
+        return self
+
+
 class AuthConfig(RichModel):
     """Bearer authentication and authorization for logical workspace scopes."""
 
@@ -571,12 +587,21 @@ class ServiceConfig(RichModel):
     agentic: AgenticConfig = Field(default_factory=AgenticConfig)
     resources: ResourceLimitsConfig = Field(default_factory=ResourceLimitsConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+    sidecar_store: SidecarStoreConfig = Field(default_factory=SidecarStoreConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     pipeline: PipelinePoolConfig = Field(default_factory=PipelinePoolConfig)
     work_queue: WorkQueueConfig = Field(default_factory=WorkQueueConfig)
     vectordb: VectorDbConfig = Field(default_factory=VectorDbConfig)
     pipeline_overrides: PipelineOverridesConfig = Field(default_factory=PipelineOverridesConfig)
+
+    @model_validator(mode="after")
+    def _validate_sidecar_payload_limit(self) -> "ServiceConfig":
+        if self.sidecar_store.max_payload_bytes > self.resources.max_upload_bytes:
+            raise ValueError(
+                "sidecar_store.max_payload_bytes must not exceed resources.max_upload_bytes"
+            )
+        return self
 
     @model_validator(mode="after")
     def _cap_process_pool_workers_for_local_models(self) -> "ServiceConfig":
@@ -666,10 +691,12 @@ def load_config(
         internal_token = internal_token.strip()
     if internal_token:
         raw.setdefault("vectordb", {})["internal_api_token"] = internal_token
+    if redis_url := os.environ.get("NRL_SIDECAR_REDIS_URL"):
+        raw.setdefault("sidecar_store", {})["redis_url"] = redis_url
 
     config = ServiceConfig(**raw)
 
-    _REDACTED_FIELDS = frozenset({"api_key", "api_token", "internal_api_token", "password", "secret"})
+    _REDACTED_FIELDS = frozenset({"api_key", "api_token", "internal_api_token", "redis_url", "password", "secret"})
 
     from rich.console import Console
     from rich.tree import Tree

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -598,9 +598,7 @@ class ServiceConfig(RichModel):
     @model_validator(mode="after")
     def _validate_sidecar_payload_limit(self) -> "ServiceConfig":
         if self.sidecar_store.max_payload_bytes > self.resources.max_upload_bytes:
-            raise ValueError(
-                "sidecar_store.max_payload_bytes must not exceed resources.max_upload_bytes"
-            )
+            raise ValueError("sidecar_store.max_payload_bytes must not exceed resources.max_upload_bytes")
         return self
 
     @model_validator(mode="after")

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -514,7 +514,8 @@ async def _gateway_enqueue(
             extra={
                 **({"write": write.model_dump(mode="json")} if write is not None else {}),
                 **({"sidecar_owner_fingerprint": sidecar_owner_fingerprint} if sidecar_owner_fingerprint else {}),
-            } or None,
+            }
+            or None,
         )
     except WorkQueueFull as exc:
         tracker = get_job_tracker()
@@ -1493,7 +1494,7 @@ async def ingest_sidecar(
     enabled) and auto-evicted after ``ttl_s`` seconds.
     """
     from datetime import datetime, timezone
-    from nemo_retriever.service.services.sidecar_store import get_sidecar_store
+    from nemo_retriever.service.services.sidecar_store import SidecarStoreUnavailable, get_sidecar_store
 
     _check_upload_size(file, request)
 
@@ -1524,6 +1525,12 @@ async def ingest_sidecar(
             ttl_s=ttl_s,
             consume_on_read=consume_on_read,
         )
+    except SidecarStoreUnavailable as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=str(exc),
+            headers={"Retry-After": _RETRY_AFTER_SECONDS},
+        ) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=429, detail=str(exc)) from exc
     except ValueError as exc:
@@ -1546,7 +1553,7 @@ async def ingest_sidecar(
 )
 async def delete_sidecar(request: Request, sidecar_id: str) -> Response:
     """Explicit deletion lets callers free server memory before the TTL elapses."""
-    from nemo_retriever.service.services.sidecar_store import get_sidecar_store
+    from nemo_retriever.service.services.sidecar_store import SidecarStoreUnavailable, get_sidecar_store
 
     config = request.app.state.config
     if _is_gateway(request) and not config.sidecar_store.backend == "redis":
@@ -1558,7 +1565,15 @@ async def delete_sidecar(request: Request, sidecar_id: str) -> Response:
     store = get_sidecar_store()
     if store is None:
         raise HTTPException(status_code=503, detail="Sidecar store not initialised")
-    if not store.delete(sidecar_id, owner_token=_sidecar_owner_fingerprint(request)):
+    try:
+        deleted = store.delete(sidecar_id, owner_token=_sidecar_owner_fingerprint(request))
+    except SidecarStoreUnavailable as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=str(exc),
+            headers={"Retry-After": _RETRY_AFTER_SECONDS},
+        ) from exc
+    if not deleted:
         raise HTTPException(status_code=404, detail="Sidecar id not found")
     return Response(status_code=204)
 

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -549,6 +549,21 @@ def _check_upload_size(file: UploadFile, request: Request) -> None:
         )
 
 
+async def _read_upload_limited(file: UploadFile, limit: int, *, label: str) -> bytes:
+    """Read an upload in bounded chunks and reject it once it exceeds *limit*."""
+    if file.size is not None and file.size > limit:
+        raise HTTPException(status_code=413, detail=f"{label} exceeds limit of {limit:,} bytes")
+
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := await file.read(min(64 * 1024, limit - total + 1)):
+        total += len(chunk)
+        if total > limit:
+            raise HTTPException(status_code=413, detail=f"{label} exceeds limit of {limit:,} bytes")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def _count_pdf_pages(file_bytes: bytes) -> int:
     """Return the number of pages in a PDF, or 1 for non-PDF / errors."""
     try:
@@ -1509,7 +1524,7 @@ async def ingest_sidecar(
     if store is None:
         raise HTTPException(status_code=503, detail="Sidecar store not initialised")
 
-    payload = await file.read()
+    payload = await _read_upload_limited(file, config.sidecar_store.max_payload_bytes, label="Sidecar upload")
     if not payload:
         raise HTTPException(status_code=400, detail="Sidecar upload is empty")
 

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -143,6 +143,12 @@ def _role(request: Request) -> str:
     return getattr(request.app.state, "prometheus_role", "standalone")
 
 
+def _sidecar_owner_fingerprint(request: Request) -> str | None:
+    """Return the gateway-authenticated sidecar owner when available."""
+    value = getattr(request.state, "caller_fingerprint", None)
+    return str(value) if value else None
+
+
 def _is_gateway(request: Request) -> bool:
     return _mode(request) == "gateway"
 
@@ -476,6 +482,7 @@ async def _gateway_enqueue(
     filename: str | None,
     pipeline_spec: dict[str, Any] | None = None,
     write: DocumentWriteContext | None = None,
+    sidecar_owner_fingerprint: str | None = None,
 ) -> None:
     """Admit split-mode work to the gateway broker after atomic spooling.
 
@@ -504,7 +511,10 @@ async def _gateway_enqueue(
             retain_results=_job_retain_results(job_id),
             pipeline_spec=pipeline_spec,
             trace_context=_safe_inject_trace_context(),
-            extra={"write": write.model_dump(mode="json")} if write is not None else None,
+            extra={
+                **({"write": write.model_dump(mode="json")} if write is not None else {}),
+                **({"sidecar_owner_fingerprint": sidecar_owner_fingerprint} if sidecar_owner_fingerprint else {}),
+            } or None,
         )
     except WorkQueueFull as exc:
         tracker = get_job_tracker()
@@ -666,6 +676,7 @@ async def _prepare_job_work_item(
         job_id=job_id,
         pipeline_spec=validated_spec.model_dump(mode="json") if validated_spec is not None else None,
         retain_results=_job_retain_results(job_id),
+        sidecar_owner_fingerprint=_sidecar_owner_fingerprint(request),
         write=DocumentWriteContext(
             scope=job.scope,
             collection_name=job.collection_name,
@@ -721,6 +732,7 @@ async def _submit_job_work_item(
             filename=item.filename,
             pipeline_spec=item.pipeline_spec,
             write=item.write,
+            sidecar_owner_fingerprint=item.sidecar_owner_fingerprint,
         )
     else:
         await _enqueue_or_reject(pool_type, item)
@@ -1485,30 +1497,12 @@ async def ingest_sidecar(
 
     _check_upload_size(file, request)
 
-    # Forward to the gateway's backend so the realtime worker pool has
-    # the sidecar available when the matching ingest call arrives. We
-    # broadcast to both pools because the routing decision happens at
-    # ingest time, not at sidecar-upload time.
-    if _is_gateway(request):
-        from nemo_retriever.service.services.proxy import get_proxy
-
-        proxy = get_proxy()
-        if proxy is None:
-            raise HTTPException(status_code=503, detail="Gateway proxy not initialised")
-        # Pick the realtime backend for the canonical response, then
-        # mirror the upload to the batch backend so either worker pool
-        # can resolve the id. If the mirror fails we still return 201
-        # because the realtime store has the entry and most workloads
-        # land there.
-        realtime_resp = await proxy.forward(request, PoolType.REALTIME)
-        try:
-            await proxy.forward(request, PoolType.BATCH)
-        except Exception as exc:
-            logger.warning(
-                "Sidecar mirror to batch backend failed (id from realtime still valid): %s",
-                exc,
-            )
-        return realtime_resp
+    config = request.app.state.config
+    if _is_gateway(request) and not config.sidecar_store.backend == "redis":
+        raise HTTPException(
+            status_code=503,
+            detail="Split sidecar operations require serviceConfig.sidecarStore.backend=redis.",
+        )
 
     store = get_sidecar_store()
     if store is None:
@@ -1518,9 +1512,8 @@ async def ingest_sidecar(
     if not payload:
         raise HTTPException(status_code=400, detail="Sidecar upload is empty")
 
-    # Owner-token scoping: use the bearer token when auth is enabled.
-    auth_header = request.headers.get("Authorization", "")
-    owner_token = auth_header.split(" ", 1)[1].strip() if auth_header.lower().startswith("bearer ") else None
+    # Redis sidecars use a gateway-derived HMAC fingerprint, never the public bearer.
+    owner_token = _sidecar_owner_fingerprint(request)
 
     try:
         entry = store.put(
@@ -1533,6 +1526,8 @@ async def ingest_sidecar(
         )
     except RuntimeError as exc:
         raise HTTPException(status_code=429, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
 
     expires_iso = datetime.fromtimestamp(entry.expires_at, tz=timezone.utc).isoformat()
     return SidecarUploadResponse(
@@ -1553,24 +1548,18 @@ async def delete_sidecar(request: Request, sidecar_id: str) -> Response:
     """Explicit deletion lets callers free server memory before the TTL elapses."""
     from nemo_retriever.service.services.sidecar_store import get_sidecar_store
 
-    if _is_gateway(request):
-        from nemo_retriever.service.services.proxy import get_proxy
-
-        proxy = get_proxy()
-        if proxy is None:
-            raise HTTPException(status_code=503, detail="Gateway proxy not initialised")
-        # Mirror delete to both pools. We don't care which one had it.
-        for pool in (PoolType.REALTIME, PoolType.BATCH):
-            try:
-                await proxy.forward(request, pool)
-            except Exception as exc:
-                logger.debug("Sidecar delete forward to %s failed: %s", pool.value, exc)
-        return Response(status_code=204)
+    config = request.app.state.config
+    if _is_gateway(request) and not config.sidecar_store.backend == "redis":
+        raise HTTPException(
+            status_code=503,
+            detail="Split sidecar operations require serviceConfig.sidecarStore.backend=redis.",
+        )
 
     store = get_sidecar_store()
     if store is None:
         raise HTTPException(status_code=503, detail="Sidecar store not initialised")
-    store.delete(sidecar_id)
+    if not store.delete(sidecar_id, owner_token=_sidecar_owner_fingerprint(request)):
+        raise HTTPException(status_code=404, detail="Sidecar id not found")
     return Response(status_code=204)
 
 

--- a/nemo_retriever/src/nemo_retriever/service/routers/work.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/work.py
@@ -26,7 +26,7 @@ class ClaimRequest(BaseModel):
 class LeaseRequest(BaseModel):
     lease_id: str = Field(min_length=1)
     lease_generation: int = Field(ge=1)
-    reason: Literal["release", "payload_fetch", "hash_mismatch"] = "release"
+    reason: Literal["release", "payload_fetch", "hash_mismatch", "sidecar_store_unavailable"] = "release"
 
 
 def _gateway_broker(request: Request):

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -415,7 +415,9 @@ def _resolve_extract_params(
     return ExtractParams(**extract_kwargs)
 
 
-def _resolve_sidecar_in_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
+def _resolve_sidecar_in_spec(
+    spec: dict[str, Any] | None, *, sidecar_owner_fingerprint: str | None = None
+) -> dict[str, Any] | None:
     """Resolve ``vdb_upload_params.meta_dataframe_id`` to in-band bytes.
 
     The pipeline runs in a child process that cannot reach the
@@ -435,14 +437,17 @@ def _resolve_sidecar_in_spec(spec: dict[str, Any] | None) -> dict[str, Any] | No
     if not sidecar_id:
         return spec
 
-    from nemo_retriever.service.services.sidecar_store import get_sidecar_store
+    from nemo_retriever.service.services.sidecar_store import RedisSidecarStore, get_sidecar_store
 
     store = get_sidecar_store()
     if store is None:
         raise RuntimeError(
             "vdb_upload_params.meta_dataframe_id was set but the SidecarStore " "is not initialised on this pod."
         )
-    entry = store.consume(sidecar_id)
+    entry = store.consume(
+        sidecar_id,
+        owner_token=sidecar_owner_fingerprint if isinstance(store, RedisSidecarStore) else None,
+    )
     if entry is None:
         raise RuntimeError(
             f"Sidecar id {sidecar_id!r} not found. The sidecar may have "
@@ -1118,7 +1123,9 @@ def _make_work_fn(
         filename = item.filename or item.id
         loop = asyncio.get_running_loop()
 
-        resolved_spec = _resolve_sidecar_in_spec(item.pipeline_spec)
+        resolved_spec = _resolve_sidecar_in_spec(
+            item.pipeline_spec, sidecar_owner_fingerprint=item.sidecar_owner_fingerprint
+        )
         write_context = item.write.resolved(fallback_document_id=item.id)
 
         try:

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -437,17 +437,14 @@ def _resolve_sidecar_in_spec(
     if not sidecar_id:
         return spec
 
-    from nemo_retriever.service.services.sidecar_store import RedisSidecarStore, get_sidecar_store
+    from nemo_retriever.service.services.sidecar_store import get_sidecar_store
 
     store = get_sidecar_store()
     if store is None:
         raise RuntimeError(
             "vdb_upload_params.meta_dataframe_id was set but the SidecarStore " "is not initialised on this pod."
         )
-    entry = store.consume(
-        sidecar_id,
-        owner_token=sidecar_owner_fingerprint if isinstance(store, RedisSidecarStore) else None,
-    )
+    entry = store.consume(sidecar_id, owner_token=sidecar_owner_fingerprint)
     if entry is None:
         raise RuntimeError(
             f"Sidecar id {sidecar_id!r} not found. The sidecar may have "

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -1124,7 +1124,7 @@ def _make_work_fn(
         loop = asyncio.get_running_loop()
 
         resolved_spec = _resolve_sidecar_in_spec(
-            item.pipeline_spec, sidecar_owner_fingerprint=item.sidecar_owner_fingerprint
+            item.pipeline_spec, sidecar_owner_fingerprint=getattr(item, "sidecar_owner_fingerprint", None)
         )
         write_context = item.write.resolved(fallback_document_id=item.id)
 

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
@@ -260,6 +260,7 @@ class _Pool:
         self._workers: list[asyncio.Task[None]] = []
         self._reporter_task: asyncio.Task[None] | None = None
         self._handoff_tasks: dict[str, asyncio.Task[None]] = {}
+        self._sidecar_release_tasks: dict[str, asyncio.Task[None]] = {}
         self._handoff_slots: asyncio.BoundedSemaphore | None = None
         self._running = False
         self._processed: int = 0
@@ -359,6 +360,48 @@ class _Pool:
                 await asyncio.sleep(_QUEUE_DEPTH_REPORT_INTERVAL_S)
         except asyncio.CancelledError:
             pass
+
+    def _schedule_sidecar_release_retry(self, *, item: WorkItem, worker_id: int) -> None:
+        """Release a sidecar-unavailable claim without holding a pool worker."""
+        if not self._running or item.id in self._sidecar_release_tasks or self._pull_client is None:
+            return
+
+        claim = {
+            "work_id": item.id,
+            "lease_id": item.lease_id,
+            "lease_generation": item.lease_generation,
+        }
+
+        async def _retry_release() -> None:
+            while self._running and not await self._pull_client.release(claim, reason="sidecar_store_unavailable"):
+                logger.warning(
+                    "Pool '%s' worker %d retrying release for item %s after a gateway failure",
+                    self._name,
+                    worker_id,
+                    item.id,
+                )
+                await asyncio.sleep(_SIDECAR_STORE_RETRY_DELAY_S)
+            if self._running:
+                logger.warning(
+                    "Pool '%s' worker %d released item %s after a temporary sidecar-store failure",
+                    self._name,
+                    worker_id,
+                    item.id,
+                )
+
+        task = asyncio.create_task(_retry_release())
+        self._sidecar_release_tasks[item.id] = task
+
+        def _remove_finished(finished: asyncio.Task[None]) -> None:
+            if self._sidecar_release_tasks.get(item.id) is finished:
+                self._sidecar_release_tasks.pop(item.id, None)
+            if not finished.cancelled():
+                try:
+                    finished.result()
+                except Exception:
+                    logger.exception("Deferred sidecar release task failed for item %s", item.id)
+
+        task.add_done_callback(_remove_finished)
 
     async def _schedule_gateway_callback_retry(
         self,
@@ -622,25 +665,7 @@ class _Pool:
 
                     if isinstance(exc, SidecarStoreUnavailable) and item.callback_url and self._pull_client is not None:
                         outcome = "retrying"
-                        claim = {
-                            "work_id": item.id,
-                            "lease_id": item.lease_id,
-                            "lease_generation": item.lease_generation,
-                        }
-                        while not await self._pull_client.release(claim, reason="sidecar_store_unavailable"):
-                            logger.warning(
-                                "Pool '%s' worker %d retrying release for item %s after a gateway failure",
-                                self._name,
-                                worker_id,
-                                item.id,
-                            )
-                            await asyncio.sleep(_SIDECAR_STORE_RETRY_DELAY_S)
-                        logger.warning(
-                            "Pool '%s' worker %d released item %s after a temporary sidecar-store failure",
-                            self._name,
-                            worker_id,
-                            item.id,
-                        )
+                        self._schedule_sidecar_release_retry(item=item, worker_id=worker_id)
                     else:
                         outcome = "failed"
                         if item.callback_url:
@@ -726,6 +751,12 @@ class _Pool:
         if self._handoff_tasks:
             await asyncio.gather(*self._handoff_tasks.values(), return_exceptions=True)
         self._handoff_tasks.clear()
+
+        for task in self._sidecar_release_tasks.values():
+            task.cancel()
+        if self._sidecar_release_tasks:
+            await asyncio.gather(*self._sidecar_release_tasks.values(), return_exceptions=True)
+        self._sidecar_release_tasks.clear()
 
         # Cancel all worker tasks immediately — don't bother draining
         # the queue with sentinels since active workers may be blocked

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
@@ -396,7 +396,12 @@ class _Pool:
             while True:
                 await asyncio.sleep(self._pull_client.config.heartbeat_interval_s)
                 if not await self._pull_client.heartbeat(item):
-                    return
+                    logger.warning(
+                        "Pool '%s' worker %d retrying heartbeat for deferred sidecar release of item %s",
+                        self._name,
+                        worker_id,
+                        item.id,
+                    )
 
         lease_heartbeat_task = asyncio.create_task(_keep_deferred_lease())
 

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
@@ -617,37 +617,56 @@ class _Pool:
                         )
                     self._processed += 1
                 except Exception as exc:
-                    outcome = "failed"
-                    if item.callback_url:
-                        error = f"{type(exc).__name__}: {exc}"
-                        callback_outcome = await _fire_gateway_callback(
-                            item.callback_url,
-                            item.id,
-                            "failed",
-                            error=error,
-                            callback_headers=item.callback_headers,
-                            lease_id=item.lease_id,
-                            lease_generation=item.lease_generation,
+                    from nemo_retriever.service.services.sidecar_store import SidecarStoreUnavailable
+
+                    if isinstance(exc, SidecarStoreUnavailable) and item.callback_url and self._pull_client is not None:
+                        outcome = "retrying"
+                        await self._pull_client.release(
+                            {
+                                "work_id": item.id,
+                                "lease_id": item.lease_id,
+                                "lease_generation": item.lease_generation,
+                            },
+                            reason="sidecar_store_unavailable",
                         )
-                        if callback_outcome == _CallbackDeliveryOutcome.RETRYABLE:
-                            await self._schedule_gateway_callback_retry(
-                                callback_url=item.callback_url,
-                                item_id=item.id,
-                                status="failed",
+                        logger.warning(
+                            "Pool '%s' worker %d released item %s after a temporary sidecar-store failure",
+                            self._name,
+                            worker_id,
+                            item.id,
+                        )
+                    else:
+                        outcome = "failed"
+                        if item.callback_url:
+                            error = f"{type(exc).__name__}: {exc}"
+                            callback_outcome = await _fire_gateway_callback(
+                                item.callback_url,
+                                item.id,
+                                "failed",
                                 error=error,
                                 callback_headers=item.callback_headers,
-                                work_item=item,
+                                lease_id=item.lease_id,
+                                lease_generation=item.lease_generation,
                             )
-                    else:
-                        tracker = get_job_tracker()
-                        if tracker is not None:
-                            tracker.mark_failed(item.id, f"{type(exc).__name__}: {exc}")
-                    logger.exception(
-                        "Pool '%s' worker %d failed on item %s",
-                        self._name,
-                        worker_id,
-                        item.id,
-                    )
+                            if callback_outcome == _CallbackDeliveryOutcome.RETRYABLE:
+                                await self._schedule_gateway_callback_retry(
+                                    callback_url=item.callback_url,
+                                    item_id=item.id,
+                                    status="failed",
+                                    error=error,
+                                    callback_headers=item.callback_headers,
+                                    work_item=item,
+                                )
+                        else:
+                            tracker = get_job_tracker()
+                            if tracker is not None:
+                                tracker.mark_failed(item.id, f"{type(exc).__name__}: {exc}")
+                        logger.exception(
+                            "Pool '%s' worker %d failed on item %s",
+                            self._name,
+                            worker_id,
+                            item.id,
+                        )
                 finally:
                     # Always observe; cheaper to keep latency series complete
                     # than to gate on outcome. Bucketed histogram, so even

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
@@ -622,15 +622,19 @@ class _Pool:
 
                     if isinstance(exc, SidecarStoreUnavailable) and item.callback_url and self._pull_client is not None:
                         outcome = "retrying"
-                        await asyncio.sleep(_SIDECAR_STORE_RETRY_DELAY_S)
-                        await self._pull_client.release(
-                            {
-                                "work_id": item.id,
-                                "lease_id": item.lease_id,
-                                "lease_generation": item.lease_generation,
-                            },
-                            reason="sidecar_store_unavailable",
-                        )
+                        claim = {
+                            "work_id": item.id,
+                            "lease_id": item.lease_id,
+                            "lease_generation": item.lease_generation,
+                        }
+                        while not await self._pull_client.release(claim, reason="sidecar_store_unavailable"):
+                            logger.warning(
+                                "Pool '%s' worker %d retrying release for item %s after a gateway failure",
+                                self._name,
+                                worker_id,
+                                item.id,
+                            )
+                            await asyncio.sleep(_SIDECAR_STORE_RETRY_DELAY_S)
                         logger.warning(
                             "Pool '%s' worker %d released item %s after a temporary sidecar-store failure",
                             self._name,

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
@@ -58,6 +58,7 @@ _QUEUE_DEPTH_REPORT_INTERVAL_S = 1.0
 _CALLBACK_RETRY_DELAYS_S = (0.5, 1.0, 2.0, 4.0, 8.0)
 _CALLBACK_DEFERRED_INITIAL_DELAY_S = 16.0
 _CALLBACK_DEFERRED_MAX_DELAY_S = 300.0
+_SIDECAR_STORE_RETRY_DELAY_S = 5.0
 
 
 class PoolType(str, Enum):
@@ -621,6 +622,7 @@ class _Pool:
 
                     if isinstance(exc, SidecarStoreUnavailable) and item.callback_url and self._pull_client is not None:
                         outcome = "retrying"
+                        await asyncio.sleep(_SIDECAR_STORE_RETRY_DELAY_S)
                         await self._pull_client.release(
                             {
                                 "work_id": item.id,

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
@@ -392,7 +392,16 @@ class _Pool:
         task = asyncio.create_task(_retry_release())
         self._sidecar_release_tasks[item.id] = task
 
+        async def _keep_deferred_lease() -> None:
+            while True:
+                await asyncio.sleep(self._pull_client.config.heartbeat_interval_s)
+                if not await self._pull_client.heartbeat(item):
+                    return
+
+        lease_heartbeat_task = asyncio.create_task(_keep_deferred_lease())
+
         def _remove_finished(finished: asyncio.Task[None]) -> None:
+            lease_heartbeat_task.cancel()
             if self._sidecar_release_tasks.get(item.id) is finished:
                 self._sidecar_release_tasks.pop(item.id, None)
             if not finished.cancelled():

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py
@@ -146,6 +146,7 @@ class WorkItem(RichModel):
     # Validated per-request pipeline overrides (PipelineSpec serialised
     # to a dict). ``None`` means: run the legacy startup-baked pipeline.
     pipeline_spec: dict[str, Any] | None = None
+    sidecar_owner_fingerprint: str | None = None
     trace_context: dict[str, str] = Field(default_factory=dict)
     enqueued_at_monotonic_s: float | None = None
     lease_id: str | None = None

--- a/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
@@ -380,7 +380,11 @@ class SidecarStore:
 
     def delete(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> bool:
         with self._lock:
-            return self._entries.pop(sidecar_id, None) is not None
+            entry = self._entries.get(sidecar_id)
+            if entry is None or (entry.owner_token is not None and owner_token != entry.owner_token):
+                return False
+            self._entries.pop(sidecar_id, None)
+            return True
 
     def stats(self) -> dict[str, int | float]:
         now = time.time()

--- a/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
@@ -33,9 +33,20 @@ import time
 from dataclasses import dataclass, field
 from typing import Optional
 
+from redis.exceptions import (
+    BusyLoadingError,
+    ConnectionError as RedisConnectionError,
+    TimeoutError as RedisTimeoutError,
+)
+
 logger = logging.getLogger(__name__)
 
 _REDIS_PREFIX = "nrl:sidecar:"
+_REDIS_OPERATION_TIMEOUT_S = 5.0
+
+
+class SidecarStoreUnavailable(RuntimeError):
+    """Raised when the shared Redis sidecar store cannot serve a request."""
 
 
 @dataclass(slots=True)
@@ -80,20 +91,21 @@ if not owner or owner ~= ARGV[1] then return 0 end
 return redis.call("DEL", KEYS[1])
 """
 
-    def __init__(
-        self, url: str, *, default_ttl_s: float = 3600.0, max_payload_bytes: int = 33_554_432
-    ) -> None:
+    def __init__(self, url: str, *, default_ttl_s: float = 3600.0, max_payload_bytes: int = 33_554_432) -> None:
         from redis import Redis
 
-        self._client = Redis.from_url(url, decode_responses=False)
+        self._client = Redis.from_url(
+            url,
+            decode_responses=False,
+            socket_connect_timeout=_REDIS_OPERATION_TIMEOUT_S,
+            socket_timeout=_REDIS_OPERATION_TIMEOUT_S,
+        )
         self._default_ttl_s = default_ttl_s
         self._max_payload_bytes = max_payload_bytes
-
 
     @staticmethod
     def _key(sidecar_id: str) -> str:
         return f"{_REDIS_PREFIX}{sidecar_id}"
-
 
     @staticmethod
     def _entry_from_data(sidecar_id: str, data: dict[bytes, bytes]) -> SidecarEntry:
@@ -122,6 +134,7 @@ return redis.call("DEL", KEYS[1])
         ttl_s: Optional[float] = None,
         consume_on_read: bool = True,
     ) -> SidecarEntry:
+        """Store a sidecar and return it, or raise when Redis is unavailable."""
         if len(payload) > self._max_payload_bytes:
             raise ValueError(f"Sidecar payload exceeds Redis limit of {self._max_payload_bytes:,} bytes.")
         sidecar_id = secrets.token_urlsafe(16)
@@ -152,11 +165,18 @@ return redis.call("DEL", KEYS[1])
             },
         )
         pipe.pexpire(key, max(1, int(ttl * 1000)))
-        pipe.execute()
+        try:
+            pipe.execute()
+        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+            raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
         return entry
 
     def get(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> Optional[SidecarEntry]:
-        data = self._client.hgetall(self._key(sidecar_id))
+        """Return an owner-matching sidecar without consuming it, if present."""
+        try:
+            data = self._client.hgetall(self._key(sidecar_id))
+        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+            raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
         if not data:
             return None
         stored_owner = data.get(b"owner_token", b"").decode()
@@ -165,14 +185,22 @@ return redis.call("DEL", KEYS[1])
         return self._entry_from_data(sidecar_id, data)
 
     def consume(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> Optional[SidecarEntry]:
-        raw_data = self._client.eval(self._CONSUME_SCRIPT, 1, self._key(sidecar_id), owner_token or "")
+        """Atomically return and optionally delete an owner-matching sidecar."""
+        try:
+            raw_data = self._client.eval(self._CONSUME_SCRIPT, 1, self._key(sidecar_id), owner_token or "")
+        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+            raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
         if not raw_data:
             return None
         data = dict(zip(raw_data[::2], raw_data[1::2]))
         return self._entry_from_data(sidecar_id, data)
 
     def delete(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> bool:
-        return bool(self._client.eval(self._DELETE_SCRIPT, 1, self._key(sidecar_id), owner_token or ""))
+        """Atomically delete an owner-matching sidecar and report success."""
+        try:
+            return bool(self._client.eval(self._DELETE_SCRIPT, 1, self._key(sidecar_id), owner_token or ""))
+        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+            raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
 
     def stats(self) -> dict[str, int | float]:
         return {"entries": 0, "total_bytes": 0, "max_entries": 0, "default_ttl_s": self._default_ttl_s}
@@ -188,15 +216,20 @@ class SidecarStore:
     can plug in via the same interface.
     """
 
-    def __init__(self, *, default_ttl_s: float = 3600.0, max_entries: int = 1024) -> None:
+    def __init__(
+        self, *, default_ttl_s: float = 3600.0, max_entries: int = 1024, max_payload_bytes: int = 33_554_432
+    ) -> None:
         if default_ttl_s <= 0:
             raise ValueError("default_ttl_s must be positive")
         if max_entries <= 0:
             raise ValueError("max_entries must be positive")
+        if max_payload_bytes <= 0:
+            raise ValueError("max_payload_bytes must be positive")
         self._entries: dict[str, SidecarEntry] = {}
         self._lock = threading.Lock()
         self._default_ttl_s = default_ttl_s
         self._max_entries = max_entries
+        self._max_payload_bytes = max_payload_bytes
 
     # ── public API ─────────────────────────────────────────────────
 
@@ -215,6 +248,8 @@ class SidecarStore:
         ``sidecar_id`` is a URL-safe 128-bit token (32 hex chars). The
         chance of collision is negligible for any realistic workload.
         """
+        if len(payload) > self._max_payload_bytes:
+            raise ValueError(f"Sidecar payload exceeds memory limit of {self._max_payload_bytes:,} bytes.")
         sidecar_id = secrets.token_urlsafe(16)
         now = time.time()
         ttl = float(ttl_s) if ttl_s is not None else self._default_ttl_s
@@ -337,12 +372,22 @@ class SidecarStore:
 _instance: SidecarStore | RedisSidecarStore | None = None
 
 
-def init_sidecar_store(*, default_ttl_s: float = 3600.0, max_entries: int = 1024, redis_url: str | None = None, max_payload_bytes: int = 33_554_432) -> SidecarStore | RedisSidecarStore:
+def init_sidecar_store(
+    *,
+    default_ttl_s: float = 3600.0,
+    max_entries: int = 1024,
+    redis_url: str | None = None,
+    max_payload_bytes: int = 33_554_432,
+) -> SidecarStore | RedisSidecarStore:
     global _instance
     _instance = (
         RedisSidecarStore(redis_url, default_ttl_s=default_ttl_s, max_payload_bytes=max_payload_bytes)
         if redis_url
-        else SidecarStore(default_ttl_s=default_ttl_s, max_entries=max_entries)
+        else SidecarStore(
+            default_ttl_s=default_ttl_s,
+            max_entries=max_entries,
+            max_payload_bytes=max_payload_bytes,
+        )
     )
     logger.info("SidecarStore initialised (ttl=%.0fs max_entries=%d)", default_ttl_s, max_entries)
     return _instance

--- a/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
@@ -35,8 +35,13 @@ from typing import Optional
 
 from redis.exceptions import (
     BusyLoadingError,
+    ClusterDownError,
     ConnectionError as RedisConnectionError,
+    MasterDownError,
+    OutOfMemoryError,
+    ReadOnlyError,
     TimeoutError as RedisTimeoutError,
+    TryAgainError,
 )
 
 logger = logging.getLogger(__name__)
@@ -167,7 +172,16 @@ return redis.call("DEL", KEYS[1])
         pipe.pexpire(key, max(1, int(ttl * 1000)))
         try:
             pipe.execute()
-        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+        except (
+            RedisConnectionError,
+            RedisTimeoutError,
+            BusyLoadingError,
+            OutOfMemoryError,
+            ReadOnlyError,
+            ClusterDownError,
+            MasterDownError,
+            TryAgainError,
+        ) as exc:
             raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
         return entry
 
@@ -175,7 +189,16 @@ return redis.call("DEL", KEYS[1])
         """Return an owner-matching sidecar without consuming it, if present."""
         try:
             data = self._client.hgetall(self._key(sidecar_id))
-        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+        except (
+            RedisConnectionError,
+            RedisTimeoutError,
+            BusyLoadingError,
+            OutOfMemoryError,
+            ReadOnlyError,
+            ClusterDownError,
+            MasterDownError,
+            TryAgainError,
+        ) as exc:
             raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
         if not data:
             return None
@@ -188,7 +211,16 @@ return redis.call("DEL", KEYS[1])
         """Atomically return and optionally delete an owner-matching sidecar."""
         try:
             raw_data = self._client.eval(self._CONSUME_SCRIPT, 1, self._key(sidecar_id), owner_token or "")
-        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+        except (
+            RedisConnectionError,
+            RedisTimeoutError,
+            BusyLoadingError,
+            OutOfMemoryError,
+            ReadOnlyError,
+            ClusterDownError,
+            MasterDownError,
+            TryAgainError,
+        ) as exc:
             raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
         if not raw_data:
             return None
@@ -199,7 +231,16 @@ return redis.call("DEL", KEYS[1])
         """Atomically delete an owner-matching sidecar and report success."""
         try:
             return bool(self._client.eval(self._DELETE_SCRIPT, 1, self._key(sidecar_id), owner_token or ""))
-        except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
+        except (
+            RedisConnectionError,
+            RedisTimeoutError,
+            BusyLoadingError,
+            OutOfMemoryError,
+            ReadOnlyError,
+            ClusterDownError,
+            MasterDownError,
+            TryAgainError,
+        ) as exc:
             raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable") from exc
 
     def stats(self) -> dict[str, int | float]:

--- a/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/sidecar_store.py
@@ -25,6 +25,7 @@ Trust boundary highlights:
 
 from __future__ import annotations
 
+import hmac
 import logging
 import secrets
 import threading
@@ -33,6 +34,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+_REDIS_PREFIX = "nrl:sidecar:"
 
 
 @dataclass(slots=True)
@@ -53,6 +56,126 @@ class SidecarEntry:
     owner_token: Optional[str] = None
     consume_on_read: bool = True
     metadata: dict[str, str] = field(default_factory=dict)
+
+
+class RedisSidecarStore:
+    """Redis-backed sidecars shared by every split worker replica."""
+
+    _CONSUME_SCRIPT = """
+local data = redis.call("HGETALL", KEYS[1])
+if #data == 0 then return nil end
+local owner = ""
+local consume = "0"
+for index = 1, #data, 2 do
+  if data[index] == "owner_token" then owner = data[index + 1] end
+  if data[index] == "consume_on_read" then consume = data[index + 1] end
+end
+if owner ~= ARGV[1] then return nil end
+if consume == "1" then redis.call("DEL", KEYS[1]) end
+return data
+"""
+    _DELETE_SCRIPT = """
+local owner = redis.call("HGET", KEYS[1], "owner_token")
+if not owner or owner ~= ARGV[1] then return 0 end
+return redis.call("DEL", KEYS[1])
+"""
+
+    def __init__(
+        self, url: str, *, default_ttl_s: float = 3600.0, max_payload_bytes: int = 33_554_432
+    ) -> None:
+        from redis import Redis
+
+        self._client = Redis.from_url(url, decode_responses=False)
+        self._default_ttl_s = default_ttl_s
+        self._max_payload_bytes = max_payload_bytes
+
+
+    @staticmethod
+    def _key(sidecar_id: str) -> str:
+        return f"{_REDIS_PREFIX}{sidecar_id}"
+
+
+    @staticmethod
+    def _entry_from_data(sidecar_id: str, data: dict[bytes, bytes]) -> SidecarEntry:
+        def text(key: str) -> str:
+            return data[key.encode()].decode()
+
+        owner_token = text("owner_token") or None
+        return SidecarEntry(
+            sidecar_id=sidecar_id,
+            filename=text("filename"),
+            content_type=text("content_type"),
+            payload=data[b"payload"],
+            created_at=float(text("created_at")),
+            expires_at=float(text("expires_at")),
+            owner_token=owner_token,
+            consume_on_read=text("consume_on_read") == "1",
+        )
+
+    def put(
+        self,
+        *,
+        filename: str,
+        content_type: str,
+        payload: bytes,
+        owner_token: Optional[str] = None,
+        ttl_s: Optional[float] = None,
+        consume_on_read: bool = True,
+    ) -> SidecarEntry:
+        if len(payload) > self._max_payload_bytes:
+            raise ValueError(f"Sidecar payload exceeds Redis limit of {self._max_payload_bytes:,} bytes.")
+        sidecar_id = secrets.token_urlsafe(16)
+        now = time.time()
+        ttl = float(ttl_s) if ttl_s is not None else self._default_ttl_s
+        entry = SidecarEntry(
+            sidecar_id=sidecar_id,
+            filename=filename,
+            content_type=content_type,
+            payload=payload,
+            created_at=now,
+            expires_at=now + ttl,
+            owner_token=owner_token,
+            consume_on_read=consume_on_read,
+        )
+        key = self._key(sidecar_id)
+        pipe = self._client.pipeline()
+        pipe.hset(
+            key,
+            mapping={
+                "filename": filename,
+                "content_type": content_type,
+                "payload": payload,
+                "created_at": repr(now),
+                "expires_at": repr(entry.expires_at),
+                "owner_token": owner_token or "",
+                "consume_on_read": "1" if consume_on_read else "0",
+            },
+        )
+        pipe.pexpire(key, max(1, int(ttl * 1000)))
+        pipe.execute()
+        return entry
+
+    def get(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> Optional[SidecarEntry]:
+        data = self._client.hgetall(self._key(sidecar_id))
+        if not data:
+            return None
+        stored_owner = data.get(b"owner_token", b"").decode()
+        if not hmac.compare_digest(stored_owner, owner_token or ""):
+            return None
+        return self._entry_from_data(sidecar_id, data)
+
+    def consume(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> Optional[SidecarEntry]:
+        raw_data = self._client.eval(self._CONSUME_SCRIPT, 1, self._key(sidecar_id), owner_token or "")
+        if not raw_data:
+            return None
+        data = dict(zip(raw_data[::2], raw_data[1::2]))
+        return self._entry_from_data(sidecar_id, data)
+
+    def delete(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> bool:
+        return bool(self._client.eval(self._DELETE_SCRIPT, 1, self._key(sidecar_id), owner_token or ""))
+
+    def stats(self) -> dict[str, int | float]:
+        return {"entries": 0, "total_bytes": 0, "max_entries": 0, "default_ttl_s": self._default_ttl_s}
 
 
 class SidecarStore:
@@ -179,7 +302,7 @@ class SidecarStore:
                 logger.debug("SidecarStore: sidecar_id=%s consumed and removed", sidecar_id)
         return entry
 
-    def delete(self, sidecar_id: str) -> bool:
+    def delete(self, sidecar_id: str, *, owner_token: Optional[str] = None) -> bool:
         with self._lock:
             return self._entries.pop(sidecar_id, None) is not None
 
@@ -211,17 +334,21 @@ class SidecarStore:
 
 # ── module-level singleton, mirroring the pattern used elsewhere ────
 
-_instance: SidecarStore | None = None
+_instance: SidecarStore | RedisSidecarStore | None = None
 
 
-def init_sidecar_store(*, default_ttl_s: float = 3600.0, max_entries: int = 1024) -> SidecarStore:
+def init_sidecar_store(*, default_ttl_s: float = 3600.0, max_entries: int = 1024, redis_url: str | None = None, max_payload_bytes: int = 33_554_432) -> SidecarStore | RedisSidecarStore:
     global _instance
-    _instance = SidecarStore(default_ttl_s=default_ttl_s, max_entries=max_entries)
+    _instance = (
+        RedisSidecarStore(redis_url, default_ttl_s=default_ttl_s, max_payload_bytes=max_payload_bytes)
+        if redis_url
+        else SidecarStore(default_ttl_s=default_ttl_s, max_entries=max_entries)
+    )
     logger.info("SidecarStore initialised (ttl=%.0fs max_entries=%d)", default_ttl_s, max_entries)
     return _instance
 
 
-def get_sidecar_store() -> SidecarStore | None:
+def get_sidecar_store() -> SidecarStore | RedisSidecarStore | None:
     return _instance
 
 

--- a/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
@@ -522,7 +522,7 @@ class GatewayWorkClient:
 
         client = await self._http()
         try:
-            await client.post(
+            response = await client.post(
                 f"/v1/internal/work/{quote(str(claim['work_id']), safe='')}/release",
                 json={
                     "lease_id": claim["lease_id"],
@@ -530,6 +530,7 @@ class GatewayWorkClient:
                     "reason": reason,
                 },
             )
+            response.raise_for_status()
         except httpx.HTTPError:
             logger.warning("Release request failed for work %s", claim["work_id"], exc_info=True)
 

--- a/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
@@ -517,7 +517,7 @@ class GatewayWorkClient:
             return False
         return True
 
-    async def release(self, claim: Mapping[str, Any], *, reason: str = "release") -> None:
+    async def release(self, claim: Mapping[str, Any], *, reason: str = "release") -> bool:
         import httpx
 
         client = await self._http()
@@ -533,6 +533,8 @@ class GatewayWorkClient:
             response.raise_for_status()
         except httpx.HTTPError:
             logger.warning("Release request failed for work %s", claim["work_id"], exc_info=True)
+            return False
+        return True
 
 
 _instance: WorkBroker | None = None

--- a/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
@@ -530,6 +530,13 @@ class GatewayWorkClient:
                     "reason": reason,
                 },
             )
+            if 400 <= response.status_code < 500:
+                logger.warning(
+                    "Release request for work %s is no longer retryable (HTTP %d)",
+                    claim["work_id"],
+                    response.status_code,
+                )
+                return True
             response.raise_for_status()
         except httpx.HTTPError:
             logger.warning("Release request failed for work %s", claim["work_id"], exc_info=True)

--- a/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/work_queue.py
@@ -328,6 +328,10 @@ class WorkBroker:
         condition = self._conditions[record.pool]
         async with condition:
             record = self._current(work_id, lease_id, generation)
+            if reason == "sidecar_store_unavailable":
+                # A Redis availability outage is not a failed work delivery.
+                # Preserve the delivery budget while the shared store recovers.
+                record.delivery_attempt = max(0, record.delivery_attempt - 1)
             self._requeue_or_exhaust_locked(record, reason)
             self._publish_metrics()
             condition.notify_all()

--- a/nemo_retriever/tests/test_service_sidecar.py
+++ b/nemo_retriever/tests/test_service_sidecar.py
@@ -388,6 +388,31 @@ def app_with_sidecars(monkeypatch: pytest.MonkeyPatch, captured_items: list[Work
         yield client
 
 
+def test_authenticated_sidecars_use_caller_fingerprint() -> None:
+    import hashlib
+
+    cfg = ServiceConfig(
+        mode="standalone",
+        auth=AuthConfig(enabled=True, api_token="alice-token"),
+        pipeline=PipelinePoolConfig(realtime_workers=1, batch_workers=1),
+        pipeline_overrides=PipelineOverridesConfig(sinks=SinksConfig(vdb_uri_schemes=["s3://"])),
+    )
+    with TestClient(create_app(cfg)) as client:
+        response = client.post(
+            "/v1/ingest/sidecar",
+            headers={"Authorization": "Bearer alice-token"},
+            files={"file": ("meta.csv", _csv_bytes(), "text/csv")},
+        )
+        assert response.status_code == 201
+        from nemo_retriever.service.services.sidecar_store import get_sidecar_store
+
+        store = get_sidecar_store()
+        assert store is not None
+        owner = hashlib.sha256(b"alice-token").hexdigest()
+        assert store.get(response.json()["sidecar_id"], owner_token=owner) is not None
+        assert store.get(response.json()["sidecar_id"], owner_token="other") is None
+
+
 def test_post_sidecar_returns_id(app_with_sidecars: TestClient) -> None:
     resp = app_with_sidecars.post(
         "/v1/ingest/sidecar",

--- a/nemo_retriever/tests/test_service_sidecar.py
+++ b/nemo_retriever/tests/test_service_sidecar.py
@@ -39,11 +39,12 @@ from nemo_retriever.service.services.pipeline_executor import (
 )
 from nemo_retriever.service.services.pipeline_pool import WorkItem
 from nemo_retriever.service.services.sidecar_store import (
+    RedisSidecarStore,
     SidecarStore,
+    SidecarStoreUnavailable,
     init_sidecar_store,
     shutdown_sidecar_store,
 )
-
 
 # ----------------------------------------------------------------------
 # SidecarStore unit behaviour
@@ -103,6 +104,36 @@ def test_store_max_entries_guard() -> None:
     store.put(filename="b", content_type="text/csv", payload=b"b")
     with pytest.raises(RuntimeError, match="full"):
         store.put(filename="c", content_type="text/csv", payload=b"c")
+
+
+def test_store_rejects_payload_over_memory_limit() -> None:
+    store = SidecarStore(max_payload_bytes=3)
+    with pytest.raises(ValueError, match="memory limit"):
+        store.put(filename="m.csv", content_type="text/csv", payload=b"four")
+
+
+def test_redis_store_uses_bounded_operations_and_translates_outage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    class UnavailableClient:
+        def hgetall(self, _key: str) -> dict[bytes, bytes]:
+            raise RedisConnectionError("unavailable")
+
+    captured: dict[str, object] = {}
+
+    def fake_from_url(_url: str, **kwargs: object) -> UnavailableClient:
+        captured.update(kwargs)
+        return UnavailableClient()
+
+    monkeypatch.setattr("redis.Redis.from_url", fake_from_url)
+    store = RedisSidecarStore("redis://sidecars")
+
+    assert captured["socket_connect_timeout"] == 5.0
+    assert captured["socket_timeout"] == 5.0
+    with pytest.raises(SidecarStoreUnavailable, match="temporarily unavailable"):
+        store.get("sidecar-id")
 
 
 # ----------------------------------------------------------------------

--- a/nemo_retriever/tests/test_service_sidecar.py
+++ b/nemo_retriever/tests/test_service_sidecar.py
@@ -14,6 +14,7 @@ Three layers:
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import time
@@ -49,6 +50,20 @@ from nemo_retriever.service.services.sidecar_store import (
 # ----------------------------------------------------------------------
 # SidecarStore unit behaviour
 # ----------------------------------------------------------------------
+
+
+def test_limited_sidecar_read_stops_after_configured_limit() -> None:
+    from fastapi import HTTPException, UploadFile
+    from nemo_retriever.service.routers.ingest import _read_upload_limited
+
+    upload = UploadFile(filename="meta.csv", file=io.BytesIO(b"four"))
+
+    async def read() -> None:
+        with pytest.raises(HTTPException) as exc:
+            await _read_upload_limited(upload, 3, label="Sidecar upload")
+        assert exc.value.status_code == 413
+
+    asyncio.run(read())
 
 
 def test_store_put_get_consume_roundtrip() -> None:

--- a/nemo_retriever/tests/test_service_sidecar.py
+++ b/nemo_retriever/tests/test_service_sidecar.py
@@ -296,6 +296,25 @@ def test_resolve_sidecar_consumes_store_entry() -> None:
         shutdown_sidecar_store()
 
 
+def test_resolve_sidecar_consumes_authenticated_memory_entry() -> None:
+    store = init_sidecar_store()
+    try:
+        entry = store.put(
+            filename="meta.csv",
+            content_type="text/csv",
+            payload=_csv_bytes(),
+            owner_token="caller-fingerprint",
+        )
+        spec = {"vdb_upload_params": {"meta_dataframe_id": entry.sidecar_id}}
+
+        resolved = _resolve_sidecar_in_spec(spec, sidecar_owner_fingerprint="caller-fingerprint")
+
+        assert resolved is not None
+        assert resolved["vdb_upload_params"]["_meta_dataframe_bytes"] == _csv_bytes()
+    finally:
+        shutdown_sidecar_store()
+
+
 def test_resolve_sidecar_missing_id_raises() -> None:
     init_sidecar_store()
     try:

--- a/nemo_retriever/tests/test_service_sidecar.py
+++ b/nemo_retriever/tests/test_service_sidecar.py
@@ -136,6 +136,20 @@ def test_redis_store_uses_bounded_operations_and_translates_outage(
         store.get("sidecar-id")
 
 
+def test_redis_store_translates_transient_command_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from redis.exceptions import OutOfMemoryError
+
+    class UnavailableClient:
+        def hgetall(self, _key: str) -> dict[bytes, bytes]:
+            raise OutOfMemoryError("OOM command not allowed")
+
+    monkeypatch.setattr("redis.Redis.from_url", lambda *_args, **_kwargs: UnavailableClient())
+    store = RedisSidecarStore("redis://sidecars")
+
+    with pytest.raises(SidecarStoreUnavailable, match="temporarily unavailable"):
+        store.get("sidecar-id")
+
+
 # ----------------------------------------------------------------------
 # Worker-side materialisation
 # ----------------------------------------------------------------------

--- a/nemo_retriever/tests/test_service_sidecar.py
+++ b/nemo_retriever/tests/test_service_sidecar.py
@@ -150,6 +150,73 @@ def test_redis_store_translates_transient_command_error(monkeypatch: pytest.Monk
         store.get("sidecar-id")
 
 
+def test_redis_store_enforces_owner_and_single_use_consumption(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePipeline:
+        def __init__(self, client: "FakeRedis") -> None:
+            self._client = client
+
+        def hset(self, key: str, mapping: dict[str, str | bytes]) -> None:
+            self._client._entries[key] = {
+                field.encode(): value if isinstance(value, bytes) else value.encode()
+                for field, value in mapping.items()
+            }
+
+        def pexpire(self, _key: str, _ttl_ms: int) -> None:
+            return None
+
+        def execute(self) -> None:
+            return None
+
+    class FakeRedis:
+        def __init__(self) -> None:
+            self._entries: dict[str, dict[bytes, bytes]] = {}
+
+        def pipeline(self) -> FakePipeline:
+            return FakePipeline(self)
+
+        def hgetall(self, key: str) -> dict[bytes, bytes]:
+            return self._entries.get(key, {}).copy()
+
+        def eval(self, script: str, _keys: int, key: str, owner: str):
+            entry = self._entries.get(key)
+            if not entry or entry[b"owner_token"] != owner.encode():
+                return None if "HGETALL" in script else 0
+            if "HGETALL" in script:
+                data = [item for pair in entry.items() for item in pair]
+                if entry[b"consume_on_read"] == b"1":
+                    del self._entries[key]
+                return data
+            del self._entries[key]
+            return 1
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr("redis.Redis.from_url", lambda *_args, **_kwargs: fake_redis)
+    store = RedisSidecarStore("redis://sidecars")
+
+    single_use = store.put(
+        filename="meta.csv",
+        content_type="text/csv",
+        payload=b"id,title\n1,foo\n",
+        owner_token="alice",
+    )
+    assert store.get(single_use.sidecar_id, owner_token="eve") is None
+    assert store.consume(single_use.sidecar_id, owner_token="eve") is None
+    assert store.consume(single_use.sidecar_id, owner_token="alice") is not None
+    assert store.get(single_use.sidecar_id, owner_token="alice") is None
+
+    reusable = store.put(
+        filename="meta.csv",
+        content_type="text/csv",
+        payload=b"id,title\n2,bar\n",
+        owner_token="alice",
+        consume_on_read=False,
+    )
+    assert store.consume(reusable.sidecar_id, owner_token="alice") is not None
+    assert store.get(reusable.sidecar_id, owner_token="alice") is not None
+    assert not store.delete(reusable.sidecar_id, owner_token="eve")
+    assert store.delete(reusable.sidecar_id, owner_token="alice")
+
+
 # ----------------------------------------------------------------------
 # Worker-side materialisation
 # ----------------------------------------------------------------------

--- a/nemo_retriever/tests/test_service_sidecar.py
+++ b/nemo_retriever/tests/test_service_sidecar.py
@@ -98,6 +98,21 @@ def test_store_owner_token_scoping() -> None:
     assert store.get(entry.sidecar_id, owner_token=None) is None
 
 
+def test_memory_sidecar_delete_enforces_owner() -> None:
+    store = SidecarStore()
+    entry = store.put(
+        filename="meta.csv",
+        content_type="text/csv",
+        payload=b"id,title\n1,foo\n",
+        owner_token="alice",
+        consume_on_read=False,
+    )
+
+    assert not store.delete(entry.sidecar_id, owner_token="eve")
+    assert store.get(entry.sidecar_id, owner_token="alice") is not None
+    assert store.delete(entry.sidecar_id, owner_token="alice")
+
+
 def test_store_max_entries_guard() -> None:
     store = SidecarStore(max_entries=2)
     store.put(filename="a", content_type="text/csv", payload=b"a")

--- a/nemo_retriever/tests/test_service_work_queue.py
+++ b/nemo_retriever/tests/test_service_work_queue.py
@@ -400,6 +400,51 @@ async def test_execution_slots_make_at_most_one_claim_each():
     assert POOL_ACTIVE_SLOTS.labels(pool="batch")._value.get() == 0
 
 
+def test_gateway_temporary_sidecar_release_requeues_without_spending_attempt(tmp_path, monkeypatch):
+    config = ServiceConfig(
+        mode="gateway",
+        auth=AuthConfig(allow_unscoped_dev=True),
+        logging=LoggingConfig(file=str(tmp_path / "service.log")),
+        mcp=MCPConfig(enabled=False),
+        pipeline=PipelinePoolConfig(realtime_queue_size=1, batch_queue_size=1),
+        work_queue=_config(tmp_path / "spool", gateway_url="http://testserver"),
+    )
+    monkeypatch.setattr(WorkBroker, "_expire_locked", lambda self, pool: None)
+
+    with TestClient(create_app(config)) as client:
+        created = client.post("/v1/ingest/job", json={"expected_documents": 1})
+        job_id = created.json()["job_id"]
+        accepted = client.post(
+            f"/v1/ingest/job/{job_id}/whole",
+            files={"file": ("document.txt", b"sidecar retry", "text/plain")},
+            data={"metadata": "{}"},
+        )
+        document_id = accepted.json()["document_id"]
+        claim = client.post(
+            "/v1/internal/work/claim",
+            json={"pool": "batch", "worker_uid": "pod-a"},
+        ).json()
+        assert claim["delivery_attempt"] == 1
+
+        release = client.post(
+            f"/v1/internal/work/{document_id}/release",
+            json={
+                "lease_id": claim["lease_id"],
+                "lease_generation": claim["lease_generation"],
+                "reason": "sidecar_store_unavailable",
+            },
+        )
+        assert release.status_code == 200
+
+        retry = client.post(
+            "/v1/internal/work/claim",
+            json={"pool": "batch", "worker_uid": "pod-b"},
+        )
+        assert retry.status_code == 200
+        assert retry.json()["work_id"] == document_id
+        assert retry.json()["delivery_attempt"] == 1
+
+
 def test_gateway_upload_claim_payload_and_callback_lifecycle(tmp_path, monkeypatch):
     results_dir = tmp_path / "results"
     results_dir.mkdir()

--- a/nemo_retriever/tests/test_service_work_queue.py
+++ b/nemo_retriever/tests/test_service_work_queue.py
@@ -327,6 +327,18 @@ async def test_gateway_work_client_heartbeat_reports_network_failure(tmp_path, c
     assert "Heartbeat request failed for work work" in caplog.text
 
 
+def test_lease_request_accepts_temporary_sidecar_store_release() -> None:
+    from nemo_retriever.service.routers.work import LeaseRequest
+
+    request = LeaseRequest(
+        lease_id="lease",
+        lease_generation=1,
+        reason="sidecar_store_unavailable",
+    )
+
+    assert request.reason == "sidecar_store_unavailable"
+
+
 @pytest.mark.anyio
 async def test_gateway_work_client_release_reports_network_failure(tmp_path, caplog):
     client = GatewayWorkClient(_config(tmp_path), pool=PoolType.BATCH, headers={})
@@ -335,6 +347,30 @@ async def test_gateway_work_client_release_reports_network_failure(tmp_path, cap
 
     with caplog.at_level(logging.WARNING, logger="nemo_retriever.service.services.work_queue"):
         await client.release(claim, reason="payload_fetch")
+
+    assert "Release request failed for work work" in caplog.text
+
+
+class _RejectedReleaseResponse:
+    def raise_for_status(self) -> None:
+        request = httpx.Request("POST", "http://gateway/v1/internal/work/work/release")
+        response = httpx.Response(422, request=request)
+        raise httpx.HTTPStatusError("unprocessable release", request=request, response=response)
+
+
+class _RejectedReleaseClient:
+    async def post(self, *_args, **_kwargs):
+        return _RejectedReleaseResponse()
+
+
+@pytest.mark.anyio
+async def test_gateway_work_client_release_reports_rejected_response(tmp_path, caplog):
+    client = GatewayWorkClient(_config(tmp_path), pool=PoolType.BATCH, headers={})
+    client._client = _RejectedReleaseClient()
+    claim = {"work_id": "work", "lease_id": "lease", "lease_generation": 1}
+
+    with caplog.at_level(logging.WARNING, logger="nemo_retriever.service.services.work_queue"):
+        await client.release(claim, reason="sidecar_store_unavailable")
 
     assert "Release request failed for work work" in caplog.text
 

--- a/nemo_retriever/tests/test_service_work_queue.py
+++ b/nemo_retriever/tests/test_service_work_queue.py
@@ -88,6 +88,34 @@ async def test_fifo_spool_integrity_and_ack_cleanup(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_transient_sidecar_release_preserves_delivery_budget(tmp_path):
+    broker = WorkBroker(
+        _config(tmp_path, max_delivery_attempts=1),
+        PipelinePoolConfig(batch_queue_size=1),
+    )
+    await broker.start()
+    try:
+        record = await _enqueue(broker, "redis-retry")
+        claim = await broker.claim(PoolType.BATCH, worker_uid="pod-a", worker_ip="10.0.0.1")
+        assert claim is not None and claim.lease is not None
+
+        await broker.release(
+            record.work_id,
+            claim.lease.lease_id,
+            claim.lease.generation,
+            reason="sidecar_store_unavailable",
+        )
+
+        assert broker.has_record(record.work_id)
+        assert record.delivery_attempt == 0
+        retry = await broker.claim(PoolType.BATCH, worker_uid="pod-b", worker_ip="10.0.0.2")
+        assert retry is record
+        assert record.delivery_attempt == 1
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.anyio
 async def test_acknowledge_revalidates_lease_after_acquiring_condition(tmp_path):
     broker = WorkBroker(_config(tmp_path), PipelinePoolConfig(batch_queue_size=1))
     await broker.start()

--- a/nemo_retriever/tests/test_service_work_queue.py
+++ b/nemo_retriever/tests/test_service_work_queue.py
@@ -352,6 +352,8 @@ async def test_gateway_work_client_release_reports_network_failure(tmp_path, cap
 
 
 class _RejectedReleaseResponse:
+    status_code = 422
+
     def raise_for_status(self) -> None:
         request = httpx.Request("POST", "http://gateway/v1/internal/work/work/release")
         response = httpx.Response(422, request=request)
@@ -363,6 +365,27 @@ class _RejectedReleaseClient:
         return _RejectedReleaseResponse()
 
 
+class _StaleReleaseResponse:
+    status_code = 409
+
+
+class _StaleReleaseClient:
+    async def post(self, *_args, **_kwargs):
+        return _StaleReleaseResponse()
+
+
+@pytest.mark.anyio
+async def test_gateway_work_client_does_not_retry_stale_release(tmp_path, caplog):
+    client = GatewayWorkClient(_config(tmp_path), pool=PoolType.BATCH, headers={})
+    client._client = _StaleReleaseClient()
+    claim = {"work_id": "work", "lease_id": "lease", "lease_generation": 1}
+
+    with caplog.at_level(logging.WARNING, logger="nemo_retriever.service.services.work_queue"):
+        assert await client.release(claim, reason="sidecar_store_unavailable")
+
+    assert "no longer retryable (HTTP 409)" in caplog.text
+
+
 @pytest.mark.anyio
 async def test_gateway_work_client_release_reports_rejected_response(tmp_path, caplog):
     client = GatewayWorkClient(_config(tmp_path), pool=PoolType.BATCH, headers={})
@@ -372,7 +395,7 @@ async def test_gateway_work_client_release_reports_rejected_response(tmp_path, c
     with caplog.at_level(logging.WARNING, logger="nemo_retriever.service.services.work_queue"):
         await client.release(claim, reason="sidecar_store_unavailable")
 
-    assert "Release request failed for work work" in caplog.text
+    assert "no longer retryable (HTTP 422)" in caplog.text
 
 
 @pytest.mark.anyio

--- a/nemo_retriever/tests/test_service_worker_callback.py
+++ b/nemo_retriever/tests/test_service_worker_callback.py
@@ -12,6 +12,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -745,6 +746,52 @@ def test_service_auth_headers_preserve_worker_pull_credentials() -> None:
     assert auth_headers(AuthConfig()) == {}
     assert auth_headers(AuthConfig(api_token="secret")) == {"Authorization": "Bearer secret"}
     assert auth_headers(AuthConfig(api_token="secret", header_name="X-Service-Token")) == {"X-Service-Token": "secret"}
+
+
+def test_worker_releases_claim_when_sidecar_store_is_temporarily_unavailable() -> None:
+    from nemo_retriever.service.services.pipeline_pool import WorkItem, _Pool
+    from nemo_retriever.service.services.sidecar_store import SidecarStoreUnavailable
+
+    released: list[tuple[dict[str, object], str]] = []
+    release_complete = asyncio.Event()
+
+    class PullClient:
+        config = SimpleNamespace(heartbeat_interval_s=60.0)
+
+        async def claim(self) -> WorkItem | None:
+            return WorkItem(
+                id="sidecar-doc",
+                callback_url="http://gateway/v1/internal/job-callback",
+                lease_id="lease-id",
+                lease_generation=1,
+            )
+
+        async def heartbeat(self, _item: WorkItem) -> bool:
+            return True
+
+        async def release(self, claim: dict[str, object], *, reason: str) -> None:
+            released.append((claim, reason))
+            release_complete.set()
+
+    def unavailable(_item: WorkItem) -> None:
+        raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable")
+
+    async def run() -> None:
+        pool = _Pool("sidecar-retry", num_workers=1, max_queue_size=1, work_fn=unavailable, pull_client=PullClient())
+        pool._running = True
+        task = asyncio.create_task(pool._worker_loop(0))
+        await asyncio.wait_for(release_complete.wait(), timeout=1.0)
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    asyncio.run(run())
+
+    assert released == [
+        (
+            {"work_id": "sidecar-doc", "lease_id": "lease-id", "lease_generation": 1},
+            "sidecar_store_unavailable",
+        )
+    ]
 
 
 def test_fire_gateway_callback_sends_internal_auth_headers() -> None:

--- a/nemo_retriever/tests/test_service_worker_callback.py
+++ b/nemo_retriever/tests/test_service_worker_callback.py
@@ -748,9 +748,14 @@ def test_service_auth_headers_preserve_worker_pull_credentials() -> None:
     assert auth_headers(AuthConfig(api_token="secret", header_name="X-Service-Token")) == {"X-Service-Token": "secret"}
 
 
-def test_worker_releases_claim_when_sidecar_store_is_temporarily_unavailable() -> None:
+def test_worker_releases_claim_when_sidecar_store_is_temporarily_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_retriever.service.services import pipeline_pool
     from nemo_retriever.service.services.pipeline_pool import WorkItem, _Pool
     from nemo_retriever.service.services.sidecar_store import SidecarStoreUnavailable
+
+    monkeypatch.setattr(pipeline_pool, "_SIDECAR_STORE_RETRY_DELAY_S", 0.0)
 
     released: list[tuple[dict[str, object], str]] = []
     release_complete = asyncio.Event()

--- a/nemo_retriever/tests/test_service_worker_callback.py
+++ b/nemo_retriever/tests/test_service_worker_callback.py
@@ -877,6 +877,40 @@ def test_sidecar_release_retries_do_not_block_the_pool_worker(
     asyncio.run(run())
 
 
+def test_deferred_sidecar_release_keeps_lease_heartbeat_alive() -> None:
+    from nemo_retriever.service.services.pipeline_pool import WorkItem, _Pool
+
+    heartbeat_sent = asyncio.Event()
+    allow_release = asyncio.Event()
+
+    class PullClient:
+        config = SimpleNamespace(heartbeat_interval_s=0.0)
+
+        async def heartbeat(self, _item: WorkItem) -> bool:
+            heartbeat_sent.set()
+            return True
+
+        async def release(self, _claim: dict[str, object], *, reason: str) -> bool:
+            assert reason == "sidecar_store_unavailable"
+            await allow_release.wait()
+            return True
+
+    async def run() -> None:
+        pool = _Pool("sidecar-release-heartbeat", num_workers=1, max_queue_size=1, pull_client=PullClient())
+        pool._running = True
+        item = WorkItem(id="sidecar-doc", lease_id="lease-id", lease_generation=1)
+        pool._schedule_sidecar_release_retry(item=item, worker_id=0)
+        release_task = pool._sidecar_release_tasks[item.id]
+        await asyncio.wait_for(heartbeat_sent.wait(), timeout=1.0)
+        allow_release.set()
+        await asyncio.wait_for(release_task, timeout=1.0)
+        await asyncio.sleep(0)
+        assert pool._sidecar_release_tasks == {}
+        pool._running = False
+
+    asyncio.run(run())
+
+
 def test_fire_gateway_callback_sends_internal_auth_headers() -> None:
     client_kwargs: dict[str, Any] = {}
 

--- a/nemo_retriever/tests/test_service_worker_callback.py
+++ b/nemo_retriever/tests/test_service_worker_callback.py
@@ -880,14 +880,20 @@ def test_sidecar_release_retries_do_not_block_the_pool_worker(
 def test_deferred_sidecar_release_keeps_lease_heartbeat_alive() -> None:
     from nemo_retriever.service.services.pipeline_pool import WorkItem, _Pool
 
-    heartbeat_sent = asyncio.Event()
+    heartbeat_recovered = asyncio.Event()
     allow_release = asyncio.Event()
 
     class PullClient:
         config = SimpleNamespace(heartbeat_interval_s=0.0)
 
+        def __init__(self) -> None:
+            self.heartbeat_calls = 0
+
         async def heartbeat(self, _item: WorkItem) -> bool:
-            heartbeat_sent.set()
+            self.heartbeat_calls += 1
+            if self.heartbeat_calls == 1:
+                return False
+            heartbeat_recovered.set()
             return True
 
         async def release(self, _claim: dict[str, object], *, reason: str) -> bool:
@@ -896,12 +902,14 @@ def test_deferred_sidecar_release_keeps_lease_heartbeat_alive() -> None:
             return True
 
     async def run() -> None:
-        pool = _Pool("sidecar-release-heartbeat", num_workers=1, max_queue_size=1, pull_client=PullClient())
+        pull_client = PullClient()
+        pool = _Pool("sidecar-release-heartbeat", num_workers=1, max_queue_size=1, pull_client=pull_client)
         pool._running = True
         item = WorkItem(id="sidecar-doc", lease_id="lease-id", lease_generation=1)
         pool._schedule_sidecar_release_retry(item=item, worker_id=0)
         release_task = pool._sidecar_release_tasks[item.id]
-        await asyncio.wait_for(heartbeat_sent.wait(), timeout=1.0)
+        await asyncio.wait_for(heartbeat_recovered.wait(), timeout=1.0)
+        assert pull_client.heartbeat_calls >= 2
         allow_release.set()
         await asyncio.wait_for(release_task, timeout=1.0)
         await asyncio.sleep(0)

--- a/nemo_retriever/tests/test_service_worker_callback.py
+++ b/nemo_retriever/tests/test_service_worker_callback.py
@@ -806,6 +806,77 @@ def test_worker_releases_claim_when_sidecar_store_is_temporarily_unavailable(
     ]
 
 
+def test_sidecar_release_retries_do_not_block_the_pool_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_retriever.service.services import pipeline_pool
+    from nemo_retriever.service.services.pipeline_pool import WorkItem, _Pool
+    from nemo_retriever.service.services.sidecar_store import SidecarStoreUnavailable
+
+    monkeypatch.setattr(pipeline_pool, "_SIDECAR_STORE_RETRY_DELAY_S", 0.0)
+
+    release_started = asyncio.Event()
+    second_processed = asyncio.Event()
+
+    class PullClient:
+        config = SimpleNamespace(heartbeat_interval_s=60.0)
+
+        def __init__(self) -> None:
+            self._items = iter(
+                [
+                    WorkItem(
+                        id="sidecar-doc",
+                        callback_url="http://gateway/v1/internal/job-callback",
+                        lease_id="lease-id",
+                        lease_generation=1,
+                    ),
+                    WorkItem(
+                        id="next-doc",
+                        callback_url="http://gateway/v1/internal/job-callback",
+                        lease_id="next-lease-id",
+                        lease_generation=1,
+                    ),
+                ]
+            )
+
+        async def claim(self) -> WorkItem | None:
+            try:
+                return next(self._items)
+            except StopIteration:
+                await asyncio.Event().wait()
+                return None
+
+        async def heartbeat(self, _item: WorkItem) -> bool:
+            return True
+
+        async def release(self, _claim: dict[str, object], *, reason: str) -> bool:
+            assert reason == "sidecar_store_unavailable"
+            release_started.set()
+            return False
+
+    def work(item: WorkItem) -> None:
+        if item.id == "sidecar-doc":
+            raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable")
+        second_processed.set()
+
+    async def run() -> None:
+        pool = _Pool(
+            "sidecar-background-release", num_workers=1, max_queue_size=1, work_fn=work, pull_client=PullClient()
+        )
+        pool._running = True
+        task = asyncio.create_task(pool._worker_loop(0))
+        await asyncio.wait_for(second_processed.wait(), timeout=1.0)
+        await asyncio.wait_for(release_started.wait(), timeout=1.0)
+        assert "sidecar-doc" in pool._sidecar_release_tasks
+        pool._running = False
+        task.cancel()
+        for release_task in pool._sidecar_release_tasks.values():
+            release_task.cancel()
+        await asyncio.gather(task, *pool._sidecar_release_tasks.values(), return_exceptions=True)
+
+    asyncio.run(run())
+
+
 def test_fire_gateway_callback_sends_internal_auth_headers() -> None:
     client_kwargs: dict[str, Any] = {}
 

--- a/nemo_retriever/tests/test_service_worker_callback.py
+++ b/nemo_retriever/tests/test_service_worker_callback.py
@@ -774,9 +774,12 @@ def test_worker_releases_claim_when_sidecar_store_is_temporarily_unavailable(
         async def heartbeat(self, _item: WorkItem) -> bool:
             return True
 
-        async def release(self, claim: dict[str, object], *, reason: str) -> None:
+        async def release(self, claim: dict[str, object], *, reason: str) -> bool:
             released.append((claim, reason))
-            release_complete.set()
+            if len(released) == 2:
+                release_complete.set()
+                return True
+            return False
 
     def unavailable(_item: WorkItem) -> None:
         raise SidecarStoreUnavailable("Redis sidecar store is temporarily unavailable")
@@ -795,7 +798,11 @@ def test_worker_releases_claim_when_sidecar_store_is_temporarily_unavailable(
         (
             {"work_id": "sidecar-doc", "lease_id": "lease-id", "lease_generation": 1},
             "sidecar_store_unavailable",
-        )
+        ),
+        (
+            {"work_id": "sidecar-doc", "lease_id": "lease-id", "lease_generation": 1},
+            "sidecar_store_unavailable",
+        ),
     ]
 
 

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -552,7 +552,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "sys_platform == 'win32'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -704,7 +704,7 @@ resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/49/4592bc94ca05a07c7947ea114fd12734c8497f2daffee9faa79a03e39fb5/cuda_tile-1.3.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:375316b64c51ee7cfadb2f170a30c1547bc41eb39f1e233a6556713857d2e81f", size = 245744, upload-time = "2026-04-20T15:52:09.621Z" },
@@ -713,9 +713,9 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-tileiras", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cuda-tileiras", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -728,7 +728,7 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform != 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/6e/7a60f317c503580ab7946dbb7fd080438fe953d0ddfdc81904beb9a1fab7/cuda_tile-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:16d97a60ed1d33388abbca85ea08cdae6325cc700476b3135f190d0fb50329f4", size = 304817, upload-time = "2026-07-08T01:49:38.853Z" },
@@ -736,7 +736,7 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "cuda-toolkit", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvvm", "tileiras"], marker = "sys_platform != 'linux'" },
+    { name = "cuda-toolkit", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvvm", "tileiras"] },
 ]
 
 [[package]]
@@ -753,37 +753,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" } },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -2524,6 +2524,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "ray" },
+    { name = "redis" },
     { name = "requests" },
     { name = "rich" },
     { name = "s3fs" },
@@ -2712,6 +2713,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ray", extras = ["data", "serve"], specifier = ">=2.56.1" },
+    { name = "redis", specifier = ">=5,<6" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "s3fs", specifier = ">=2025.5.1" },
@@ -2753,12 +2755,12 @@ name = "nemotron-ocr"
 version = "2.0.1.dev20260720042916"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "shapely", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "shapely" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
+    { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/9a/0395e4918a79c4322fcc872b639c59cbb96efdbc807ef60b394de0457ccb/nemotron_ocr-2.0.1.dev20260720042916.tar.gz", hash = "sha256:620c1edc1bf6bcadafea23076682b690e36fec903f1b941d77f991309fb22c1b", size = 155950, upload-time = "2026-07-20T04:39:17.449Z" }
 wheels = [
@@ -2956,9 +2958,9 @@ resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a3/403638f80960e677ae8ecc78059d8c85dc2519b85ed8c0229840dc6f3b54/nvidia_cuda_nvcc-13.2.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:909140a1f942b943982b2eff120e618c94e29d75d9e33f5cd074f0e64eb411e8", size = 38716270, upload-time = "2026-07-16T09:37:12.754Z" },
@@ -2975,10 +2977,10 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "sys_platform != 'linux'" },
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
     { name = "nvidia-cuda-runtime", version = "13.3.29", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/89/97eb797bb8bdee1d4e74069d072c24b79ae90c012fa3b539f2a7ccecf6cf/nvidia_cuda_nvcc-13.3.73-py3-none-win_amd64.whl", hash = "sha256:3d9da631bcac3dee49d1357b84cd05abe56aa3ccf76b05a7df8a80ef78addcb5", size = 32536529, upload-time = "2026-06-29T17:11:25.455Z" },
@@ -3029,9 +3031,9 @@ resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/a2/ade26f7fb55a5bb87815f7650660463d6601db411d5a9228f414b3ed5dfe/nvidia_cuda_tileiras-13.2.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f79c6a9bf8583dae105cd67b985555f39f4576416664a86383ba892e8c346c9", size = 36418795, upload-time = "2026-07-16T09:43:35.006Z" },
@@ -3046,9 +3048,9 @@ resolution-markers = [
     "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-nvcc", version = "13.3.73", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvcc", version = "13.3.73", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/b1/9dcc1aa140205c8f9ecdb671b488e1189462d870e5ed0eac02522722cb9a/nvidia_cuda_tileiras-13.3.36-py3-none-win_amd64.whl", hash = "sha256:0dd286086c6d273826218d02c076ddea8e285b50ee223bd1429756b706b7bbc7", size = 29715011, upload-time = "2026-05-26T17:05:29.974Z" },
@@ -3059,7 +3061,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3081,7 +3083,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3111,9 +3113,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3125,7 +3127,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3326,12 +3328,12 @@ resolution-markers = [
     "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "sys_platform == 'win32'" },
-    { name = "flatbuffers", marker = "sys_platform == 'win32'" },
-    { name = "numpy", marker = "sys_platform == 'win32'" },
-    { name = "packaging", marker = "sys_platform == 'win32'" },
-    { name = "protobuf", marker = "sys_platform == 'win32'" },
-    { name = "sympy", marker = "sys_platform == 'win32'" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/f1/aabfdf91d013320aa2fc46cf43c88ca0182860ff15df872b4552254a9680/onnxruntime-1.20.1-cp312-cp312-win32.whl", hash = "sha256:bd386cc9ee5f686ee8a75ba74037750aca55183085bf1941da8efcfe12d5b120", size = 9814562, upload-time = "2024-11-21T00:49:15.453Z" },
@@ -3349,10 +3351,10 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "sys_platform != 'win32'" },
-    { name = "numpy", marker = "sys_platform != 'win32'" },
-    { name = "packaging", marker = "sys_platform != 'win32'" },
-    { name = "protobuf", marker = "sys_platform != 'win32'" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/b7/dd3a524ed93a820dff1af902d0412957ab12499953333e9daa01af5bc480/onnxruntime-1.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a14c2ce45312def86b77aea651f46565e45960cf5f0721bfdff449165086ab76", size = 18433506, upload-time = "2026-06-15T22:43:47.026Z" },
@@ -3440,7 +3442,7 @@ name = "opencv-python"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
 
@@ -4306,6 +4308,18 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4542,8 +4556,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform == 'linux'" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4610,7 +4624,7 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -4986,10 +5000,10 @@ name = "tokenspeed-mla"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl", marker = "sys_platform == 'linux'" },
-    { name = "tokenspeed-triton", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "tokenspeed-triton" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/20/4110d624d81d63f0bee2f19dba7ea0e1d8a31ea50147e6c1db82223c88a4/tokenspeed_mla-0.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:592590f36d85e624ecdc5e357ff35e29e761e6d879900dce8b67a6785c8ce75c", size = 743769, upload-time = "2026-05-13T03:30:54.486Z" },
@@ -5014,13 +5028,13 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "setuptools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
@@ -5036,20 +5050,20 @@ resolution-markers = [
     "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "cuda-bindings", marker = "sys_platform != 'win32'" },
+    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform != 'win32'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:252f237d417fac3ba59b1635815c1f035a8241f2af038f2c076ed430932d89f1", upload-time = "2026-04-27T20:01:46Z" },
@@ -5104,9 +5118,9 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pillow", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
@@ -5122,9 +5136,9 @@ resolution-markers = [
     "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pillow", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e2b39db78be674ee4ce7e921f54b70e5c281594c9267d981c061684ed38df936", upload-time = "2026-03-23T15:36:26Z" },
@@ -5536,13 +5550,13 @@ resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
+    { name = "transformers" },
+    { name = "triton" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/f4/e71693d8cec60b7e36dab660784ecc5a6aa51e478a83b556011645c58c87/xgrammar-0.2.3.tar.gz", hash = "sha256:f76423630ae3ac4e090cb38ce1e30e7bcc69b3dee4d22d94353944386a4c6f18", size = 2447704, upload-time = "2026-06-27T04:45:24.759Z" }
 wheels = [
@@ -5560,13 +5574,13 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "numpy", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "pydantic", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "numpy" },
+    { name = "pydantic" },
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "transformers", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/17/de9c2d0f2f37d78d4898ded27525bdb9d86817529c1c0dbd5b5ca9cc853f/xgrammar-0.2.4-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:2502403e179a73daccc7ea480d63f3a1a636d4b59738bb4dff0469135cc6e523", size = 23664403, upload-time = "2026-07-18T14:52:55.316Z" },


### PR DESCRIPTION
## Description

Fixes nvbugs/6622890. Adds a Redis-backed sidecar store for split topology so the gateway writes each payload once and all eligible workers can resolve the returned ID. The Redis URL is read from an existing Kubernetes Secret; split sidecar upload/delete returns HTTP 503 when the memory backend is configured.

Depends on #2518 for the gateway-derived caller fingerprint used to preserve bearer isolation.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.