### PR TITLE
Honor explicit local embedding and pdf method selection

### DIFF
--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -383,10 +383,32 @@ Hugging Face remains the local query backend for non-ModelOpt checkpoints.
 Local directories must contain `config.json`, and their absolute path must be
 available to every Ray worker or service replica that loads the model.
 
-### OCR language mode
+### PDF extraction method
+
+Use `--method` to select how the CLI extracts text from PDF pages. The default
+method is `pdfium`.
+
+- `pdfium` extracts native PDF text. It does not use OCR as a fallback for
+  scanned-page text.
+- `pdfium_hybrid` extracts native PDF text and uses OCR as a fallback for
+  scanned pages.
+- `ocr` uses OCR for PDF page text.
+- `nemotron_parse` uses the Nemotron Parse extraction path.
+
+For example, select hybrid extraction for a PDF that contains scanned pages:
 
 ```bash
 retriever ingest ./data/scanned.pdf \
+  --method pdfium_hybrid
+```
+
+`--ocr-version` and `--ocr-lang` configure the local OCR engine when an enabled
+stage uses OCR. These options do not select a PDF extraction method.
+
+### OCR language mode
+
+```bash
+retriever ingest ./data/multimodal_test.pdf \
   --ocr-version v2 \
   --ocr-lang english
 ```

--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -53,6 +53,20 @@ def _batch_tuning(params: Any) -> Any:
     return getattr(params, "batch_tuning", None)
 
 
+def _local_embed_requested(params: Any) -> bool:
+    """Return whether embedding configuration explicitly requires a local actor."""
+    if params is None:
+        return False
+    endpoint = getattr(params, "embed_invoke_url", None) or getattr(params, "embedding_endpoint", None)
+    if str(endpoint or "").strip():
+        return False
+    fields_set = getattr(params, "model_fields_set", set())
+    if "local_ingest_embed_backend" in fields_set:
+        return True
+    gpu_embed = getattr(_batch_tuning(params), "gpu_embed", None)
+    return gpu_embed is not None and float(gpu_embed) > 0
+
+
 def default_concurrency_node_names(
     extract_params: Any | None,
     embed_params: Any | None,
@@ -571,7 +585,10 @@ def _append_ordered_transform_stages(
                         name="ExplodeContentToRows",
                         preserve_pandas_output=True,
                     )
-            graph = graph >> _BatchEmbedActor(params=embed_params)
+            graph = graph >> _BatchEmbedActor(
+                params=embed_params,
+                force_local=_local_embed_requested(embed_params),
+            )
 
     if vdb_upload_params is not None:
         graph = graph >> IngestVdbOperator(

--- a/nemo_retriever/src/nemo_retriever/operators/embed/operators.py
+++ b/nemo_retriever/src/nemo_retriever/operators/embed/operators.py
@@ -26,6 +26,17 @@ class _BatchEmbedActor(ArchetypeOperator):
     """Graph-facing batch embedding archetype."""
 
     @classmethod
+    def resolve_operator_class(
+        cls,
+        resources: Any = None,
+        operator_kwargs: dict[str, Any] | None = None,
+    ):
+        kwargs = operator_kwargs or {}
+        if kwargs.get("force_local") and not cls.prefers_cpu_variant(kwargs):
+            return cls.gpu_variant_class()
+        return super().resolve_operator_class(resources, operator_kwargs=kwargs)
+
+    @classmethod
     def prefers_cpu_variant(cls, operator_kwargs: dict[str, Any] | None = None) -> bool:
         params = (operator_kwargs or {}).get("params")
         endpoint = getattr(params, "embed_invoke_url", None) or getattr(params, "embedding_endpoint", None)
@@ -43,8 +54,18 @@ class _BatchEmbedActor(ArchetypeOperator):
 
         return _BatchEmbedGPUActor
 
-    def __init__(self, params: Any) -> None:
-        super().__init__(params=params)
+    @classmethod
+    def variant_operator_kwargs(
+        cls,
+        operator_class: type,
+        operator_kwargs: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        kwargs = super().variant_operator_kwargs(operator_class, operator_kwargs)
+        kwargs.pop("force_local", None)
+        return kwargs
+
+    def __init__(self, params: Any, *, force_local: bool = False) -> None:
+        super().__init__(params=params, force_local=force_local)
 
 
 def __getattr__(name: str):

--- a/nemo_retriever/tests/test_ingest_manifest.py
+++ b/nemo_retriever/tests/test_ingest_manifest.py
@@ -202,6 +202,34 @@ def test_ingest_plan_auto_profile_preserves_manifest_defaults(tmp_path) -> None:
     assert plan.create_kwargs == {"run_mode": "inprocess"}
 
 
+@pytest.mark.parametrize(
+    "extract",
+    [
+        pytest.param(IngestExtractOptions(ocr_version="v2"), id="version"),
+        pytest.param(IngestExtractOptions(ocr_lang="english"), id="language"),
+    ],
+)
+def test_ingest_plan_ocr_selector_preserves_default_pdfium_method(tmp_path, extract) -> None:
+    pdf = tmp_path / "scanned.pdf"
+    pdf.write_bytes(b"pdf")
+
+    plan = _resolve_plan([str(pdf)], extract=extract)
+
+    assert plan.extract_params.method == "pdfium"
+
+
+def test_ingest_plan_explicit_hybrid_method_with_ocr_selector(tmp_path) -> None:
+    pdf = tmp_path / "scanned.pdf"
+    pdf.write_bytes(b"pdf")
+
+    plan = _resolve_plan(
+        [str(pdf)],
+        extract=IngestExtractOptions(method="pdfium_hybrid", ocr_version="v2"),
+    )
+
+    assert plan.extract_params.method == "pdfium_hybrid"
+
+
 def test_ingest_plan_fast_text_profile_is_pdf_text_only(tmp_path) -> None:
     pdf = tmp_path / "manual.pdf"
     pdf.write_bytes(b"pdf")

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -267,6 +267,51 @@ def test_build_graph_resolves_local_nodes_to_gpu_variants_when_gpus_available(
 
 
 @pytest.mark.parametrize(
+    "embed_params",
+    [
+        pytest.param(
+            EmbedParams(
+                model_name="nvidia/llama-nemotron-embed-1b-v2",
+                local_ingest_embed_backend="hf",
+            ),
+            id="explicit-local-hf-backend",
+        ),
+        pytest.param(
+            EmbedParams(
+                model_name="nvidia/llama-nemotron-embed-1b-v2",
+                batch_tuning=BatchTuningParams(gpu_embed=1.0),
+            ),
+            id="explicit-gpu-reservation",
+        ),
+    ],
+)
+def test_build_graph_explicit_local_embedding_resolves_to_gpu_variant(embed_params: EmbedParams) -> None:
+    graph = build_graph(extraction_mode="text", embed_params=embed_params)
+
+    resolved = graph.resolve(Resources(cpu_count=8, gpu_count=0))
+    classes = {node.name: node.operator_class for node in _linear_nodes(resolved)}
+
+    assert issubclass(classes["_BatchEmbedActor"], GPUOperator)
+
+
+def test_build_graph_remote_endpoint_wins_over_explicit_local_embedding_backend() -> None:
+    graph = build_graph(
+        extraction_mode="text",
+        embed_params=EmbedParams(
+            model_name="nvidia/llama-nemotron-embed-1b-v2",
+            embed_invoke_url="http://embed.example/v1",
+            local_ingest_embed_backend="hf",
+            batch_tuning=BatchTuningParams(gpu_embed=1.0),
+        ),
+    )
+
+    resolved = graph.resolve(Resources(cpu_count=8, gpu_count=4))
+    classes = {node.name: node.operator_class for node in _linear_nodes(resolved)}
+
+    assert issubclass(classes["_BatchEmbedActor"], CPUOperator)
+
+
+@pytest.mark.parametrize(
     "ocr_version, expected_actor_name",
     [
         ("v2", "OCRActor"),

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -655,6 +655,7 @@ def test_root_ingest_passes_ocr_lang_option(monkeypatch, tmp_path) -> None:
     assert result.exit_code == 0
     extract_params = fake_ingestor.extract.call_args.args[0]
     assert isinstance(extract_params, ExtractParams)
+    assert extract_params.method == "pdfium"
     assert extract_params.ocr_version == "v2"
     assert extract_params.ocr_lang == "english"
 


### PR DESCRIPTION
## Description

The batch graph selected the embedding actor from detected hardware resources without considering an explicitly configured local Hugging Face backend or positive GPU reservation. This allowed a local embedding request to resolve to `_BatchEmbedCPUActor`, which uses the hosted NVIDIA endpoint and requires an API key. OCR version and language selectors were also incorrectly treated as requests to change the PDF extraction method, even though they should only configure an OCR stage.

The fix preserves explicit local embedding intent during graph construction and forces the GPU embedding actor unless an HTTP embedding endpoint is configured. The internal routing hint is removed before constructing the concrete actor. PDF extraction continues to default to `pdfium`; callers must explicitly select `pdfium_hybrid` or `ocr`, while -`-ocr-version` and `--ocr-lang` only configure the OCR engine.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
