### PR TITLE
fix(rerank): honor invoke_url alias for SDK remote reranking

### DIFF
--- a/nemo_retriever/retriever.md
+++ b/nemo_retriever/retriever.md
@@ -12,7 +12,7 @@ The high-level **`Retriever`** runs **query → embed → vector search → opti
 | **`graph`** | Optional custom `Graph`. When set, **`embed_kwargs` / `vdb_kwargs` are not used to build the default graph**—you supply a fully wired pipeline. |
 | **`embed_kwargs`** | Passed to **`EmbedParams`** (merged over library defaults). Controls model, endpoints, `input_type` (default `"query"`), batch sizes, `runtime` (device, HF cache), etc. |
 | **`vdb_kwargs`** | Passed to **`RetrieveVdbOperator`**. Either nested `{"vdb_op": "lancedb", "vdb_kwargs": {"uri": "...", "table_name": "..."}}` or, for convenience, a **flat** Lance-only dict `{"uri": "...", "table_name": "..."}` is coerced to `vdb_op="lancedb"`. |
-| **`rerank_kwargs`** | Forwarded to **`NemotronRerankActor`** (merged over defaults). Common keys: `model_name`, `invoke_url`, `api_key`, `batch_size`, `max_length`, `score_column`, `local_reranker_backend`. **`refine_factor`** (default `4`) multiplies `top_k` for retrieval when **`rerank`** is true; it is **not** passed to the actor. |
+| **`rerank_kwargs`** | Forwarded to **`NemotronRerankActor`** (merged over defaults). Common keys: `model_name`, `rerank_invoke_url` (alias: `invoke_url`), `api_key`, `batch_size`, `max_length`, `score_column`, `local_reranker_backend`. Setting the endpoint selects the remote reranker; leaving it unset loads a local model through `local_reranker_backend`. **`refine_factor`** (default `4`) multiplies `top_k` for retrieval when **`rerank`** is true; it is **not** passed to the actor. |
 
 ### Default pipeline
 
@@ -88,7 +88,7 @@ r = Retriever(
     vdb_kwargs={"uri": "./kb", "table_name": "nemo-retriever"},
     rerank=True,
     rerank_kwargs={
-        "invoke_url": "http://localhost:8015",
+        "rerank_invoke_url": "http://localhost:8015",
         "model_name": "nvidia/llama-nemotron-rerank-1b-v2",
         "refine_factor": 4,
     },
@@ -97,6 +97,9 @@ r = Retriever(
 hits = r.query("detailed question")
 assert "_rerank_score" in hits[0]
 ```
+
+`invoke_url` is accepted as an alias for `rerank_invoke_url`. Omit both keys to
+rerank with a locally loaded model instead of a served endpoint.
 
 ### 5) Per-call overrides
 

--- a/nemo_retriever/src/nemo_retriever/common/modality/ocr/shared.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/ocr/shared.py
@@ -1055,7 +1055,7 @@ def ocr_page_elements(
     if not isinstance(batch_df, pd.DataFrame):
         raise NotImplementedError("ocr_page_elements currently only supports pandas.DataFrame input.")
 
-    invoke_url = (invoke_url or kwargs.get("ocr_invoke_url") or "").strip()
+    invoke_url = str(invoke_url or "").strip() or str(kwargs.get("ocr_invoke_url") or "").strip()
     use_remote = bool(invoke_url)
     if not use_remote and model is None:
         raise ValueError("A local `model` is required when `invoke_url` is not provided.")
@@ -1184,7 +1184,7 @@ def nemotron_parse_page_elements(
     if not isinstance(batch_df, pd.DataFrame):
         raise NotImplementedError("nemotron_parse_page_elements currently only supports pandas.DataFrame input.")
 
-    invoke_url = (invoke_url or kwargs.get("nemotron_parse_invoke_url") or "").strip()
+    invoke_url = str(invoke_url or "").strip() or str(kwargs.get("nemotron_parse_invoke_url") or "").strip()
     use_remote = bool(invoke_url)
     if not use_remote and model is None:
         raise ValueError("A local `model` is required when `invoke_url` is not provided.")

--- a/nemo_retriever/src/nemo_retriever/common/modality/page_elements/shared.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/page_elements/shared.py
@@ -496,7 +496,7 @@ def detect_page_elements_v3(
     # print(preds)
     # breakpoint()
 
-    invoke_url = (invoke_url or kwargs.get("page_elements_invoke_url") or "").strip()
+    invoke_url = str(invoke_url or "").strip() or str(kwargs.get("page_elements_invoke_url") or "").strip()
     use_remote = bool(invoke_url)
 
     if not use_remote and model is None:

--- a/nemo_retriever/src/nemo_retriever/common/modality/table/shared.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/table/shared.py
@@ -329,7 +329,9 @@ def table_structure_ocr_page_elements(
     if not isinstance(batch_df, pd.DataFrame):
         raise NotImplementedError("table_structure_ocr_page_elements currently only supports pandas.DataFrame input.")
 
-    ts_url = (table_structure_invoke_url or kwargs.get("table_structure_invoke_url") or "").strip()
+    ts_url = (
+        str(table_structure_invoke_url or "").strip() or str(kwargs.get("table_structure_invoke_url") or "").strip()
+    )
     use_remote_ts = bool(ts_url)
     table_output_format = kwargs.get("table_output_format")
 

--- a/nemo_retriever/src/nemo_retriever/operators/extract/ocr/cpu_ocr.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/ocr/cpu_ocr.py
@@ -27,11 +27,12 @@ class OCRCPUActor(AbstractOperator, CPUOperator):
     def __init__(self, **ocr_kwargs: Any) -> None:
         super().__init__(**ocr_kwargs)
         self.ocr_kwargs = dict(ocr_kwargs)
-        invoke_url = str(
-            self.ocr_kwargs.get("ocr_invoke_url") or self.ocr_kwargs.get("invoke_url") or self.DEFAULT_INVOKE_URL
-        ).strip()
-        if "invoke_url" not in self.ocr_kwargs:
-            self.ocr_kwargs["invoke_url"] = invoke_url
+        invoke_url = (
+            str(self.ocr_kwargs.get("ocr_invoke_url") or "").strip()
+            or str(self.ocr_kwargs.get("invoke_url") or "").strip()
+            or self.DEFAULT_INVOKE_URL
+        )
+        self.ocr_kwargs["invoke_url"] = invoke_url
 
         self.ocr_kwargs["extract_text"] = bool(self.ocr_kwargs.get("extract_text", False))
         self.ocr_kwargs["extract_tables"] = bool(self.ocr_kwargs.get("extract_tables", False))

--- a/nemo_retriever/src/nemo_retriever/operators/extract/ocr/cpu_parse.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/ocr/cpu_parse.py
@@ -35,7 +35,9 @@ class NemotronParseCPUActor(AbstractOperator, CPUOperator):
         remote_max_429_retries: int = 5,
     ) -> None:
         super().__init__()
-        self._invoke_url = (nemotron_parse_invoke_url or invoke_url or self.DEFAULT_INVOKE_URL).strip()
+        self._invoke_url = (
+            str(nemotron_parse_invoke_url or "").strip() or str(invoke_url or "").strip() or self.DEFAULT_INVOKE_URL
+        )
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)
         self._task_prompt = str(task_prompt)

--- a/nemo_retriever/src/nemo_retriever/operators/extract/ocr/gpu_ocr.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/ocr/gpu_ocr.py
@@ -27,8 +27,11 @@ class OCRActor(AbstractOperator, GPUOperator):
             warnings.filterwarnings("ignore", category=Image.DecompressionBombWarning)
 
         self.ocr_kwargs = dict(ocr_kwargs)
-        invoke_url = str(self.ocr_kwargs.get("ocr_invoke_url") or self.ocr_kwargs.get("invoke_url") or "").strip()
-        if invoke_url and "invoke_url" not in self.ocr_kwargs:
+        invoke_url = (
+            str(self.ocr_kwargs.get("ocr_invoke_url") or "").strip()
+            or str(self.ocr_kwargs.get("invoke_url") or "").strip()
+        )
+        if invoke_url:
             self.ocr_kwargs["invoke_url"] = invoke_url
 
         self.ocr_kwargs["extract_text"] = bool(self.ocr_kwargs.get("extract_text", False))

--- a/nemo_retriever/src/nemo_retriever/operators/extract/ocr/gpu_parse.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/ocr/gpu_parse.py
@@ -35,7 +35,7 @@ class NemotronParseActor(AbstractOperator, GPUOperator):
         remote_max_429_retries: int = 5,
     ) -> None:
         super().__init__()
-        self._invoke_url = (nemotron_parse_invoke_url or invoke_url or "").strip()
+        self._invoke_url = str(nemotron_parse_invoke_url or "").strip() or str(invoke_url or "").strip()
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)
         self._task_prompt = str(task_prompt)

--- a/nemo_retriever/src/nemo_retriever/operators/extract/ocr/ocr.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/ocr/ocr.py
@@ -72,7 +72,7 @@ class OCRActor(ArchetypeOperator):
     @classmethod
     def prefers_cpu_variant(cls, operator_kwargs: dict[str, Any] | None = None) -> bool:
         kwargs = operator_kwargs or {}
-        return bool(str(kwargs.get("ocr_invoke_url") or kwargs.get("invoke_url") or "").strip())
+        return bool(str(kwargs.get("ocr_invoke_url") or "").strip() or str(kwargs.get("invoke_url") or "").strip())
 
     @classmethod
     def cpu_variant_class(cls):

--- a/nemo_retriever/src/nemo_retriever/operators/extract/page_elements/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/page_elements/cpu_actor.py
@@ -26,13 +26,12 @@ class PageElementDetectionCPUActor(AbstractOperator, CPUOperator):
     def __init__(self, **detect_kwargs: Any) -> None:
         super().__init__(**detect_kwargs)
         self.detect_kwargs = dict(detect_kwargs)
-        invoke_url = str(
-            self.detect_kwargs.get("page_elements_invoke_url")
-            or self.detect_kwargs.get("invoke_url")
+        invoke_url = (
+            str(self.detect_kwargs.get("page_elements_invoke_url") or "").strip()
+            or str(self.detect_kwargs.get("invoke_url") or "").strip()
             or self.DEFAULT_INVOKE_URL
-        ).strip()
-        if "invoke_url" not in self.detect_kwargs:
-            self.detect_kwargs["invoke_url"] = invoke_url
+        )
+        self.detect_kwargs["invoke_url"] = invoke_url
         self._model = None
         self._nim_client = NIMClient(
             max_pool_workers=int(self.detect_kwargs.get("remote_max_pool_workers", 24)),

--- a/nemo_retriever/src/nemo_retriever/operators/extract/page_elements/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/page_elements/gpu_actor.py
@@ -25,12 +25,12 @@ class PageElementDetectionActor(AbstractOperator, GPUOperator):
     def __init__(self, **detect_kwargs: Any) -> None:
         super().__init__(**detect_kwargs)
         self.detect_kwargs = dict(detect_kwargs)
-        invoke_url = str(
-            self.detect_kwargs.get("page_elements_invoke_url") or self.detect_kwargs.get("invoke_url") or ""
-        ).strip()
-        if invoke_url and "invoke_url" not in self.detect_kwargs:
-            self.detect_kwargs["invoke_url"] = invoke_url
+        invoke_url = (
+            str(self.detect_kwargs.get("page_elements_invoke_url") or "").strip()
+            or str(self.detect_kwargs.get("invoke_url") or "").strip()
+        )
         if invoke_url:
+            self.detect_kwargs["invoke_url"] = invoke_url
             self._model = None
             self._nim_client = NIMClient(
                 max_pool_workers=int(self.detect_kwargs.get("remote_max_pool_workers", 24)),

--- a/nemo_retriever/src/nemo_retriever/operators/extract/page_elements/page_elements.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/page_elements/page_elements.py
@@ -27,7 +27,9 @@ class PageElementDetectionActor(ArchetypeOperator):
     @classmethod
     def prefers_cpu_variant(cls, operator_kwargs: dict[str, Any] | None = None) -> bool:
         kwargs = operator_kwargs or {}
-        return bool(str(kwargs.get("page_elements_invoke_url") or kwargs.get("invoke_url") or "").strip())
+        return bool(
+            str(kwargs.get("page_elements_invoke_url") or "").strip() or str(kwargs.get("invoke_url") or "").strip()
+        )
 
     @classmethod
     def cpu_variant_class(cls):

--- a/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
@@ -326,7 +326,7 @@ def nemotron_parse_pages(
     if not isinstance(batch_df, pd.DataFrame):
         raise NotImplementedError("nemotron_parse_pages currently only supports pandas.DataFrame input.")
 
-    invoke_url = (invoke_url or kwargs.get("nemotron_parse_invoke_url") or "").strip()
+    invoke_url = str(invoke_url or "").strip() or str(kwargs.get("nemotron_parse_invoke_url") or "").strip()
     use_remote = bool(invoke_url)
     if not use_remote and model is None:
         raise ValueError("A local `model` is required when `invoke_url` is not provided.")
@@ -528,7 +528,7 @@ class NemotronParseGPUActor(AbstractOperator, GPUOperator):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self._invoke_url = (nemotron_parse_invoke_url or invoke_url or "").strip()
+        self._invoke_url = str(nemotron_parse_invoke_url or "").strip() or str(invoke_url or "").strip()
         self._nemotron_parse_model = nemotron_parse_model
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)
@@ -627,7 +627,9 @@ class NemotronParseCPUActor(AbstractOperator, CPUOperator):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self._invoke_url = (nemotron_parse_invoke_url or invoke_url or self.DEFAULT_INVOKE_URL).strip()
+        self._invoke_url = (
+            str(nemotron_parse_invoke_url or "").strip() or str(invoke_url or "").strip() or self.DEFAULT_INVOKE_URL
+        )
         self._nemotron_parse_model = nemotron_parse_model
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)
@@ -696,7 +698,9 @@ class NemotronParseActor(ArchetypeOperator):
     @classmethod
     def prefers_cpu_variant(cls, operator_kwargs: dict[str, Any] | None = None) -> bool:
         kwargs = operator_kwargs or {}
-        return bool(str(kwargs.get("nemotron_parse_invoke_url") or kwargs.get("invoke_url") or "").strip())
+        return bool(
+            str(kwargs.get("nemotron_parse_invoke_url") or "").strip() or str(kwargs.get("invoke_url") or "").strip()
+        )
 
     def __init__(
         self,

--- a/nemo_retriever/src/nemo_retriever/operators/extract/table/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/table/cpu_actor.py
@@ -45,8 +45,10 @@ class TableStructureCPUActor(AbstractOperator, CPUOperator):
     ) -> None:
         super().__init__()
         self._table_structure_invoke_url = (
-            table_structure_invoke_url or invoke_url or self.DEFAULT_TABLE_STRUCTURE_INVOKE_URL
-        ).strip()
+            str(table_structure_invoke_url or "").strip()
+            or str(invoke_url or "").strip()
+            or self.DEFAULT_TABLE_STRUCTURE_INVOKE_URL
+        )
         self._ocr_invoke_url = str(ocr_invoke_url or "").strip()
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)

--- a/nemo_retriever/src/nemo_retriever/operators/extract/table/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/table/gpu_actor.py
@@ -40,8 +40,10 @@ class TableStructureActor(AbstractOperator, GPUOperator):
         remote_max_429_retries: int = 5,
     ) -> None:
         super().__init__()
-        self._table_structure_invoke_url = (table_structure_invoke_url or invoke_url or "").strip()
-        self._ocr_invoke_url = (ocr_invoke_url or "").strip()
+        self._table_structure_invoke_url = (
+            str(table_structure_invoke_url or "").strip() or str(invoke_url or "").strip()
+        )
+        self._ocr_invoke_url = str(ocr_invoke_url or "").strip()
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)
         self._table_output_format = table_output_format

--- a/nemo_retriever/src/nemo_retriever/operators/extract/table/table_detection.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/table/table_detection.py
@@ -29,7 +29,9 @@ class TableStructureActor(ArchetypeOperator):
     @classmethod
     def prefers_cpu_variant(cls, operator_kwargs: dict[str, Any] | None = None) -> bool:
         kwargs = operator_kwargs or {}
-        return bool(str(kwargs.get("table_structure_invoke_url") or kwargs.get("invoke_url") or "").strip())
+        return bool(
+            str(kwargs.get("table_structure_invoke_url") or "").strip() or str(kwargs.get("invoke_url") or "").strip()
+        )
 
     @classmethod
     def cpu_variant_class(cls):

--- a/nemo_retriever/src/nemo_retriever/operators/extract/video/ocr_actor.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/video/ocr_actor.py
@@ -47,8 +47,8 @@ logger = logging.getLogger(__name__)
 
 
 def _ocr_invoke_url(ocr_kwargs: dict[str, Any]) -> str | None:
-    raw = ocr_kwargs.get("ocr_invoke_url") or ocr_kwargs.get("invoke_url")
-    return str(raw).strip() if raw else None
+    endpoint = str(ocr_kwargs.get("ocr_invoke_url") or "").strip() or str(ocr_kwargs.get("invoke_url") or "").strip()
+    return endpoint or None
 
 
 class VideoFrameOCRGPUActor(AbstractOperator, GPUOperator):

--- a/nemo_retriever/src/nemo_retriever/operators/rerank.py
+++ b/nemo_retriever/src/nemo_retriever/operators/rerank.py
@@ -85,6 +85,16 @@ def _default_rerank_invoke_url(model_name: str | None) -> str:
     return _DEFAULT_RERANK_INVOKE_URL
 
 
+def _configured_rerank_invoke_url(kwargs: dict[str, Any] | None) -> str:
+    """Return the configured endpoint, preferring ``rerank_invoke_url`` over its ``invoke_url`` alias.
+
+    Each candidate is stripped before the choice so a blank canonical value does
+    not shadow a usable alias.
+    """
+    candidates = kwargs or {}
+    return str(candidates.get("rerank_invoke_url") or "").strip() or str(candidates.get("invoke_url") or "").strip()
+
+
 # ---------------------------------------------------------------------------
 # Remote endpoint helper
 # ---------------------------------------------------------------------------
@@ -459,7 +469,7 @@ class NemotronRerankGPUActor(AbstractOperator, GPUOperator):
         super().__init__(**kwargs)
         self._kwargs = dict(kwargs)
 
-        if str(self._kwargs.get("rerank_invoke_url") or self._kwargs.get("invoke_url") or "").strip():
+        if _configured_rerank_invoke_url(self._kwargs):
             raise ValueError(
                 "NemotronRerankGPUActor does not support remote endpoint execution. Use NemotronRerankCPUActor instead."
             )
@@ -501,7 +511,7 @@ class NemotronRerankCPUActor(AbstractOperator, CPUOperator):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._kwargs = dict(kwargs)
-        configured_url = str(self._kwargs.get("rerank_invoke_url") or self._kwargs.get("invoke_url") or "").strip()
+        configured_url = _configured_rerank_invoke_url(self._kwargs)
         rerank_invoke_url = configured_url or _default_rerank_invoke_url(
             str(self._kwargs.get("model_name") or _DEFAULT_MODEL)
         )
@@ -544,8 +554,7 @@ class NemotronRerankActor(ArchetypeOperator):
 
     @classmethod
     def prefers_cpu_variant(cls, operator_kwargs: dict[str, Any] | None = None) -> bool:
-        kwargs = operator_kwargs or {}
-        return bool(str(kwargs.get("rerank_invoke_url") or kwargs.get("invoke_url") or "").strip())
+        return bool(_configured_rerank_invoke_url(operator_kwargs))
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/nemo_retriever/src/nemo_retriever/operators/rerank.py
+++ b/nemo_retriever/src/nemo_retriever/operators/rerank.py
@@ -12,7 +12,8 @@ Provides:
 Remote endpoint
 ---------------
 When ``rerank_invoke_url`` is set the actor/function calls a vLLM (>=0.14) or NIM
-server that exposes a ranking REST API. The helper accepts fully qualified
+server that exposes a ranking REST API. ``invoke_url`` is accepted as a
+compatibility alias (same pattern as OCR). The helper accepts fully qualified
 ``.../reranking``, ``.../v1/ranking``, or ``.../v1/rerank`` URLs. Other base
 URLs append ``/v1/ranking`` automatically::
 
@@ -458,7 +459,7 @@ class NemotronRerankGPUActor(AbstractOperator, GPUOperator):
         super().__init__(**kwargs)
         self._kwargs = dict(kwargs)
 
-        if str(self._kwargs.get("rerank_invoke_url") or "").strip():
+        if str(self._kwargs.get("rerank_invoke_url") or self._kwargs.get("invoke_url") or "").strip():
             raise ValueError(
                 "NemotronRerankGPUActor does not support remote endpoint execution. Use NemotronRerankCPUActor instead."
             )
@@ -500,7 +501,7 @@ class NemotronRerankCPUActor(AbstractOperator, CPUOperator):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._kwargs = dict(kwargs)
-        configured_url = str(self._kwargs.get("rerank_invoke_url") or "").strip()
+        configured_url = str(self._kwargs.get("rerank_invoke_url") or self._kwargs.get("invoke_url") or "").strip()
         rerank_invoke_url = configured_url or _default_rerank_invoke_url(
             str(self._kwargs.get("model_name") or _DEFAULT_MODEL)
         )
@@ -544,7 +545,7 @@ class NemotronRerankActor(ArchetypeOperator):
     @classmethod
     def prefers_cpu_variant(cls, operator_kwargs: dict[str, Any] | None = None) -> bool:
         kwargs = operator_kwargs or {}
-        return bool(str(kwargs.get("rerank_invoke_url") or "").strip())
+        return bool(str(kwargs.get("rerank_invoke_url") or kwargs.get("invoke_url") or "").strip())
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/nemo_retriever/tests/test_invoke_url_alias_precedence.py
+++ b/nemo_retriever/tests/test_invoke_url_alias_precedence.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from nemo_retriever.operators.extract.ocr.gpu_ocr import OCRActor as OCRGPUActor
+from nemo_retriever.operators.extract.ocr.ocr import OCRActor
+from nemo_retriever.operators.extract.page_elements.gpu_actor import PageElementDetectionActor as PageElementsGPUActor
+from nemo_retriever.operators.extract.page_elements.page_elements import PageElementDetectionActor
+from nemo_retriever.operators.extract.parse.nemotron_parse import NemotronParseActor
+from nemo_retriever.operators.extract.table.table_detection import TableStructureActor
+
+
+def test_ocr_blank_canonical_does_not_shadow_alias() -> None:
+    kwargs = {"ocr_invoke_url": "   ", "invoke_url": "http://localhost:8000"}
+    assert OCRActor.prefers_cpu_variant(kwargs) is True
+    assert OCRActor.prefers_cpu_variant({"ocr_invoke_url": "   "}) is False
+
+
+def test_ocr_canonical_endpoint_replaces_blank_alias_for_delegate() -> None:
+    actor = OCRGPUActor(ocr_invoke_url="http://canonical", invoke_url="   ")
+    assert actor.ocr_kwargs["invoke_url"] == "http://canonical"
+    assert actor._model is None
+
+
+def test_page_elements_blank_canonical_does_not_shadow_alias() -> None:
+    kwargs = {"page_elements_invoke_url": "   ", "invoke_url": "http://localhost:8000"}
+    assert PageElementDetectionActor.prefers_cpu_variant(kwargs) is True
+
+
+def test_page_elements_canonical_endpoint_replaces_conflicting_alias_for_delegate() -> None:
+    actor = PageElementsGPUActor(page_elements_invoke_url="http://canonical", invoke_url="http://alias")
+    assert actor.detect_kwargs["invoke_url"] == "http://canonical"
+    assert actor._model is None
+
+
+def test_table_structure_blank_canonical_does_not_shadow_alias() -> None:
+    kwargs = {"table_structure_invoke_url": "   ", "invoke_url": "http://localhost:8000"}
+    assert TableStructureActor.prefers_cpu_variant(kwargs) is True
+
+
+def test_nemotron_parse_blank_canonical_does_not_shadow_alias() -> None:
+    kwargs = {"nemotron_parse_invoke_url": "   ", "invoke_url": "http://localhost:8000"}
+    assert NemotronParseActor.prefers_cpu_variant(kwargs) is True

--- a/nemo_retriever/tests/test_nemotron_rerank_v2.py
+++ b/nemo_retriever/tests/test_nemotron_rerank_v2.py
@@ -625,6 +625,24 @@ class TestNemotronRerankActor:
 
         assert actor._kwargs["rerank_invoke_url"] == "http://canonical:8015"
 
+    def test_blank_canonical_endpoint_does_not_shadow_alias(self):
+        """A whitespace-only canonical value must not hide a usable alias."""
+        from nemo_retriever.operators.rerank import NemotronRerankActor, NemotronRerankCPUActor
+
+        kwargs = {"rerank_invoke_url": "   ", "invoke_url": "http://localhost:8015"}
+
+        assert NemotronRerankActor.prefers_cpu_variant(kwargs) is True
+        assert NemotronRerankCPUActor(**kwargs)._kwargs["rerank_invoke_url"] == "http://localhost:8015"
+
+    def test_gpu_actor_rejects_blank_canonical_endpoint_with_alias(self):
+        from nemo_retriever.operators.rerank import NemotronRerankGPUActor
+
+        with patch("nemo_retriever.models.create_local_reranker") as create_local_reranker:
+            with pytest.raises(ValueError, match="does not support remote endpoint"):
+                NemotronRerankGPUActor(rerank_invoke_url="   ", invoke_url="http://localhost:8015")
+
+        create_local_reranker.assert_not_called()
+
     def test_archetype_selects_remote_variant_for_invoke_url_alias(self):
         from nemo_retriever.operators.rerank import NemotronRerankActor, NemotronRerankCPUActor
 

--- a/nemo_retriever/tests/test_nemotron_rerank_v2.py
+++ b/nemo_retriever/tests/test_nemotron_rerank_v2.py
@@ -607,6 +607,44 @@ class TestNemotronRerankActor:
         assert actor._model is None
         assert actor._kwargs.get("rerank_invoke_url") == "http://localhost:8000"
 
+    def test_cpu_actor_accepts_invoke_url_alias(self):
+        from nemo_retriever.operators.rerank import NemotronRerankCPUActor
+
+        actor = NemotronRerankCPUActor(invoke_url="http://localhost:8015")
+
+        assert actor._model is None
+        assert actor._kwargs["rerank_invoke_url"] == "http://localhost:8015"
+
+    def test_cpu_actor_prefers_canonical_endpoint_key_over_alias(self):
+        from nemo_retriever.operators.rerank import NemotronRerankCPUActor
+
+        actor = NemotronRerankCPUActor(
+            rerank_invoke_url="http://canonical:8015",
+            invoke_url="http://alias:8015",
+        )
+
+        assert actor._kwargs["rerank_invoke_url"] == "http://canonical:8015"
+
+    def test_archetype_selects_remote_variant_for_invoke_url_alias(self):
+        from nemo_retriever.operators.rerank import NemotronRerankActor, NemotronRerankCPUActor
+
+        actor = NemotronRerankActor(invoke_url="http://localhost:8015")
+        delegate = actor._resolve_delegate()
+
+        assert NemotronRerankActor.prefers_cpu_variant({"invoke_url": "http://localhost:8015"}) is True
+        assert NemotronRerankActor.prefers_cpu_variant({"invoke_url": "   "}) is False
+        assert isinstance(delegate, NemotronRerankCPUActor)
+        assert delegate._kwargs["rerank_invoke_url"] == "http://localhost:8015"
+
+    def test_gpu_actor_rejects_invoke_url_alias_without_loading_local_model(self):
+        from nemo_retriever.operators.rerank import NemotronRerankGPUActor
+
+        with patch("nemo_retriever.models.create_local_reranker") as create_local_reranker:
+            with pytest.raises(ValueError, match="does not support remote endpoint"):
+                NemotronRerankGPUActor(invoke_url="http://localhost:8015")
+
+        create_local_reranker.assert_not_called()
+
     def test_actor_call_scores_dataframe(self):
         import pandas as pd
         from nemo_retriever.operators.rerank import NemotronRerankActor

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 
 from nemo_retriever.graph.retriever import Retriever
+from nemo_retriever.operators.abstract_operator import AbstractOperator
 from nemo_retriever.query.shaping import shape_query_hits
 
 
@@ -326,6 +327,72 @@ class TestQueriesGraphExecution:
     def test_candidate_k_must_cover_top_k(self) -> None:
         with pytest.raises(ValueError, match=r"candidate_k \(2\).*top_k \(5\)"):
             _make_retriever(top_k=5).queries(["q"], candidate_k=2)
+
+
+class TestRerankEndpointWiring:
+    """A reranker endpoint set through ``rerank_kwargs`` must be the one that serves the request.
+
+    ``NemotronRerankActor`` dispatches on ``rerank_invoke_url``; an endpoint
+    stored under any other key leaves the remote variant unselected and loads a
+    local reranker instead.
+    """
+
+    @staticmethod
+    def _build_graph(monkeypatch: pytest.MonkeyPatch, rerank_kwargs: dict[str, Any]) -> Any:
+        """Build the default graph with only the rerank stage kept real."""
+
+        class _PassthroughOperator(AbstractOperator):
+            def preprocess(self, data: Any, **kwargs: Any) -> Any:
+                return data
+
+            def process(self, data: Any, **kwargs: Any) -> Any:
+                return data
+
+            def postprocess(self, data: Any, **kwargs: Any) -> Any:
+                return data
+
+        monkeypatch.setattr(
+            "nemo_retriever.operators.embed.operators._BatchEmbedActor",
+            _PassthroughOperator,
+        )
+        monkeypatch.setattr(
+            "nemo_retriever.graph.retriever.RetrieveVdbOperator",
+            _PassthroughOperator,
+        )
+        retriever = _make_retriever(rerank=True, rerank_kwargs=rerank_kwargs)
+        return retriever._build_default_graph()
+
+    @staticmethod
+    def _rerank_node(graph: Any) -> Any:
+        node = graph.roots[0]
+        while node.children:
+            node = node.children[0]
+        return node
+
+    @pytest.mark.parametrize("endpoint_key", ["rerank_invoke_url", "invoke_url"])
+    def test_configured_endpoint_selects_remote_reranker(
+        self, monkeypatch: pytest.MonkeyPatch, endpoint_key: str
+    ) -> None:
+        from nemo_retriever.operators.rerank import NemotronRerankActor, NemotronRerankCPUActor
+
+        graph = self._build_graph(monkeypatch, {endpoint_key: "http://localhost:8015", "refine_factor": 4})
+        node = self._rerank_node(graph)
+
+        assert isinstance(node.operator, NemotronRerankActor)
+        assert NemotronRerankActor.prefers_cpu_variant(node.operator_kwargs) is True
+
+        delegate = node.operator._resolve_delegate()
+        assert isinstance(delegate, NemotronRerankCPUActor)
+        assert delegate._kwargs["rerank_invoke_url"] == "http://localhost:8015"
+
+    def test_absent_endpoint_still_reranks_locally(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nemo_retriever.operators.rerank import NemotronRerankActor
+
+        graph = self._build_graph(monkeypatch, {"local_reranker_backend": "hf"})
+        node = self._rerank_node(graph)
+
+        assert node.operator_kwargs.get("rerank_invoke_url") is None
+        assert NemotronRerankActor.prefers_cpu_variant(node.operator_kwargs) is False
 
 
 class TestRetrieverDefaults:


### PR DESCRIPTION
## Description
- closes this gap: public `Retriever` docs showed `invoke_url`, which the operator ignored and fell back to a local reranker.
- Keep `rerank_invoke_url` as the one real name (same pattern as OCR's `ocr_invoke_url` / `invoke_url` alias). Normalize `invoke_url` → `rerank_invoke_url` in the rerank operator so SDK, CLI, agentic, and direct actor construction all behave the same.
- Update `retriever.md` to document the canonical key, with `invoke_url` noted as a compatibility alias. Add regression coverage for both spellings on the public SDK path.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
