### PR TITLE
docs(extraction): align hosted Page Elements image limits with live API (NVBug 5456115)

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -23,7 +23,7 @@ On Windows PowerShell you can use `$env:NVIDIA_API_KEY = "nvapi-..."`.
 
 The SDK and CLI do not load a `.env` file automatically. For a full list of related variables and how to source a `.env` file into the shell, refer to [Environment configuration variables](environment-config.md).
 
-When you call hosted object-detection NIMs (Page Elements, Table Structure, Graphic Elements) with images larger than about 180,000 characters (roughly 180 KB) inline, you also use this key with the [NVCF Asset API](https://docs.api.nvidia.com/cloud-functions/reference/createasset) to upload inputs and reference them by `asset_id`. Refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits) for the workflow and example code.
+Hosted object-detection NIMs (Page Elements, Table Structure, Graphic Elements) cap inline base64 image payloads at about 180,000 characters (roughly 180 KB). This key authorizes those hosted inference calls. For size limits and what to do when an image exceeds the cap, refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits).
 
 !!! note
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -126,7 +126,7 @@ Extracted objects follow the schema and field descriptions in the [Metadata refe
 
 ## Extraction limitations and quality { #extraction-limitations-and-quality }
 
-Hosted Page Elements, Table Structure, and Graphic Elements NIM endpoints cap inline base64 image payloads at about **180,000 characters** (roughly 180 KB). The NeMo Retriever pipeline downscales large page renders before remote NIM calls. Direct API integrations must keep inline payloads under that cap. Hosted Page Elements does not accept NVCF Asset API references. For limits and `dpi` and `render_mode` tuning, refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits).
+Hosted Page Elements, Table Structure, and Graphic Elements NIM endpoints cap inline base64 image payloads at about **180,000 characters** (roughly 180 KB). The NeMo Retriever pipeline downscales large page renders before remote NIM calls. Direct API integrations must keep inline payloads under that cap. Hosted Page Elements does not accept NVCF Asset API references. For limits, plus `dpi` and `render_mode` tuning, refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits).
 
 Image payload limits are separate from the throughput metrics in the rest of this section.
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -126,7 +126,7 @@ Extracted objects follow the schema and field descriptions in the [Metadata refe
 
 ## Extraction limitations and quality { #extraction-limitations-and-quality }
 
-Hosted Page Elements, Table Structure, and Graphic Elements NIM endpoints cap inline base64 image payloads at about **180,000 characters** (roughly 180 KB). The NeMo Retriever pipeline downscales large page renders before remote NIM calls. Direct API integrations must use the NVCF Asset API for larger inputs. For limits, `dpi` and `render_mode` tuning, and a step-by-step asset upload example, refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits).
+Hosted Page Elements, Table Structure, and Graphic Elements NIM endpoints cap inline base64 image payloads at about **180,000 characters** (roughly 180 KB). The NeMo Retriever pipeline downscales large page renders before remote NIM calls. Direct API integrations must keep inline payloads under that cap. Hosted Page Elements does not accept NVCF Asset API references. For limits and `dpi` and `render_mode` tuning, refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits).
 
 Image payload limits are separate from the throughput metrics in the rest of this section.
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -270,7 +270,7 @@ To use hosted Build, omit `nemotron_parse_model` so the library selects `nvidia/
 
 ## Hosted Page Elements NIM image size limits { #hosted-page-elements-nim-image-size-limits }
 
-[NVIDIA-hosted Page Elements NIM](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) endpoints on `ai.api.nvidia.com` (and the matching build.nvidia.com model experience) accept only **inline** PNG or JPEG payloads. The same `/v1/infer` request shape applies to hosted **Table Structure** and **Graphic Elements** object-detection NIMs.
+[NVIDIA-hosted Page Elements NIM](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) endpoints on `ai.api.nvidia.com` accept only **inline** PNG or JPEG payloads. The matching build.nvidia.com model experience uses the same contract. The same `/v1/infer` request shape applies to hosted **Table Structure** and **Graphic Elements** object-detection NIMs.
 
 The [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html) documents image URLs as `data:image/<format>;base64,<data>`. Hosted Page Elements inference does not accept NVCF Asset API identifiers in that `url` field.
 
@@ -281,7 +281,7 @@ The following table summarizes inline payload limits by deployment:
 | Hosted (`build.nvidia.com`, `ai.api.nvidia.com`) | About **180,000 characters** on the base64 portion of the data URL (roughly 180 KB; build.nvidia.com validates `len(image_b64) < 180_000`) | Resize or re-encode the image so the inline payload fits. Self-host the NIM if you need larger images. Do not use the NVCF Asset API as a hosted fallback. |
 | Self-hosted NIM container | Higher; the NeMo Retriever client downscales HTTP payloads above **512,000 characters** before calling the NIM | Resize or re-encode the source image, or rely on the client downscaling |
 
-The Object Detection NIM API reference states only that “very large images may cause processing issues.” For hosted integrations, treat **180,000 characters** as the inline cap unless NVIDIA publishes a different limit for your endpoint.
+That API reference states only that "very large images may cause processing issues." For hosted integrations, treat **180,000 characters** as the inline cap unless NVIDIA publishes a different limit for your endpoint.
 
 !!! important
 
@@ -300,9 +300,9 @@ When you route extraction to hosted Page Elements NIM URLs (for example `page_el
 
 If you still receive **422** responses mentioning invalid image URLs on hosted endpoints, lower `dpi` in `ExtractParams` and keep `render_mode="fit_to_model"`. For very large standalone image inputs, preprocess the files before ingest. For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
-### Direct Page Elements NIM API calls (build.nvidia.com or custom clients)
+### Direct Page Elements NIM API calls
 
-When you call Page Elements NIM **directly**, send only inline base64. Direct calls include the build playground, curl, and custom integrations that do not go through the NeMo Retriever pipeline.
+When you call Page Elements NIM **directly**, send only inline base64. Direct calls include the build playground, curl, and custom integrations that do not go through the NeMo Retriever pipeline. The following example shows the required `input` payload:
 
 ```json
 {
@@ -315,7 +315,7 @@ When you call Page Elements NIM **directly**, send only inline base64. Direct ca
 }
 ```
 
-Use this form only when `len(base64_image) < 180_000`. If the encoded image is larger, resize or re-encode it to PNG or JPEG until the base64 string is under 180,000 characters. Alternatively, self-host Page Elements NIM.
+Use this form only when `len(base64_image) < 180_000`. If the encoded image is larger, resize or re-encode it to PNG or JPEG until the base64 string is under 180,000 characters. You can also self-host Page Elements NIM.
 
 Do not send `"url": "data:image/png;asset_id,<assetId>"`. Hosted Page Elements rejects that encoding with HTTP 422.
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -270,16 +270,22 @@ To use hosted Build, omit `nemotron_parse_model` so the library selects `nvidia/
 
 ## Hosted Page Elements NIM image size limits { #hosted-page-elements-nim-image-size-limits }
 
-[NVIDIA-hosted Page Elements NIM](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) endpoints on `ai.api.nvidia.com` (and the matching build.nvidia.com model experience) enforce a strict limit on **inline** image payloads. The same limit applies to hosted **Table Structure** and **Graphic Elements** object-detection NIMs because they share the same `/v1/infer` request shape.
+[NVIDIA-hosted Page Elements NIM](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) endpoints on `ai.api.nvidia.com` (and the matching build.nvidia.com model experience) accept only **inline** PNG or JPEG payloads. The same `/v1/infer` request shape applies to hosted **Table Structure** and **Graphic Elements** object-detection NIMs.
+
+The [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html) documents image URLs as `data:image/<format>;base64,<data>`. Hosted Page Elements inference does not accept NVCF Asset API identifiers in that `url` field.
 
 The following table summarizes inline payload limits by deployment:
 
-| Deployment | Inline base64 limit | Oversized images |
-|------------|---------------------|------------------|
-| Hosted (`build.nvidia.com`, `ai.api.nvidia.com`) | About **180,000 characters** on the base64 portion of the data URL (roughly 180 KB; build.nvidia.com validates `len(image_b64) < 180_000`) | Upload with the [NVCF Asset API](https://docs.api.nvidia.com/cloud-functions/reference/createasset), then reference `data:image/<format>;asset_id,<asset_id>` in the `url` field |
+| Deployment | Inline base64 limit | If the image exceeds the limit |
+|------------|---------------------|--------------------------------|
+| Hosted (`build.nvidia.com`, `ai.api.nvidia.com`) | About **180,000 characters** on the base64 portion of the data URL (roughly 180 KB; build.nvidia.com validates `len(image_b64) < 180_000`) | Resize or re-encode the image so the inline payload fits. Self-host the NIM if you need larger images. Do not use the NVCF Asset API as a hosted fallback. |
 | Self-hosted NIM container | Higher; the NeMo Retriever client downscales HTTP payloads above **512,000 characters** before calling the NIM | Resize or re-encode the source image, or rely on the client downscaling |
 
-The [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html) states only that “very large images may cause processing issues.” For hosted integrations, treat **180,000 characters** as the inline cap unless NVIDIA publishes a different limit for your endpoint.
+The Object Detection NIM API reference states only that “very large images may cause processing issues.” For hosted integrations, treat **180,000 characters** as the inline cap unless NVIDIA publishes a different limit for your endpoint.
+
+!!! important
+
+    The build.nvidia.com playground can tell you to use the NVCF Asset API when an image exceeds the inline cap. Creating and uploading an asset can succeed. Hosted Page Elements inference still rejects `data:image/<format>;asset_id,<asset-id>` with HTTP 422. That rejection occurs with or without the `NVCF-INPUT-ASSET-REFERENCES` header. There is no Asset API recovery path for this hosted endpoint.
 
 ### NeMo Retriever Library pipeline users
 
@@ -292,75 +298,30 @@ When you route extraction to hosted Page Elements NIM URLs (for example `page_el
 
     The library downscales payloads to **512,000** characters before HTTP calls to object-detection NIMs. Hosted endpoints still reject inline base64 above **180,000** characters. Treat the lower hosted cap as the effective limit when `page_elements_invoke_url` points at `ai.api.nvidia.com`.
 
-If you still receive **422** responses mentioning invalid image URLs on hosted endpoints, lower `dpi` in `ExtractParams`, keep `render_mode="fit_to_model"`, or preprocess very large standalone image inputs before ingest. For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+If you still receive **422** responses mentioning invalid image URLs on hosted endpoints, lower `dpi` in `ExtractParams` and keep `render_mode="fit_to_model"`. For very large standalone image inputs, preprocess the files before ingest. For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
 ### Direct Page Elements NIM API calls (build.nvidia.com or custom clients)
 
-When you call Page Elements NIM **directly** (build playground, curl, or a custom integration—not through the NeMo Retriever pipeline), use inline base64 only when `len(base64_image) < 180_000`. For larger PNG or JPEG inputs, upload once with the NVCF Asset API and pass an asset reference in the inference payload.
+When you call Page Elements NIM **directly**, send only inline base64. Direct calls include the build playground, curl, and custom integrations that do not go through the NeMo Retriever pipeline.
 
-1. **Create an asset** — `POST https://api.nvcf.nvidia.com/v2/nvcf/assets` with `Authorization: Bearer $NVIDIA_API_KEY`, plus JSON `contentType` (for example `image/png`) and `description`.
-2. **Upload the file** — `PUT` the image bytes to the `uploadUrl` from step 1. Set `Content-Type` to match `contentType`, and set `x-amz-meta-nvcf-asset-description` to the same description string.
-3. **Infer** — `POST` to your Page Elements invoke URL with `"url": "data:image/png;asset_id,<assetId>"` inside each `input[]` item (same `type: image_url` schema as inline base64).
-
-For the full asset workflow (including reuse across requests), refer to [NVCF assets](https://docs.nvidia.com/cloud-functions/user-guide/latest/cloud-function/assets.html) in the Cloud Functions user guide and the [Create Asset](https://docs.api.nvidia.com/cloud-functions/reference/createasset) API reference. Hosted calls require the same [`NVIDIA_API_KEY`](api-keys.md#nvidia-api-key) you use for other build.nvidia.com NIM endpoints.
-
-For the request schema, refer to the [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html).
-
-??? example "Create an NVCF asset, upload a PNG, and call Page Elements"
-
-    ```python
-    import os
-    import requests
-
-    API_KEY = os.environ["NVIDIA_API_KEY"]
-    PAGE_ELEMENTS_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3"
-    IMAGE_PATH = "large_page.png"
-
-    create = requests.post(
-        "https://api.nvcf.nvidia.com/v2/nvcf/assets",
-        headers={
-            "Authorization": f"Bearer {API_KEY}",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        },
-        json={"contentType": "image/png", "description": "page-elements-large-input"},
-        timeout=60,
-    )
-    create.raise_for_status()
-    asset = create.json()
-
-    with open(IMAGE_PATH, "rb") as image_file:
-        upload = requests.put(
-            asset["uploadUrl"],
-            headers={
-                "Content-Type": "image/png",
-                "x-amz-meta-nvcf-asset-description": "page-elements-large-input",
-            },
-            data=image_file,
-            timeout=120,
-        )
-    upload.raise_for_status()
-
-    payload = {
-        "input": [{
-            "type": "image_url",
-            "url": f"data:image/png;asset_id,{asset['assetId']}",
-        }]
+```json
+{
+  "input": [
+    {
+      "type": "image_url",
+      "url": "data:image/png;base64,<BASE64_ENCODED_IMAGE>"
     }
-    response = requests.post(
-        PAGE_ELEMENTS_URL,
-        headers={
-            "Authorization": f"Bearer {API_KEY}",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        },
-        json=payload,
-        timeout=120,
-    )
-    response.raise_for_status()
-    ```
+  ]
+}
+```
 
-Supported inline formats remain **PNG** and **JPEG**, encoded as `data:image/<format>;base64,<data>` or `data:image/<format>;asset_id,<uuid>`. OpenAPI specs for Page Elements v2 and v3 are linked from the [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html#openapi-reference-for-page-elements).
+Use this form only when `len(base64_image) < 180_000`. If the encoded image is larger, resize or re-encode it to PNG or JPEG until the base64 string is under 180,000 characters. Alternatively, self-host Page Elements NIM.
+
+Do not send `"url": "data:image/png;asset_id,<assetId>"`. Hosted Page Elements rejects that encoding with HTTP 422.
+
+Hosted calls require the same [`NVIDIA_API_KEY`](api-keys.md#nvidia-api-key) you use for other build.nvidia.com NIM endpoints. For the request schema, refer to the [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html).
+
+Supported formats remain **PNG** and **JPEG**, encoded as `data:image/<format>;base64,<data>`. OpenAPI specs for Page Elements v2 and v3 are linked from the [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html#openapi-reference-for-page-elements).
 
 ## Too many open files error { #too-many-open-files-error }
 


### PR DESCRIPTION
## Summary

- QA on 26.08-RC4 failed the previous docs fix because hosted Page Elements rejects `data:image/<format>;asset_id,<id>` with HTTP 422 (with or without `NVCF-INPUT-ASSET-REFERENCES`). Inline base64 still succeeds.
- This update removes the NVCF Asset API recovery path and example from extraction docs. Hosted guidance is now: keep `len(image_b64) < 180_000`, resize or re-encode, or self-host. The build.nvidia.com Asset API prompt is documented as not a working fallback for this endpoint.
- Cross-links in `api-keys.md` and `multimodal-extraction.md` no longer tell readers to upload assets for oversized images.

Fixes NVBug 5456115 (docs alignment after QA return-to-dev). Does not change library or Helm behavior. The NRL client still downscales object-detection payloads to 512,000 characters, which remains above the hosted 180,000-character cap.

## Test plan

- [ ] Confirm `troubleshoot.md` no longer documents `asset_id` as a working hosted recovery path.
- [ ] Confirm the 180,000-character hosted inline limit and resize/self-host guidance remain.
- [ ] Confirm `api-keys.md` and `multimodal-extraction.md` no longer instruct readers to use the NVCF Asset API for this endpoint.
- [ ] QA: re-verify against hosted Page Elements that docs no longer prescribe the HTTP 422 `asset_id` request format.

## PR scope check

- **Base:** `main`
- **Commits:** 1 — `docs(extraction): align hosted Page Elements image limits with live API (NVBug 5456115)`
- **Files changed:** `docs/docs/extraction/troubleshoot.md`, `docs/docs/extraction/api-keys.md`, `docs/docs/extraction/multimodal-extraction.md`
- **Red flags:** none