### PR TITLE
fix: return row-safe pandas frames from batch ingest

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import math
-from typing import Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 import pandas as pd
+
+if TYPE_CHECKING:
+    import ray.data
 
 from nemo_retriever.operators.gpu_operator import GPUOperator
 from nemo_retriever.graph.pipeline_graph import Graph, Node
@@ -104,6 +107,34 @@ def arrow_table_to_pandas(table: Any) -> pd.DataFrame:
     table = _compact_vulnerable_arrow_columns(table)
     frame = BlockAccessor.for_block(table).to_pandas()
     return _normalize_pickled_object_columns(table, frame)
+
+
+def ray_dataset_to_pandas(dataset: ray.data.Dataset) -> pd.DataFrame:
+    """Materialize a Ray Dataset without returning malformed Arrow arrays.
+
+    Ray 2.56+ enables Arrow-backed pandas conversion by default. Calling
+    ``Dataset.to_pandas()`` directly can therefore expose sliced nested Arrow
+    columns whose child offsets are invalid for pandas row access. Convert
+    each Arrow block through :func:`arrow_table_to_pandas` before concatenating
+    so the public SDK result is safe to consume with standard pandas APIs.
+
+    Parameters
+    ----------
+    dataset
+        Ray dataset to materialize as Arrow batches.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Row-safe DataFrame containing all rows from ``dataset``.
+    """
+    frames = [arrow_table_to_pandas(batch) for batch in dataset.iter_batches(batch_format="pyarrow")]
+    if frames:
+        return pd.concat(frames, ignore_index=True)
+
+    schema = dataset.schema()
+    names = getattr(schema, "names", None)
+    return pd.DataFrame(columns=list(names) if names is not None else None)
 
 
 def call_pandas_function_on_arrow(
@@ -509,7 +540,7 @@ class RayDataExecutor(AbstractExecutor):
     def ingest(self, data: Any, **kwargs: Any) -> Any:
         """Build, execute, and materialize a Ray Data pipeline from the graph."""
 
-        return self.build_dataset(data, **kwargs).to_pandas()
+        return ray_dataset_to_pandas(self.build_dataset(data, **kwargs))
 
     def build_dataset(self, data: Any, **kwargs: Any) -> Any:
         """Build a lazy Ray Data pipeline from the graph.

--- a/nemo_retriever/tests/test_executor_arrow_pandas.py
+++ b/nemo_retriever/tests/test_executor_arrow_pandas.py
@@ -18,6 +18,7 @@ from nemo_retriever.graph.executor import (
     _ArrowPandasOperatorAdapter,
     _preserves_pandas_output,
     _requires_stable_pandas_blocks,
+    ray_dataset_to_pandas,
 )
 from nemo_retriever.graph.pipeline_graph import Graph
 from nemo_retriever.common.modality.content_transforms import collapse_content_to_page_rows, explode_content_to_rows
@@ -57,6 +58,31 @@ def test_adapter_compacts_sliced_nested_arrow_columns() -> None:
 
     roundtripped.validate(full=True)
     assert isinstance(result.dtypes["text"], pd.ArrowDtype)
+
+
+def test_dataset_materialization_returns_row_safe_pandas_dataframe() -> None:
+    table = pa.Table.from_pylist(
+        [
+            {
+                "metadata": {"error": None, "timing": None},
+                "text": f"page {page_number}",
+            }
+            for page_number in range(3)
+        ]
+    )
+
+    class _Dataset:
+        def iter_batches(self, *, batch_format: str):
+            assert batch_format == "pyarrow"
+            yield table.slice(1, 1)
+
+        def schema(self):
+            return table.schema
+
+    result = ray_dataset_to_pandas(_Dataset())
+
+    assert [row.text for row in result.itertuples(index=False)] == ["page 1"]
+    assert result.to_dict("records") == [{"metadata": {"error": None, "timing": None}, "text": "page 1"}]
 
 
 def test_adapter_preserves_ray_pandas_conversion_policy() -> None:

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1379,11 +1379,12 @@ class TestRayDataExecutor:
         pdf_path.write_bytes(b"pdf")
 
         class _FakeDataset:
-            def materialize(self):
-                return self
+            def iter_batches(self, *, batch_format):
+                assert batch_format == "pyarrow"
+                return iter([])
 
-            def to_pandas(self):
-                return pd.DataFrame()
+            def schema(self):
+                return SimpleNamespace(names=[])
 
         captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

- materialize final Ray Dataset results through the existing safe Arrow-to-Pandas boundary
- compact sliced nested Arrow columns before exposing them to callers
- normalize Ray pickled-object columns and preserve empty-result schemas
- add regression coverage for `DataFrame.itertuples()` and `DataFrame.to_dict("records")`

## Root cause

Ray 2.56+ enables Arrow-backed Pandas conversion by default. The public batch SDK return path called `Dataset.to_pandas()` directly, bypassing the normalization already used at internal operator boundaries. Sliced nested Arrow columns could therefore retain child offsets that were invalid for Pandas row access, producing `pyarrow.lib.ArrowIndexError` even though ingestion and file storage completed successfully.

## User impact

Results returned by batch `.extract().store().ingest()` are now ordinary consumable Pandas DataFrames. Standard row-oriented APIs such as `itertuples()` and `to_dict("records")` work with Ray 2.56.1 and later.

## Validation

- reproduced the failure with Ray 2.56.1, Pandas 2.3.3, and PyArrow 25.0.1
- verified both reported Pandas APIs after applying the Arrow compaction boundary
- focused test suite: 27 passed
- expanded executor run: 39 passed; 3 pre-existing tests require Ray >=2.56.1 and do not run under the repository's older local Ray 2.55.1 environment
- `git diff --check`