### PR TITLE
fix(vllm): NCCL fallback for local agentic TP without NVLink

### DIFF
--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -14,9 +14,9 @@ The larger `super-49b` profile is also supported. Pass
 `--agentic-local-tensor-parallel-size 2` with two visible GPUs for that
 profile (and the same pattern for other multi-GPU local TP runs).
 Tensor-parallel startup automatically disables NVLink multicast collectives
-(`NCCL_NVLS_ENABLE=0`, `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`) when the
-CUDA-visible GPUs have no NVLink — common on dual-GPU PCIe workstations —
-where those collectives abort vLLM startup. Other custom in-process LLMs are not supported yet because the agent
+(`NCCL_NVLS_ENABLE=0`, `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`) when the TP
+device group has no NVLink — common on dual-GPU PCIe workstations — where
+those collectives abort vLLM startup. Other custom in-process LLMs are not supported yet because the agent
 loop depends on OpenAI-style tool-call messages; use an OpenAI-compatible
 endpoint for custom models.
 

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -12,11 +12,13 @@ in-process local vLLM agent LLM. If no agent model is provided, the library load
 `nemotron-8b` (`nvidia/Llama-3.1-Nemotron-Nano-8B-v1`) on the local CUDA host.
 The larger `super-49b` profile is also supported. Pass
 `--agentic-local-tensor-parallel-size 2` with two visible GPUs for that
-profile. Tensor-parallel startup automatically disables NVLink multicast
-collectives (`NCCL_NVLS_ENABLE=0`, `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`) on
-hosts without NVLink, where they abort vLLM startup. Other custom in-process
-LLMs are not supported yet because the agent loop depends on OpenAI-style
-tool-call messages; use an OpenAI-compatible endpoint for custom models.
+profile (and the same pattern for other multi-GPU local TP runs).
+Tensor-parallel startup automatically disables NVLink multicast collectives
+(`NCCL_NVLS_ENABLE=0`, `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`) when the
+CUDA-visible GPUs have no NVLink — common on dual-GPU PCIe workstations —
+where those collectives abort vLLM startup. Other custom in-process LLMs are not supported yet because the agent
+loop depends on OpenAI-style tool-call messages; use an OpenAI-compatible
+endpoint for custom models.
 
 ```bash
 retriever query "find documents about parser behavior" --agentic

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -12,9 +12,11 @@ in-process local vLLM agent LLM. If no agent model is provided, the library load
 `nemotron-8b` (`nvidia/Llama-3.1-Nemotron-Nano-8B-v1`) on the local CUDA host.
 The larger `super-49b` profile is also supported. Pass
 `--agentic-local-tensor-parallel-size 2` with two visible GPUs for that
-profile. Other custom in-process LLMs
-are not supported yet because the agent loop depends on OpenAI-style tool-call
-messages; use an OpenAI-compatible endpoint for custom models.
+profile. Tensor-parallel startup automatically disables NVLink multicast
+collectives (`NCCL_NVLS_ENABLE=0`, `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`) on
+hosts without NVLink, where they abort vLLM startup. Other custom in-process
+LLMs are not supported yet because the agent loop depends on OpenAI-style
+tool-call messages; use an OpenAI-compatible endpoint for custom models.
 
 ```bash
 retriever query "find documents about parser behavior" --agentic

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -381,12 +381,13 @@ CUDA_VISIBLE_DEVICES=0,1 retriever query "Given their activities, which animal i
   --embed-model-name nvidia/llama-nemotron-embed-vl-1b-v2
 ```
 
-When the CUDA-visible GPUs are not NVLink-connected (typical dual-GPU PCIe
-workstations; detection is scoped to the visible devices), tensor-parallel
+When the first ``tensor_parallel_size`` CUDA-visible GPUs are not
+NVLink-connected (typical dual-GPU PCIe workstations), tensor-parallel
 startup automatically sets `NCCL_NVLS_ENABLE=0` and
 `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`, since NVLink multicast collectives abort
 vLLM startup with a NCCL CUDA error there. Set either variable yourself to
-override the fallback.
+override the fallback. Detection is scoped to that TP device group, not the
+whole host or extra visible GPUs outside the shard.
 
 **OpenAI-compatible agent endpoint.** Pass `--agentic-invoke-url` when you want a
 custom model or a separately hosted chat-completions server, such as vLLM server

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -380,6 +380,13 @@ CUDA_VISIBLE_DEVICES=0,1 retriever query "Given their activities, which animal i
   --table-name nemo-retriever \
   --embed-model-name nvidia/llama-nemotron-embed-vl-1b-v2
 ```
+
+On hosts whose GPUs are not NVLink-connected, tensor-parallel startup
+automatically sets `NCCL_NVLS_ENABLE=0` and
+`TORCH_SYMM_MEM_DISABLE_MULTICAST=1`, since NVLink multicast collectives abort
+vLLM startup with a NCCL CUDA error there. Set either variable yourself to
+override the fallback.
+
 **OpenAI-compatible agent endpoint.** Pass `--agentic-invoke-url` when you want a
 custom model or a separately hosted chat-completions server, such as vLLM server
 mode or a self-hosted NIM. When an invoke URL is provided, `--agentic-llm-model`

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -381,8 +381,9 @@ CUDA_VISIBLE_DEVICES=0,1 retriever query "Given their activities, which animal i
   --embed-model-name nvidia/llama-nemotron-embed-vl-1b-v2
 ```
 
-On hosts whose GPUs are not NVLink-connected, tensor-parallel startup
-automatically sets `NCCL_NVLS_ENABLE=0` and
+When the CUDA-visible GPUs are not NVLink-connected (typical dual-GPU PCIe
+workstations; detection is scoped to the visible devices), tensor-parallel
+startup automatically sets `NCCL_NVLS_ENABLE=0` and
 `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`, since NVLink multicast collectives abort
 vLLM startup with a NCCL CUDA error there. Set either variable yourself to
 override the fallback.

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -229,7 +229,10 @@ Agentic-only knobs (apply only with `--agentic`):
 - `--agentic-local-tensor-parallel-size` (default `1`) — vLLM
   `tensor_parallel_size` for the in-process agent LLM. Set to `2` (with two
   visible GPUs via `CUDA_VISIBLE_DEVICES`) for local `super-49b`. Ignored when
-  `--agentic-invoke-url` is set.
+  `--agentic-invoke-url` is set. On a host whose GPUs are not NVLink-connected,
+  tensor-parallel startup automatically sets `NCCL_NVLS_ENABLE=0` and
+  `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`, because NVLink multicast collectives
+  abort vLLM startup there; set either variable yourself to override.
 - `--agentic-invoke-url` — OpenAI-compatible chat-completions endpoint for the
   agent LLM. Providing it routes agent LLM calls to that remote endpoint; omit it
   to run the in-process local model.

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -227,12 +227,15 @@ Agentic-only knobs (apply only with `--agentic`):
   provided (`nemotron-8b` by default; `super-49b` also supported), or the remote
   model ID when `--agentic-invoke-url` is provided.
 - `--agentic-local-tensor-parallel-size` (default `1`) — vLLM
-  `tensor_parallel_size` for the in-process agent LLM. Set to `2` (with two
-  visible GPUs via `CUDA_VISIBLE_DEVICES`) for local `super-49b`. Ignored when
-  `--agentic-invoke-url` is set. On a host whose GPUs are not NVLink-connected,
-  tensor-parallel startup automatically sets `NCCL_NVLS_ENABLE=0` and
-  `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`, because NVLink multicast collectives
-  abort vLLM startup there; set either variable yourself to override.
+  `tensor_parallel_size` for the in-process agent LLM. Use `2+` with matching
+  `CUDA_VISIBLE_DEVICES` for multi-GPU local profiles (for example
+  `super-49b`). Ignored when `--agentic-invoke-url` is set. When the
+  CUDA-visible GPUs are not NVLink-connected (typical dual-GPU PCIe
+  workstations), tensor-parallel startup automatically sets
+  `NCCL_NVLS_ENABLE=0` and `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`, because NVLink
+  multicast collectives abort vLLM startup there; set either variable yourself
+  to override. Detection is scoped to the CUDA-visible devices, not the whole
+  host.
 - `--agentic-invoke-url` — OpenAI-compatible chat-completions endpoint for the
   agent LLM. Providing it routes agent LLM calls to that remote endpoint; omit it
   to run the in-process local model.

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -229,13 +229,13 @@ Agentic-only knobs (apply only with `--agentic`):
 - `--agentic-local-tensor-parallel-size` (default `1`) — vLLM
   `tensor_parallel_size` for the in-process agent LLM. Use `2+` with matching
   `CUDA_VISIBLE_DEVICES` for multi-GPU local profiles (for example
-  `super-49b`). Ignored when `--agentic-invoke-url` is set. When the
-  CUDA-visible GPUs are not NVLink-connected (typical dual-GPU PCIe
-  workstations), tensor-parallel startup automatically sets
+  `super-49b`). Ignored when `--agentic-invoke-url` is set. When the first
+  `tensor_parallel_size` CUDA-visible GPUs are not NVLink-connected (typical
+  dual-GPU PCIe workstations), tensor-parallel startup automatically sets
   `NCCL_NVLS_ENABLE=0` and `TORCH_SYMM_MEM_DISABLE_MULTICAST=1`, because NVLink
   multicast collectives abort vLLM startup there; set either variable yourself
-  to override. Detection is scoped to the CUDA-visible devices, not the whole
-  host.
+  to override. Detection is scoped to that TP device group, not the whole host
+  or extra visible GPUs outside the shard.
 - `--agentic-invoke-url` — OpenAI-compatible chat-completions endpoint for the
   agent LLM. Providing it routes agent LLM calls to that remote endpoint; omit it
   to run the in-process local model.

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -223,8 +223,8 @@ AgenticLocalTensorParallelSizeOption = Annotated[
         min=1,
         help=(
             "vLLM tensor_parallel_size for the in-process agent LLM. "
-            "Use 2 (with two visible GPUs) for local super-49b; ignored when "
-            "--agentic-invoke-url is set."
+            "Use 2+ with matching CUDA_VISIBLE_DEVICES for multi-GPU local "
+            "profiles (e.g. super-49b); ignored when --agentic-invoke-url is set."
         ),
     ),
 ]

--- a/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
+++ b/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
@@ -48,18 +48,42 @@ def apply_vllm_startup_defaults(*, tensor_parallel_size: int = 1) -> None:
         for name, value in VLLM_NO_NVLINK_ENV_DEFAULTS.items():
             os.environ.setdefault(name, value)
         logger.info(
-            "No NVLink detected on this host; running tensor_parallel_size=%d with %s "
+            "No NVLink detected among the CUDA-visible GPUs; running tensor_parallel_size=%d with %s "
             "so vLLM does not start NVLink multicast collectives.",
             int(tensor_parallel_size),
             ", ".join(f"{name}={value}" for name, value in VLLM_NO_NVLINK_ENV_DEFAULTS.items()),
         )
 
 
+def _visible_nvml_device_indices(device_count: int) -> list[int] | None:
+    """Map ``CUDA_VISIBLE_DEVICES`` to physical NVML indices for the TP group.
+
+    NVML always enumerates every physical GPU, so scanning the whole host would
+    misclassify a PCIe-only visible pair on a machine that also has an
+    NVLink-connected pair. ``None`` means the selection is not resolvable here
+    (UUID or MIG tokens) and callers treat it as unknown connectivity.
+    """
+
+    raw = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    if not raw:
+        return list(range(device_count))
+
+    indices: list[int] = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if not token.isdigit() or int(token) >= device_count:
+            return None
+        indices.append(int(token))
+    return indices
+
+
 def nvlink_is_available() -> bool:
-    """Return whether NVML reports at least one active NVLink on this host.
+    """Return whether NVML reports an active NVLink on the CUDA-visible GPUs.
 
     Unknown counts as available so an NVML gap never silently downgrades
-    collectives on a host that does have NVLink.
+    collectives on a host that does have NVLink among the selected devices.
     """
 
     try:
@@ -69,13 +93,21 @@ def nvlink_is_available() -> bool:
 
     try:
         pynvml.nvmlInit()
-    except Exception:
+    except pynvml.NVMLError:
         logger.debug("NVML unavailable; assuming NVLink is present", exc_info=True)
         return True
 
     try:
+        device_indices = _visible_nvml_device_indices(int(pynvml.nvmlDeviceGetCount()))
+        if device_indices is None:
+            logger.debug(
+                "Could not resolve CUDA_VISIBLE_DEVICES=%r to NVML indices; assuming NVLink is present",
+                os.environ.get("CUDA_VISIBLE_DEVICES"),
+            )
+            return True
+
         max_links = int(getattr(pynvml, "NVML_NVLINK_MAX_LINKS", 18))
-        for device_index in range(int(pynvml.nvmlDeviceGetCount())):
+        for device_index in device_indices:
             handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
             for link in range(max_links):
                 try:
@@ -83,16 +115,16 @@ def nvlink_is_available() -> bool:
                         return True
                 except pynvml.NVMLError:
                     # Not supported on this device, or the link index is beyond
-                    # what it exposes; keep probing the remaining devices.
+                    # what it exposes; keep probing the remaining visible devices.
                     break
         return False
-    except Exception:
+    except pynvml.NVMLError:
         logger.debug("NVML NVLink query failed; assuming NVLink is present", exc_info=True)
         return True
     finally:
         try:
             pynvml.nvmlShutdown()
-        except Exception:
+        except pynvml.NVMLError:
             logger.debug("Ignoring NVML shutdown error", exc_info=True)
 
 

--- a/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
+++ b/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
@@ -44,19 +44,20 @@ def apply_vllm_startup_defaults(*, tensor_parallel_size: int = 1) -> None:
     # when the optional DeepGEMM/CUDA-toolkit stack is not discoverable.
     os.environ.setdefault("VLLM_DEEP_GEMM_WARMUP", VLLM_DEEP_GEMM_WARMUP_DEFAULT)
 
-    if int(tensor_parallel_size) > 1 and not nvlink_is_available():
+    tp = int(tensor_parallel_size)
+    if tp > 1 and not nvlink_is_available(tensor_parallel_size=tp):
         for name, value in VLLM_NO_NVLINK_ENV_DEFAULTS.items():
             os.environ.setdefault(name, value)
         logger.info(
-            "No NVLink detected among the CUDA-visible GPUs; running tensor_parallel_size=%d with %s "
+            "No NVLink detected in the tensor-parallel GPU group; running tensor_parallel_size=%d with %s "
             "so vLLM does not start NVLink multicast collectives.",
-            int(tensor_parallel_size),
+            tp,
             ", ".join(f"{name}={value}" for name, value in VLLM_NO_NVLINK_ENV_DEFAULTS.items()),
         )
 
 
 def _visible_nvml_device_indices(device_count: int) -> list[int] | None:
-    """Map ``CUDA_VISIBLE_DEVICES`` to physical NVML indices for the TP group.
+    """Map ``CUDA_VISIBLE_DEVICES`` to physical NVML indices.
 
     NVML always enumerates every physical GPU, so scanning the whole host would
     misclassify a PCIe-only visible pair on a machine that also has an
@@ -79,8 +80,12 @@ def _visible_nvml_device_indices(device_count: int) -> list[int] | None:
     return indices
 
 
-def nvlink_is_available() -> bool:
-    """Return whether NVML reports an active NVLink on the CUDA-visible GPUs.
+def nvlink_is_available(*, tensor_parallel_size: int | None = None) -> bool:
+    """Return whether NVML reports an active NVLink in the vLLM TP GPU group.
+
+    When ``tensor_parallel_size`` is set, only the first N CUDA-visible devices
+    are checked — matching vLLM's default rank→device mapping — so extra visible
+    GPUs outside the TP group cannot mask a PCIe-only shard.
 
     Unknown counts as available so an NVML gap never silently downgrades
     collectives on a host that does have NVLink among the selected devices.
@@ -106,6 +111,12 @@ def nvlink_is_available() -> bool:
             )
             return True
 
+        if tensor_parallel_size is not None:
+            tp = int(tensor_parallel_size)
+            if tp < 1:
+                return True
+            device_indices = device_indices[:tp]
+
         max_links = int(getattr(pynvml, "NVML_NVLINK_MAX_LINKS", 18))
         for device_index in device_indices:
             handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
@@ -115,7 +126,7 @@ def nvlink_is_available() -> bool:
                         return True
                 except pynvml.NVMLError:
                     # Not supported on this device, or the link index is beyond
-                    # what it exposes; keep probing the remaining visible devices.
+                    # what it exposes; keep probing the remaining TP devices.
                     break
         return False
     except pynvml.NVMLError:

--- a/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
+++ b/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
@@ -85,7 +85,9 @@ def nvlink_is_available(*, tensor_parallel_size: int | None = None) -> bool:
 
     When ``tensor_parallel_size`` is set, only the first N CUDA-visible devices
     are checked — matching vLLM's default rank→device mapping — so extra visible
-    GPUs outside the TP group cannot mask a PCIe-only shard.
+    GPUs outside the TP group cannot mask a PCIe-only shard. An active link only
+    counts when it reaches another GPU in that group (or an NVSwitch): hosts with
+    separately bridged pairs give every device a link that leads elsewhere.
 
     Unknown counts as available so an NVML gap never silently downgrades
     collectives on a host that does have NVLink among the selected devices.
@@ -103,7 +105,8 @@ def nvlink_is_available(*, tensor_parallel_size: int | None = None) -> bool:
         return True
 
     try:
-        device_indices = _visible_nvml_device_indices(int(pynvml.nvmlDeviceGetCount()))
+        device_count = int(pynvml.nvmlDeviceGetCount())
+        device_indices = _visible_nvml_device_indices(device_count)
         if device_indices is None:
             logger.debug(
                 "Could not resolve CUDA_VISIBLE_DEVICES=%r to NVML indices; assuming NVLink is present",
@@ -117,17 +120,32 @@ def nvlink_is_available(*, tensor_parallel_size: int | None = None) -> bool:
                 return True
             device_indices = device_indices[:tp]
 
+        handles = {index: pynvml.nvmlDeviceGetHandleByIndex(index) for index in range(device_count)}
+        bus_ids = {
+            index: str(pynvml.nvmlDeviceGetPciInfo(handle).busId).strip().lower() for index, handle in handles.items()
+        }
+        tp_bus_ids = {bus_ids[index] for index in device_indices}
+        host_bus_ids = set(bus_ids.values())
         max_links = int(getattr(pynvml, "NVML_NVLINK_MAX_LINKS", 18))
         for device_index in device_indices:
-            handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+            handle = handles[device_index]
             for link in range(max_links):
                 try:
-                    if pynvml.nvmlDeviceGetNvLinkState(handle, link) == 1:
-                        return True
+                    active = pynvml.nvmlDeviceGetNvLinkState(handle, link) == 1
                 except pynvml.NVMLError:
                     # Not supported on this device, or the link index is beyond
                     # what it exposes; keep probing the remaining TP devices.
                     break
+                if not active:
+                    continue
+                try:
+                    remote = str(pynvml.nvmlDeviceGetNvLinkRemotePciInfo(handle, link).busId).strip().lower()
+                except (pynvml.NVMLError, AttributeError):
+                    return True  # Cannot see the peer, so trust the active link.
+                # A peer that is not one of this host's GPUs is an NVSwitch, which
+                # still connects the whole tensor-parallel group.
+                if remote in tp_bus_ids or remote not in host_bus_ids:
+                    return True
         return False
     except pynvml.NVMLError:
         logger.debug("NVML NVLink query failed; assuming NVLink is present", exc_info=True)

--- a/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
+++ b/nemo_retriever/src/nemo_retriever/models/inference/vllm.py
@@ -25,14 +25,75 @@ VLLM_DTYPE = "bfloat16"
 VLLM_ATTENTION_BACKEND = "FLASH_ATTN"
 VLLM_DEEP_GEMM_WARMUP_DEFAULT = "skip"
 
+# Multi-GPU collectives that rely on NVLink multicast (NCCL NVLS and torch
+# symmetric-memory all-reduce) abort with "NCCL error: unhandled cuda error"
+# during engine startup when the visible GPUs are only PCIe-connected, which is
+# the common two-workstation-card layout. Falling back to ring collectives costs
+# throughput that these hosts cannot use anyway.
+VLLM_NO_NVLINK_ENV_DEFAULTS = {
+    "NCCL_NVLS_ENABLE": "0",
+    "TORCH_SYMM_MEM_DISABLE_MULTICAST": "1",
+}
 
-def apply_vllm_startup_defaults() -> None:
+
+def apply_vllm_startup_defaults(*, tensor_parallel_size: int = 1) -> None:
     """Apply conservative vLLM startup defaults without overriding users."""
 
     # DeepGEMM can still be used by vLLM at runtime. This only skips the
     # ahead-of-time warmup path, which may fail before local inference starts
     # when the optional DeepGEMM/CUDA-toolkit stack is not discoverable.
     os.environ.setdefault("VLLM_DEEP_GEMM_WARMUP", VLLM_DEEP_GEMM_WARMUP_DEFAULT)
+
+    if int(tensor_parallel_size) > 1 and not nvlink_is_available():
+        for name, value in VLLM_NO_NVLINK_ENV_DEFAULTS.items():
+            os.environ.setdefault(name, value)
+        logger.info(
+            "No NVLink detected on this host; running tensor_parallel_size=%d with %s "
+            "so vLLM does not start NVLink multicast collectives.",
+            int(tensor_parallel_size),
+            ", ".join(f"{name}={value}" for name, value in VLLM_NO_NVLINK_ENV_DEFAULTS.items()),
+        )
+
+
+def nvlink_is_available() -> bool:
+    """Return whether NVML reports at least one active NVLink on this host.
+
+    Unknown counts as available so an NVML gap never silently downgrades
+    collectives on a host that does have NVLink.
+    """
+
+    try:
+        import pynvml
+    except ImportError:
+        return True
+
+    try:
+        pynvml.nvmlInit()
+    except Exception:
+        logger.debug("NVML unavailable; assuming NVLink is present", exc_info=True)
+        return True
+
+    try:
+        max_links = int(getattr(pynvml, "NVML_NVLINK_MAX_LINKS", 18))
+        for device_index in range(int(pynvml.nvmlDeviceGetCount())):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+            for link in range(max_links):
+                try:
+                    if pynvml.nvmlDeviceGetNvLinkState(handle, link) == 1:
+                        return True
+                except pynvml.NVMLError:
+                    # Not supported on this device, or the link index is beyond
+                    # what it exposes; keep probing the remaining devices.
+                    break
+        return False
+    except Exception:
+        logger.debug("NVML NVLink query failed; assuming NVLink is present", exc_info=True)
+        return True
+    finally:
+        try:
+            pynvml.nvmlShutdown()
+        except Exception:
+            logger.debug("Ignoring NVML shutdown error", exc_info=True)
 
 
 def create_vllm_llm(
@@ -55,7 +116,7 @@ def create_vllm_llm(
     Uses bfloat16 and FLASH_ATTN backend (fixed for this module).
 
     """
-    apply_vllm_startup_defaults()
+    apply_vllm_startup_defaults(tensor_parallel_size=tensor_parallel_size)
     try:
         from vllm import LLM
     except ImportError as e:
@@ -210,6 +271,7 @@ def embed_multimodal_with_vllm_llm(
 
 __all__ = [
     "apply_vllm_startup_defaults",
+    "nvlink_is_available",
     "create_vllm_llm",
     "embed_with_vllm_llm",
     "embed_multimodal_with_vllm_llm",

--- a/nemo_retriever/src/nemo_retriever/models/local/agent_llm.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/agent_llm.py
@@ -120,7 +120,7 @@ class VLLMAgentChatLLM(BaseModel):
                 'Local agentic LLM inference requires vLLM. Install with: pip install "nemo-retriever[local]"'
             ) from e
 
-        apply_vllm_startup_defaults()
+        apply_vllm_startup_defaults(tensor_parallel_size=int(config.tensor_parallel_size))
         _raise_if_cuda_unavailable()
         self._model_path = model_path
         self._max_tokens = int(config.max_tokens)

--- a/nemo_retriever/tests/test_vllm_embed.py
+++ b/nemo_retriever/tests/test_vllm_embed.py
@@ -245,7 +245,7 @@ class TestVllmStartupDefaults:
     def test_single_gpu_keeps_nvlink_collectives_untouched(self, monkeypatch):
         monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
         monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
-        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: False)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda **_kwargs: False)
 
         apply_vllm_startup_defaults(tensor_parallel_size=1)
 
@@ -255,7 +255,7 @@ class TestVllmStartupDefaults:
     def test_tensor_parallel_without_nvlink_disables_multicast_collectives(self, monkeypatch):
         monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
         monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
-        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: False)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda **_kwargs: False)
 
         apply_vllm_startup_defaults(tensor_parallel_size=2)
 
@@ -265,7 +265,7 @@ class TestVllmStartupDefaults:
     def test_tensor_parallel_with_nvlink_keeps_multicast_collectives(self, monkeypatch):
         monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
         monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
-        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: True)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda **_kwargs: True)
 
         apply_vllm_startup_defaults(tensor_parallel_size=2)
 
@@ -275,7 +275,7 @@ class TestVllmStartupDefaults:
     def test_nvlink_fallback_respects_user_override(self, monkeypatch):
         monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
         monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
-        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: False)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda **_kwargs: False)
 
         apply_vllm_startup_defaults(tensor_parallel_size=2)
 
@@ -335,7 +335,7 @@ class TestNvlinkDetection:
             devices_link_states=[[1], [1], [0], [0]],
         )
 
-        assert vllm_inference.nvlink_is_available() is False
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is False
 
     def test_visible_nvlink_pair_reports_available(self, monkeypatch):
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
@@ -344,14 +344,26 @@ class TestNvlinkDetection:
             devices_link_states=[[1], [1], [0], [0]],
         )
 
-        assert vllm_inference.nvlink_is_available() is True
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is True
+
+    def test_tp_group_ignores_extra_visible_nvlink_devices(self, monkeypatch):
+        # Four visible GPUs: TP=2 uses physical 0/1 (PCIe-only). NVLink on 2/3
+        # must not keep multicast enabled for the TP shard.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3")
+        self._install_fake_pynvml(
+            monkeypatch,
+            devices_link_states=[[0], [0], [1], [1]],
+        )
+
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is False
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=4) is True
 
     def test_uuid_visible_devices_assume_available(self, monkeypatch):
         """UUID selections are not resolved here, so keep vLLM's own defaults."""
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-deadbeef")
         self._install_fake_pynvml(monkeypatch, devices_link_states=[[0], [0]])
 
-        assert vllm_inference.nvlink_is_available() is True
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is True
 
     def test_missing_nvml_assumes_available(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "pynvml", None)

--- a/nemo_retriever/tests/test_vllm_embed.py
+++ b/nemo_retriever/tests/test_vllm_embed.py
@@ -15,6 +15,7 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
+from nemo_retriever.models.inference import vllm as vllm_inference
 from nemo_retriever.models.inference.vllm import (
     apply_vllm_startup_defaults,
     embed_multimodal_with_vllm_llm,
@@ -240,6 +241,92 @@ class TestVllmStartupDefaults:
         apply_vllm_startup_defaults()
 
         assert os.environ["VLLM_DEEP_GEMM_WARMUP"] == "full"
+
+    def test_single_gpu_keeps_nvlink_collectives_untouched(self, monkeypatch):
+        monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
+        monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: False)
+
+        apply_vllm_startup_defaults(tensor_parallel_size=1)
+
+        assert "NCCL_NVLS_ENABLE" not in os.environ
+        assert "TORCH_SYMM_MEM_DISABLE_MULTICAST" not in os.environ
+
+    def test_tensor_parallel_without_nvlink_disables_multicast_collectives(self, monkeypatch):
+        monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
+        monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: False)
+
+        apply_vllm_startup_defaults(tensor_parallel_size=2)
+
+        assert os.environ["NCCL_NVLS_ENABLE"] == "0"
+        assert os.environ["TORCH_SYMM_MEM_DISABLE_MULTICAST"] == "1"
+
+    def test_tensor_parallel_with_nvlink_keeps_multicast_collectives(self, monkeypatch):
+        monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
+        monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: True)
+
+        apply_vllm_startup_defaults(tensor_parallel_size=2)
+
+        assert "NCCL_NVLS_ENABLE" not in os.environ
+        assert "TORCH_SYMM_MEM_DISABLE_MULTICAST" not in os.environ
+
+    def test_nvlink_fallback_respects_user_override(self, monkeypatch):
+        monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+        monkeypatch.delenv("TORCH_SYMM_MEM_DISABLE_MULTICAST", raising=False)
+        monkeypatch.setattr(vllm_inference, "nvlink_is_available", lambda: False)
+
+        apply_vllm_startup_defaults(tensor_parallel_size=2)
+
+        assert os.environ["NCCL_NVLS_ENABLE"] == "1"
+        assert os.environ["TORCH_SYMM_MEM_DISABLE_MULTICAST"] == "1"
+
+
+class TestNvlinkDetection:
+    def _install_fake_pynvml(self, monkeypatch, *, link_states, device_count=2):
+        class FakeNVMLError(Exception):
+            pass
+
+        fake = ModuleType("pynvml")
+        fake.NVMLError = FakeNVMLError
+        fake.NVML_NVLINK_MAX_LINKS = len(link_states) or 1
+        fake.nvmlInit = lambda: None
+        fake.nvmlShutdown = lambda: None
+        fake.nvmlDeviceGetCount = lambda: device_count
+        fake.nvmlDeviceGetHandleByIndex = lambda index: index
+
+        def get_nvlink_state(_handle, link):
+            try:
+                state = link_states[link]
+            except IndexError as exc:
+                raise FakeNVMLError("invalid link") from exc
+            if state is None:
+                raise FakeNVMLError("not supported")
+            return state
+
+        fake.nvmlDeviceGetNvLinkState = get_nvlink_state
+        monkeypatch.setitem(sys.modules, "pynvml", fake)
+
+    def test_active_link_reports_available(self, monkeypatch):
+        self._install_fake_pynvml(monkeypatch, link_states=[0, 1])
+
+        assert vllm_inference.nvlink_is_available() is True
+
+    def test_no_link_support_reports_unavailable(self, monkeypatch):
+        self._install_fake_pynvml(monkeypatch, link_states=[None])
+
+        assert vllm_inference.nvlink_is_available() is False
+
+    def test_inactive_links_report_unavailable(self, monkeypatch):
+        self._install_fake_pynvml(monkeypatch, link_states=[0, 0])
+
+        assert vllm_inference.nvlink_is_available() is False
+
+    def test_missing_nvml_assumes_available(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "pynvml", None)
+
+        assert vllm_inference.nvlink_is_available() is True
 
 
 class TestVLLMEmbedderImages:

--- a/nemo_retriever/tests/test_vllm_embed.py
+++ b/nemo_retriever/tests/test_vllm_embed.py
@@ -284,7 +284,13 @@ class TestVllmStartupDefaults:
 
 
 class TestNvlinkDetection:
-    def _install_fake_pynvml(self, monkeypatch, *, devices_link_states):
+    def _install_fake_pynvml(self, monkeypatch, *, devices_link_states, link_peers=None, support_remote_pci=True):
+        """Install a fake ``pynvml``.
+
+        ``link_peers`` maps a device index to the peer of each of its links:
+        another device index, or ``"switch"`` for an NVSwitch endpoint.
+        """
+
         class FakeNVMLError(Exception):
             pass
 
@@ -295,6 +301,7 @@ class TestNvlinkDetection:
         fake.nvmlShutdown = lambda: None
         fake.nvmlDeviceGetCount = lambda: len(devices_link_states)
         fake.nvmlDeviceGetHandleByIndex = lambda index: index
+        fake.nvmlDeviceGetPciInfo = lambda handle: SimpleNamespace(busId=f"0000:0{int(handle)}:00.0".encode())
 
         def get_nvlink_state(handle, link):
             try:
@@ -305,15 +312,62 @@ class TestNvlinkDetection:
                 raise FakeNVMLError("not supported")
             return state
 
+        def get_remote_pci_info(handle, link):
+            peers = (link_peers or {}).get(int(handle), [])
+            peer = peers[link] if link < len(peers) else None
+            if peer is None:
+                raise FakeNVMLError("remote pci info unavailable")
+            if peer == "switch":
+                return SimpleNamespace(busId=b"0000:ff:00.0")
+            return SimpleNamespace(busId=f"0000:0{int(peer)}:00.0".encode())
+
         fake.nvmlDeviceGetNvLinkState = get_nvlink_state
+        if support_remote_pci:
+            fake.nvmlDeviceGetNvLinkRemotePciInfo = get_remote_pci_info
         monkeypatch.setitem(sys.modules, "pynvml", fake)
         return fake
 
     def test_active_link_reports_available(self, monkeypatch):
         monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-        self._install_fake_pynvml(monkeypatch, devices_link_states=[[0, 1], [0, 1]])
+        self._install_fake_pynvml(
+            monkeypatch,
+            devices_link_states=[[0, 1], [0, 1]],
+            link_peers={0: [None, 1], 1: [None, 0]},
+        )
 
         assert vllm_inference.nvlink_is_available() is True
+
+    def test_active_link_to_gpu_outside_tp_group_reports_unavailable(self, monkeypatch):
+        # Separately bridged pairs 0-1 and 2-3: a TP group of 0 and 2 has active
+        # links on both devices, but neither reaches the other TP member.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,2")
+        self._install_fake_pynvml(
+            monkeypatch,
+            devices_link_states=[[1], [1], [1], [1]],
+            link_peers={0: [1], 1: [0], 2: [3], 3: [2]},
+        )
+
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is False
+
+    def test_nvswitch_peer_reports_available(self, monkeypatch):
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        self._install_fake_pynvml(
+            monkeypatch,
+            devices_link_states=[[1], [1]],
+            link_peers={0: ["switch"], 1: ["switch"]},
+        )
+
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is True
+
+    def test_unreportable_peer_trusts_active_link(self, monkeypatch):
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        self._install_fake_pynvml(
+            monkeypatch,
+            devices_link_states=[[1], [1]],
+            support_remote_pci=False,
+        )
+
+        assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is True
 
     def test_no_link_support_reports_unavailable(self, monkeypatch):
         monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
@@ -342,6 +396,7 @@ class TestNvlinkDetection:
         self._install_fake_pynvml(
             monkeypatch,
             devices_link_states=[[1], [1], [0], [0]],
+            link_peers={0: [1], 1: [0]},
         )
 
         assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is True
@@ -353,6 +408,7 @@ class TestNvlinkDetection:
         self._install_fake_pynvml(
             monkeypatch,
             devices_link_states=[[0], [0], [1], [1]],
+            link_peers={2: [3], 3: [2]},
         )
 
         assert vllm_inference.nvlink_is_available(tensor_parallel_size=2) is False

--- a/nemo_retriever/tests/test_vllm_embed.py
+++ b/nemo_retriever/tests/test_vllm_embed.py
@@ -284,21 +284,21 @@ class TestVllmStartupDefaults:
 
 
 class TestNvlinkDetection:
-    def _install_fake_pynvml(self, monkeypatch, *, link_states, device_count=2):
+    def _install_fake_pynvml(self, monkeypatch, *, devices_link_states):
         class FakeNVMLError(Exception):
             pass
 
         fake = ModuleType("pynvml")
         fake.NVMLError = FakeNVMLError
-        fake.NVML_NVLINK_MAX_LINKS = len(link_states) or 1
+        fake.NVML_NVLINK_MAX_LINKS = max((len(states) for states in devices_link_states), default=1)
         fake.nvmlInit = lambda: None
         fake.nvmlShutdown = lambda: None
-        fake.nvmlDeviceGetCount = lambda: device_count
+        fake.nvmlDeviceGetCount = lambda: len(devices_link_states)
         fake.nvmlDeviceGetHandleByIndex = lambda index: index
 
-        def get_nvlink_state(_handle, link):
+        def get_nvlink_state(handle, link):
             try:
-                state = link_states[link]
+                state = devices_link_states[int(handle)][link]
             except IndexError as exc:
                 raise FakeNVMLError("invalid link") from exc
             if state is None:
@@ -307,24 +307,69 @@ class TestNvlinkDetection:
 
         fake.nvmlDeviceGetNvLinkState = get_nvlink_state
         monkeypatch.setitem(sys.modules, "pynvml", fake)
+        return fake
 
     def test_active_link_reports_available(self, monkeypatch):
-        self._install_fake_pynvml(monkeypatch, link_states=[0, 1])
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        self._install_fake_pynvml(monkeypatch, devices_link_states=[[0, 1], [0, 1]])
 
         assert vllm_inference.nvlink_is_available() is True
 
     def test_no_link_support_reports_unavailable(self, monkeypatch):
-        self._install_fake_pynvml(monkeypatch, link_states=[None])
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        self._install_fake_pynvml(monkeypatch, devices_link_states=[[None], [None]])
 
         assert vllm_inference.nvlink_is_available() is False
 
     def test_inactive_links_report_unavailable(self, monkeypatch):
-        self._install_fake_pynvml(monkeypatch, link_states=[0, 0])
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        self._install_fake_pynvml(monkeypatch, devices_link_states=[[0, 0], [0, 0]])
 
         assert vllm_inference.nvlink_is_available() is False
 
+    def test_visible_pcie_pair_ignores_unrelated_nvlink_devices(self, monkeypatch):
+        # Host has NVLink on 0/1, but CUDA_VISIBLE_DEVICES selects the PCIe-only 2/3 pair.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+        self._install_fake_pynvml(
+            monkeypatch,
+            devices_link_states=[[1], [1], [0], [0]],
+        )
+
+        assert vllm_inference.nvlink_is_available() is False
+
+    def test_visible_nvlink_pair_reports_available(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+        self._install_fake_pynvml(
+            monkeypatch,
+            devices_link_states=[[1], [1], [0], [0]],
+        )
+
+        assert vllm_inference.nvlink_is_available() is True
+
+    def test_uuid_visible_devices_assume_available(self, monkeypatch):
+        """UUID selections are not resolved here, so keep vLLM's own defaults."""
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-deadbeef")
+        self._install_fake_pynvml(monkeypatch, devices_link_states=[[0], [0]])
+
+        assert vllm_inference.nvlink_is_available() is True
+
     def test_missing_nvml_assumes_available(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "pynvml", None)
+
+        assert vllm_inference.nvlink_is_available() is True
+
+    def test_nvml_init_error_assumes_available(self, monkeypatch):
+        class FakeNVMLError(Exception):
+            pass
+
+        fake = ModuleType("pynvml")
+        fake.NVMLError = FakeNVMLError
+
+        def fail_init():
+            raise FakeNVMLError("init failed")
+
+        fake.nvmlInit = fail_init
+        monkeypatch.setitem(sys.modules, "pynvml", fake)
 
         assert vllm_inference.nvlink_is_available() is True
 


### PR DESCRIPTION
## Description
- When `tensor_parallel_size > 1` and NVML reports no active NVLink, auto-set `NCCL_NVLS_ENABLE=0` and `TORCH_SYMM_MEM_DISABLE_MULTICAST=1` before starting vLLM so PCIe-only 2-GPU hosts can load local Super-49B.
- Leave NVLink hosts and any user-set env values unchanged.
- Document the Super-49B TP=2 / non-NVLink behavior and add unit coverage for detection and defaults.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
