### PR TITLE
Pin library BEIR runfiles to VL embedder

### DIFF
--- a/nemo_retriever/harness/runfiles/bo767_beir.json
+++ b/nemo_retriever/harness/runfiles/bo767_beir.json
@@ -8,5 +8,8 @@
     "pages==54730",
     "query_count==991"
   ],
-  "set": {}
+  "set": {
+    "ingest.embed.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
+    "query.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2"
+  }
 }

--- a/nemo_retriever/harness/runfiles/earnings_beir.json
+++ b/nemo_retriever/harness/runfiles/earnings_beir.json
@@ -8,5 +8,8 @@
     "pages==12988",
     "query_count==628"
   ],
-  "set": {}
+  "set": {
+    "ingest.embed.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
+    "query.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2"
+  }
 }

--- a/nemo_retriever/harness/runfiles/financebench_beir.json
+++ b/nemo_retriever/harness/runfiles/financebench_beir.json
@@ -8,5 +8,8 @@
     "pages==54057",
     "query_count==150"
   ],
-  "set": {}
+  "set": {
+    "ingest.embed.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
+    "query.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2"
+  }
 }

--- a/nemo_retriever/harness/runfiles/jp20_beir.json
+++ b/nemo_retriever/harness/runfiles/jp20_beir.json
@@ -8,5 +8,8 @@
     "pages==1940",
     "query_count==115"
   ],
-  "set": {}
+  "set": {
+    "ingest.embed.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
+    "query.embed_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2"
+  }
 }


### PR DESCRIPTION
## Summary

Pins the JP20, Earnings, FinanceBench, and BO767 library harness runfiles to `nvidia/llama-nemotron-embed-vl-1b-v2` for both ingest and query.

## Why

These runfiles are thin selectors whose library-mode settings resolve through the benchmark registry. The registry default is still the text-only embedder, so the affected library runs did not match the VL-pinned NRB configuration.

## Scope

Adds explicit `set` overrides in the four affected runfiles. It does not change global registry defaults or unrelated benchmarks.

## Validation

- `nemo_retriever/.venv/bin/python -m pytest nemo_retriever/tests/test_harness_benchmark_registry.py -q` (17 passed)
- Resolved each changed runfile and verified that both `ingest.embed.embed_model_name` and `query.embed_model_name` are `nvidia/llama-nemotron-embed-vl-1b-v2`.
- Validated all four edited JSON files and ran `git diff --check`.
