### PR TITLE
Fix element image URIs in default text mode

### DIFF
--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/store_operator.py
@@ -18,6 +18,7 @@ import fsspec
 import numpy as np
 import pandas as pd
 
+from nemo_retriever.common.modality.ocr.shared import _crop_b64_image_by_norm_bbox
 from nemo_retriever.operators.abstract_operator import AbstractOperator
 from nemo_retriever.operators.cpu_operator import CPUOperator
 
@@ -157,6 +158,21 @@ def _store_nested_image_payloads(
     return out
 
 
+def _structured_page_crop_b64(row: pd.Series, page_image_b64: Any) -> str | None:
+    content_type = row.get("_content_type")
+    if not isinstance(content_type, str) or not content_type.strip() or content_type == "text":
+        return None
+
+    bbox = row.get("_bbox_xyxy_norm")
+    if hasattr(bbox, "tolist"):
+        bbox = bbox.tolist()
+    if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+        return None
+
+    cropped_b64, _ = _crop_b64_image_by_norm_bbox(page_image_b64, bbox_xyxy_norm=bbox)
+    return cropped_b64
+
+
 def _row_image_b64_with_source(row: pd.Series) -> tuple[Any, str | None]:
     value = row.get("_image_b64")
     if isinstance(value, str) and value.strip():
@@ -168,7 +184,11 @@ def _row_image_b64_with_source(row: pd.Series) -> tuple[Any, str | None]:
 
     page_image = row.get("page_image")
     if isinstance(page_image, dict):
-        return page_image.get("image_b64"), "page_image"
+        page_image_b64 = page_image.get("image_b64")
+        cropped_b64 = _structured_page_crop_b64(row, page_image_b64)
+        if cropped_b64:
+            return cropped_b64, "page_image_crop"
+        return page_image_b64, "page_image"
 
     return None, None
 

--- a/nemo_retriever/tests/test_store_pipeline_stages.py
+++ b/nemo_retriever/tests/test_store_pipeline_stages.py
@@ -15,9 +15,12 @@ from urllib.parse import urlparse
 import numpy as np
 import pandas as pd
 import pytest
+from PIL import Image
 
 from nemo_retriever.graph import InprocessExecutor, StoreOperator, UDFOperator
+from nemo_retriever.common.modality.content_transforms import explode_content_to_rows
 from nemo_retriever.common.params import StoreParams
+from nemo_retriever.common.vdb.records import to_client_vdb_records
 
 
 def _make_tiny_png_b64(width: int = 4, height: int = 4, color=(255, 0, 0)) -> str:
@@ -176,6 +179,72 @@ class TestStoreOperatorInGraph:
         assert result.iloc[0]["_image_b64"] is None
         assert result.iloc[0]["page_image"]["image_b64"] is None
         assert result.iloc[0]["page_image"]["stored_image_uri"] == "file:///old/page.png"
+
+    def test_store_operator_associates_text_mode_structured_row_with_page_crop(self, tmp_path: Path):
+        page_b64 = _make_tiny_png_b64(width=100, height=80)
+        source = pd.DataFrame(
+            [
+                {
+                    "path": "/docs/test.pdf",
+                    "page_number": 1,
+                    "text": "Page text",
+                    "page_image": {"image_b64": page_b64},
+                    "table": [
+                        {
+                            "text": "Table text",
+                            "bbox_xyxy_norm": [0.25, 0.25, 0.75, 0.75],
+                        }
+                    ],
+                    "metadata": {
+                        "content_metadata": {"uploaded_image_uri": ""},
+                        "table_metadata": {"uploaded_image_uri": ""},
+                    },
+                }
+            ]
+        )
+        exploded = explode_content_to_rows(source, modality="text")
+        assert "_image_b64" not in exploded.columns
+
+        result = StoreOperator(params=StoreParams(storage_uri=str(tmp_path))).process(exploded)
+
+        page_row = result.loc[result["_content_type"] == "text"].iloc[0]
+        table_row = result.loc[result["_content_type"] == "table"].iloc[0]
+        page_uri = page_row["_stored_image_uri"]
+        table_uri = table_row["_stored_image_uri"]
+
+        assert table_uri != page_uri
+        assert Image.open(Path(urlparse(page_uri).path)).size == (100, 80)
+        assert Image.open(Path(urlparse(table_uri).path)).size == (50, 40)
+        assert table_row["page_image"]["stored_image_uri"] == page_uri
+        assert table_row["metadata"]["content_metadata"]["uploaded_image_uri"] == table_uri
+        assert table_row["metadata"]["table_metadata"]["uploaded_image_uri"] == table_uri
+
+        result["metadata"] = result["metadata"].apply(lambda metadata: {**metadata, "embedding": [0.1, 0.2]})
+        records = to_client_vdb_records(result)[0]
+        table_record = next(
+            record for record in records if record["metadata"]["content_metadata"].get("type") == "table"
+        )
+        content_metadata = table_record["metadata"]["content_metadata"]
+        assert content_metadata["stored_image_uri"] == table_uri
+        assert content_metadata["uploaded_image_uri"] == table_uri
+        assert content_metadata["bbox_xyxy_norm"] == [0.25, 0.25, 0.75, 0.75]
+
+    def test_store_operator_crops_structured_row_with_numpy_bbox(self, tmp_path: Path):
+        page_b64 = _make_tiny_png_b64(width=100, height=80)
+        df = pd.DataFrame(
+            [
+                {
+                    "_content_type": "table",
+                    "_bbox_xyxy_norm": np.array([0.25, 0.25, 0.75, 0.75]),
+                    "page_image": {"image_b64": page_b64},
+                }
+            ]
+        )
+
+        result = StoreOperator(params=StoreParams(storage_uri=str(tmp_path))).process(df)
+
+        stored_uri = result.iloc[0]["_stored_image_uri"]
+        assert Image.open(Path(urlparse(stored_uri).path)).size == (50, 40)
 
     def test_store_operator_skips_rows_without_image_b64(self, tmp_path: Path):
         df = _make_embedded_df(None)


### PR DESCRIPTION
## Summary

- crop structured element rows from the page image when default text embedding does not produce a row-level image payload
- preserve the full-page URI on `page_image` while publishing the crop URI through the row and structured metadata
- cover default text-mode element explosion, crop dimensions, NumPy/Arrow-like bounding boxes, and canonical VDB record conversion

## Problem

With `--embed-granularity element` and the default `--embed-modality text`, table and chart rows retained the parent page image as `stored_image_uri`. The corresponding bounding box was correct, but downstream consumers received a full-page asset instead of the structured region.

The text-mode explosion intentionally omits `_image_b64`. StoreOperator therefore fell back to `page_image` for the row-level write and URI. Image-bearing embedding modalities did not reproduce the issue because they supplied a cropped row payload before storage.

Tracked by [NVBug 6620978](https://nvbugspro.nvidia.com/bug/6620978).

## Fix

When a non-text row has a normalized four-coordinate bbox but no row-level image payload, StoreOperator crops the page image with the existing normalized-bbox helper and stores that crop as the row asset. Missing or invalid bboxes retain the existing page-image fallback.

## Validation

- `uv run pytest -q tests/test_store_pipeline_stages.py`: 24 passed
- full test suite: 3,257 passed, 146 skipped, 12 deselected
- pre-commit hooks: passed
- `git diff --check`: passed
- hosted root CLI E2E using `multimodal_test.pdf`, default text modality, element granularity, local storage, and real LanceDB:
  - 8 rows, including 5 boxed structured rows
  - all 5 boxed rows reference distinct existing element crops
  - zero boxed rows reference a full-page image
  - crop dimensions exactly match the known-good `text_image` control

On current main, both text and `text_image` control runs persist 13 assets: 3 page images, 5 embedded PDF images, and 5 bbox-aligned structured crops.