### PR TITLE
fix: support optional Nemotron Parse v2

### DIFF
--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -110,7 +110,7 @@ The production Helm chart reconciles NIM microservices through `nimOperator.<key
 | `ocr` | [nemotron-ocr-v2](https://build.nvidia.com/nvidia/nemotron-ocr-v2) | `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` | Image OCR | Yes |
 | `vlm_embed` | [llama-nemotron-embed-vl-1b-v2](https://build.nvidia.com/nvidia/llama-nemotron-embed-vl-1b-v2) | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0` | Multimodal (VL) embedding | Yes |
 | `rerankqa` | [llama-nemotron-rerank-vl-1b-v2](https://build.nvidia.com/nvidia/llama-nemotron-rerank-vl-1b-v2) | `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0` | Reranking for improved retrieval accuracy | No |
-| `nemotron_parse` | [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) | `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant` | Optional PDF `method="nemotron_parse"` (default PDF extraction uses **pdfium**) | No |
+| `nemotron_parse` | [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) | `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant` | Optional PDF `method="nemotron_parse"` (default PDF extraction uses **pdfium**). You can select Parse v2.0 with an image override. | No |
 | `nemotron_3_nano_omni_30b_a3b_reasoning` | [nemotron-3-nano-omni-30b-a3b-reasoning](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) | `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` | Image captioning when you enable the caption stage | No |
 | `audio` | [parakeet-1-1b-ctc-en-us](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/index.html) | `nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0` | [Audio and video](audio-video.md) transcription | No |
 | `answer_llm` | [llama-3.3-nemotron-super-49b-v1.5](https://build.nvidia.com/nvidia/llama-3.3-nemotron-super-49b-v1.5) | `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5` | Optional `/v1/answer` generation LLM (not part of the default extraction pipeline) | No |
@@ -149,21 +149,24 @@ When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-host
 | nemotron-ocr-v2 | `https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v2` | Chart default OCR SKU; library CPU actors default to this URL when no OCR invoke URL is set. **Local OCR language selectors (`--ocr-lang`, API `ocr_lang`) are not sent on remote requests** — hosted OCR v2 uses its own language behavior |
 | llama-nemotron-embed-vl-1b-v2 | `https://integrate.api.nvidia.com/v1/embeddings` with model ID `nvidia/llama-nemotron-embed-vl-1b-v2` | Core multimodal embedding |
 | llama-nemotron-rerank-vl-1b-v2 | `https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking` | Optional VL reranker |
-| nemotron-parse | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/nemotron-parse` | Optional `method="nemotron_parse"`. Hosted Build and self-hosted `nemotron-parse-v1.2` use different request contracts; the library selects the matching contract automatically. Refer to [Nemotron Parse: hosted Build endpoint vs self-hosted NIM](#nemotron-parse-hosted-vs-self-hosted) |
+| nemotron-parse | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/nemotron-parse` | Optional `method="nemotron_parse"`. Hosted Build, self-hosted Parse v1.2, and self-hosted Parse v2.0 use different request contracts. Refer to [Nemotron Parse: hosted Build endpoint vs self-hosted NIM](#nemotron-parse-hosted-vs-self-hosted) |
 | nemotron-3-nano-omni-30b-a3b-reasoning | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Optional image captioning |
 | llama-3.3-nemotron-super-49b-v1.5 | `https://integrate.api.nvidia.com/v1/chat/completions` with model ID `nvidia/llama-3.3-nemotron-super-49b-v1.5` | Optional `/v1/answer` (Helm `answer_llm`) and OpenAI-compatible agentic RAG endpoint mode; not part of the default extraction pipeline. Agentic query/harness runs default to local in-process vLLM instead. Helm auto-wires to the in-cluster NIM when `nimOperator.answer_llm` is enabled |
 | parakeet-1-1b-ctc-en-us | `grpc.nvcf.nvidia.com:443` (function ID from [build.nvidia.com](https://build.nvidia.com/)) | Optional ASR; refer to [Parakeet hosted inference](audio-video.md#parakeet-hosted-inference-build-nvidia) |
 
 <a id="nemotron-parse-hosted-vs-self-hosted"></a>
 
-!!! note "Nemotron Parse: hosted Build endpoint vs self-hosted NIM"
+!!! note "Nemotron Parse: hosted Build and self-hosted NIM contracts"
 
-    Hosted NVIDIA Build and self-hosted Nemotron Parse use **different request contracts**. The library selects the matching contract from the endpoint and model:
+    NVIDIA Build and self-hosted Nemotron Parse use distinct request contracts:
 
     - **Hosted Build** (`https://integrate.api.nvidia.com/v1/chat/completions`) resolves to model ID `nvidia/nemotron-parse` and uses an image-only tool-call contract.
-    - **Self-hosted chat endpoints** default to model ID `nvidia/nemotron-parse-v1.2` and use the tagged text-prompt contract.
+    - **Self-hosted Parse v1.2** uses `nvidia/nemotron-parse-v1.2` and the tagged text-prompt contract. The Helm chart defaults to `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant`.
+    - **Self-hosted Parse v2.0** uses `nvidia/nemotron-parse-v2.0` and its v2.0 contract. It is an optional Helm image override, not the chart default.
 
-    To use hosted Build, set `nemotron_parse_invoke_url` to the Build chat-completions URL (and set `method="nemotron_parse"`). You can normally omit `nemotron_parse_model` so the library selects the model automatically. If you set `nemotron_parse_model` explicitly, it must match the endpoint contract. Mixed Build and self-hosted endpoint lists require an explicit model.
+    To use hosted Build, set `nemotron_parse_invoke_url` to the Build chat-completions URL and set `method="nemotron_parse"`. You can normally omit `nemotron_parse_model` so the library selects the model automatically. If you set `nemotron_parse_model` explicitly, it must match the endpoint contract. Mixed Build and self-hosted endpoint lists require an explicit model.
+
+    When the chart manages the Parse NIM, it wires the model that matches the selected v1.2 or v2.0 image. To select Parse v2.0, enable Parse and set `nimOperator.nemotron_parse.image.repository=nvcr.io/nim/nvidia/nemotron-parse-v2.0` and `nimOperator.nemotron_parse.image.tag=2.0.8-variant`. For a direct external v2.0 endpoint, set `nemotron_parse_model="nvidia/nemotron-parse-v2.0"` explicitly with its invoke URL.
 
     For model/endpoint mismatch symptoms, refer to [Nemotron Parse model and endpoint mismatch](troubleshoot.md#nemotron-parse-model-endpoint-mismatch).
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -264,9 +264,9 @@ When you run PDF extraction with `method="nemotron_parse"`, a mismatched model a
 HTTP 400: Content cannot be a plain string. The model does not support text input.
 ```
 
-This can occur when you send a tagged or versioned `v1.2` model (for example `nvidia/nemotron-parse-v1.2`) to the NVIDIA-hosted Build endpoint, which expects the image-only `nvidia/nemotron-parse` contract. The library may replace the raw HTTP error with a targeted model/contract mismatch hint.
+This can occur when you send a versioned self-hosted model (for example `nvidia/nemotron-parse-v1.2` or `nvidia/nemotron-parse-v2.0`) to the NVIDIA-hosted Build endpoint, which expects the image-only `nvidia/nemotron-parse` contract. It can also occur when the selected self-hosted Parse image and configured model use different versions. The library may replace the raw HTTP error with a targeted model/contract mismatch hint.
 
-To use hosted Build, omit `nemotron_parse_model` so the library selects `nvidia/nemotron-parse` automatically, or set `nemotron_parse_model="nvidia/nemotron-parse"` explicitly. Send versioned `v1.2` models only to a compatible self-hosted chat endpoint. For more information, refer to [Nemotron Parse: hosted Build endpoint vs self-hosted NIM](prerequisites-support-matrix.md#nemotron-parse-hosted-vs-self-hosted).
+To use hosted Build, omit `nemotron_parse_model` so the library selects `nvidia/nemotron-parse` automatically, or set `nemotron_parse_model="nvidia/nemotron-parse"` explicitly. Send `nvidia/nemotron-parse-v1.2` or `nvidia/nemotron-parse-v2.0` only to its matching self-hosted chat endpoint. For direct external Parse v2.0 endpoints, set `nemotron_parse_model="nvidia/nemotron-parse-v2.0"` explicitly. For more information, refer to [Nemotron Parse: hosted Build and self-hosted NIM contracts](prerequisites-support-matrix.md#nemotron-parse-hosted-vs-self-hosted).
 
 ## Hosted Page Elements NIM image size limits { #hosted-page-elements-nim-image-size-limits }
 

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -313,6 +313,29 @@ helm install retriever ./nemo_retriever/helm \
 >
 > This matches the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md) and avoids silently pulling ≈ 62 GiB of Omni weights, loading a large two-GPU LLM, or claiming extra dedicated GPUs on a "default" install. Refer to the [model hardware requirements](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#model-hardware-requirements) table for per-NIM GPU and disk costs.
 
+### Nemotron Parse (optional)
+
+Enable `nimOperator.nemotron_parse` to use `method="nemotron_parse"`. The
+default self-hosted image is `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant`.
+The chart wires its matching `nvidia/nemotron-parse-v1.2` model into the
+retriever service.
+
+To deploy the optional Parse v2.0 NIM instead, override both image fields:
+
+```bash
+helm upgrade --install retriever ./nemo_retriever/helm \
+  --set nimOperator.nemotron_parse.enabled=true \
+  --set nimOperator.nemotron_parse.image.repository=nvcr.io/nim/nvidia/nemotron-parse-v2.0 \
+  --set nimOperator.nemotron_parse.image.tag=2.0.8-variant
+```
+
+With this override, the chart wires `nvidia/nemotron-parse-v2.0` into the
+retriever service. Do not set `serviceConfig.nimEndpoints.nemotronParseModel`
+unless you need a custom model value; an explicit service value takes precedence
+over the image-selected model. For direct external Parse v2.0 endpoints, set
+`nemotron_parse_model="nvidia/nemotron-parse-v2.0"` in the SDK extraction
+configuration.
+
 The chart auto-wires the operator-managed in-cluster URLs of the three
 "core" NIMs into the service's `nim_endpoints` block:
 
@@ -611,7 +634,7 @@ gated on three conditions ALL holding:
 | `nimOperator.vlm_embed.image`          | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0` | Default VLM embed NIM image. |
 | `nimOperator.rerankqa.enabled`         | `false` | VL reranker NIM (optional; not auto-wired). Set `true` to opt in. Default `false` so chart installs honor the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md) and do not silently provision an extra ≈ 3.1 GiB GPU NIM. The image points at the **VL** SKU (`llama-nemotron-rerank-vl-1b-v2`) per [prerequisites-support-matrix.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#default-helm-nims) — the text-only `llama-nemotron-rerank-1b-v2` silently degrades multimodal reranking and is not the documented POR. |
 | `nimOperator.rerankqa.image`           | `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0` | Default optional VL reranker NIM image. |
-| `nimOperator.nemotron_parse.enabled`   | `false` | Structured-parse NIM (optional). Set `true` when using `method="nemotron_parse"`. Default `false` so chart installs honor the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md). Image tag follows the [image tag conventions](#image-tag-conventions). |
+| `nimOperator.nemotron_parse.enabled`   | `false` | Structured-parse NIM (optional). Set `true` when using `method="nemotron_parse"`. Default `false` so chart installs honor the "optional and disabled by default" contract in [deployment-options.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md). The default image is Parse v1.2; you can select Parse v2.0 with its documented image override. Image tags follow the [image tag conventions](#image-tag-conventions). |
 | `nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled` | `false` | Omni 30B caption NIM (optional). Set `true` to enable image captioning — refer to [Image captioning (Omni 30B)](#image-captioning-omni-30b). Default `false` so chart installs do not silently pull ≈ 62 GiB of BF16 weights or claim a second dedicated GPU. Image tag follows the [image tag conventions](#image-tag-conventions). |
 | `nimOperator.answer_llm.enabled`       | `false` | Generic answer-generation LLM NIM (optional; Super-49B defaults). Set `true` to enable `/v1/answer` — refer to [Answer generation (operator-managed LLM)](#answer-generation-llm). Default `false` so installs do not silently claim answer-generation GPUs. |
 | `nimOperator.answer_llm.model`         | `openai/nvidia/llama-3.3-nemotron-super-49b-v1.5` | LiteLLM/OpenAI model id inherited by `serviceConfig.llm.model` when the operator-managed answer LLM is enabled and no explicit service model is set. |

--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -46,6 +46,20 @@ inherits the NIMService resource name, so the mapping is fixed:
 {{- $ocrURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "ocr" "serviceName" $ctx.Values.nimOperator.ocr.nimServiceName "configKey" "ocrInvokeUrl" "invokePath" "/v1/ocr") -}}
 {{- $nemotronParseURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "nemotron_parse" "serviceName" "nemotron-parse" "configKey" "nemotronParseInvokeUrl" "invokePath" "/v1/chat/completions") -}}
 {{- $nemotronParseModel := $ctx.Values.serviceConfig.nimEndpoints.nemotronParseModel | default "" -}}
+{{- /*
+  When the chart auto-wires the operator-managed Parse NIM, derive the
+  matching model id from its SKU. Explicit endpoint/model settings keep
+  their existing precedence, and unknown image names retain the previous
+  URL-only behavior for custom deployments.
+*/}}
+{{- if and (not $nemotronParseModel) (not $ctx.Values.serviceConfig.nimEndpoints.nemotronParseInvokeUrl) $nemotronParseURL -}}
+{{- $parseRepository := $ctx.Values.nimOperator.nemotron_parse.image.repository | default "" -}}
+{{- if regexMatch "(^|/)nemotron-parse-v1\\.2$" $parseRepository -}}
+{{- $nemotronParseModel = "nvidia/nemotron-parse-v1.2" -}}
+{{- else if regexMatch "(^|/)nemotron-parse-v2\\.0$" $parseRepository -}}
+{{- $nemotronParseModel = "nvidia/nemotron-parse-v2.0" -}}
+{{- end -}}
+{{- end -}}
 {{- $embedURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "vlm_embed" "serviceName" $ctx.Values.nimOperator.vlm_embed.nimServiceName "configKey" "embedInvokeUrl" "invokePath" "/v1/embeddings") -}}
 {{- $captionURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "nemotron_3_nano_omni_30b_a3b_reasoning" "serviceName" "nemotron-3-nano-omni-30b-a3b-reasoning" "configKey" "captionInvokeUrl" "invokePath" "/v1/chat/completions") -}}
 {{- /*

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -552,8 +552,9 @@ serviceConfig:
     # operator-managed Parse NIM is enabled, its in-cluster URL is used
     # unless this explicit endpoint is set.
     nemotronParseInvokeUrl: ""
-    # Optional model override. Leave empty to infer the hosted
-    # nvidia/nemotron-parse or self-hosted v1.2 contract from the URL.
+    # Optional model override. Leave empty to infer the operator-managed
+    # Parse v1.2 or v2.0 model from its image repository. For external
+    # endpoints, set the matching model explicitly.
     nemotronParseModel: ""
     embedInvokeUrl: ""
     # Optional remote reranking endpoint used by POST /v1/query with
@@ -1033,7 +1034,7 @@ nimOperator:
   #   Optional (enabled: false by default, NOT auto-wired):
   #     - rerankqa                                 (VL reranker,
   #                                                 ≈ 3.1 GiB GPU)
-  #     - nemotron_parse                           (Parse v1.2, ≈ 3.5 GiB GPU)
+  #     - nemotron_parse                           (Parse v1.2 by default, ≈ 3.5 GiB GPU)
   #     - nemotron_3_nano_omni_30b_a3b_reasoning   (Omni 30B caption NIM,
   #                                                 ≈ 62 GiB BF16 weights)
   #     - answer_llm                               (OpenAI-compatible answer LLM,

--- a/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Nemotron Parse v1.2 pipeline stage.
+Nemotron Parse v1.2 and v2.0 pipeline stage.
 
 Runs the Nemotron Parse model on full page images to extract structured
 document content (text, tables, charts, infographics) in a single pass,
@@ -20,7 +20,6 @@ from urllib.parse import urlsplit
 import base64
 import io
 import json
-import re
 import time
 import traceback
 
@@ -50,6 +49,7 @@ except Exception:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 NEMOTRON_PARSE_REMOTE_DEFAULT_MODEL = "nvidia/nemotron-parse-v1.2"
+NEMOTRON_PARSE_V2_MODEL = "nvidia/nemotron-parse-v2.0"
 NEMOTRON_PARSE_HOSTED_MODEL = "nvidia/nemotron-parse"
 NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL = "nvidia/NVIDIA-Nemotron-Parse-v1.2"
 NEMOTRON_PARSE_DEFAULT_TASK_PROMPT = "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>"
@@ -153,8 +153,8 @@ def _route_parsed_elements(
 
 class _NemotronParseContractProfile(str, Enum):
     HOSTED_TOOL_CALL = "hosted_tool_call"
-    LEGACY_TOOL_CALL = "legacy_tool_call"
     V1_2_TAGGED = "v1_2_tagged"
+    V2_0_TAGGED = "v2_0_tagged"
 
 
 @dataclass(frozen=True)
@@ -165,15 +165,7 @@ class _ResolvedNemotronParseContract:
 
     @property
     def uses_tool_call_routing(self) -> bool:
-        return self.profile in {
-            _NemotronParseContractProfile.HOSTED_TOOL_CALL,
-            _NemotronParseContractProfile.LEGACY_TOOL_CALL,
-        }
-
-
-def _is_legacy_nemotron_parse_model(model_name: str) -> bool:
-    normalized = model_name.lower()
-    return bool(re.search(r"v1[._][01](?!\d)", normalized))
+        return self.profile == _NemotronParseContractProfile.HOSTED_TOOL_CALL
 
 
 def _is_nvidia_build_endpoint(invoke_url: str) -> bool:
@@ -204,8 +196,8 @@ def _resolve_nemotron_parse_contract(
     normalized_model = resolved_model.lower()
     if normalized_model == NEMOTRON_PARSE_HOSTED_MODEL:
         profile = _NemotronParseContractProfile.HOSTED_TOOL_CALL
-    elif _is_legacy_nemotron_parse_model(normalized_model):
-        profile = _NemotronParseContractProfile.LEGACY_TOOL_CALL
+    elif normalized_model == NEMOTRON_PARSE_V2_MODEL:
+        profile = _NemotronParseContractProfile.V2_0_TAGGED
     else:
         profile = _NemotronParseContractProfile.V1_2_TAGGED
 
@@ -223,7 +215,7 @@ def _route_tool_call_elements(
     extract_charts: bool,
     extract_infographics: bool,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], Optional[str]]:
-    """Route hosted or legacy tool-call JSON into pipeline content channels."""
+    """Route NVIDIA Build tool-call JSON into pipeline content channels."""
 
     try:
         parsed = json.loads(raw_json_text)
@@ -309,7 +301,7 @@ def nemotron_parse_pages(
     nim_client: NIMClient | None = None,
     **kwargs: Any,
 ) -> Any:
-    """Run Nemotron Parse v1.2 on full page images.
+    """Run Nemotron Parse v1.2 or v2.0 on full page images.
 
     Each page is parsed in a single model call.  The structured output is
     split by element class (Text, Table, Chart, Picture, …) and routed to
@@ -377,8 +369,13 @@ def nemotron_parse_pages(
                     contract = _resolve_nemotron_parse_contract(invoke_url, nemotron_parse_model)
                     uses_tool_call_routing = contract.uses_tool_call_routing
                     extra_body: Dict[str, Any] = {"max_tokens": 8192}
-                    if contract.profile == _NemotronParseContractProfile.LEGACY_TOOL_CALL:
-                        extra_body["tools"] = [{"type": "function", "function": {"name": "markdown_bbox"}}]
+                    if contract.profile == _NemotronParseContractProfile.V2_0_TAGGED:
+                        # Parse 2.0 NIMs require their documented decoding options.
+                        extra_body = {
+                            "max_tokens": 9000,
+                            "top_k": 1,
+                            "skip_special_tokens": False,
+                        }
                     _chat_kw = dict(
                         invoke_url=invoke_url,
                         image_b64_list=batch_images,
@@ -419,7 +416,7 @@ def nemotron_parse_pages(
                         )
                     raw_texts = [_extract_parse_text(item) for item in response_items]
             else:
-                # Local vLLM model (v1.2): uses task_prompt, returns tagged text.
+                # Local vLLM Parse model: uses task_prompt and returns tagged text.
                 invoke_batch = getattr(model, "invoke_batch", None)
                 if invoke_batch is not None:
                     raw_texts = [str(t or "").strip() for t in invoke_batch(batch_images, task_prompt=task_prompt)]
@@ -430,15 +427,19 @@ def nemotron_parse_pages(
                 contract is not None
                 and nemotron_parse_model
                 and contract.has_build_endpoint
-                and contract.profile == _NemotronParseContractProfile.V1_2_TAGGED
+                and contract.profile
+                in {
+                    _NemotronParseContractProfile.V1_2_TAGGED,
+                    _NemotronParseContractProfile.V2_0_TAGGED,
+                }
                 and "text input" in str(e).lower()
             ):
                 hint = ValueError(
                     "Nemotron Parse model/contract mismatch: NVIDIA Build model "
                     "`nvidia/nemotron-parse` uses an image-only tool-call contract, but "
-                    f"`{contract.model}` selected the v1.2 text-control-token contract. "
+                    f"`{contract.model}` selected a tagged text-control-token contract. "
                     "Use `nemotron_parse_model='nvidia/nemotron-parse'` with Build, or send "
-                    "the versioned v1.2 model to a compatible self-hosted endpoint."
+                    "the versioned Parse model to a compatible self-hosted endpoint."
                 )
                 hint.__cause__ = e
                 e = hint

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -165,7 +165,8 @@ class NimEndpointsConfig(RichModel):
         description=(
             "Model identifier passed to the remote Nemotron Parse endpoint. "
             "Use nvidia/nemotron-parse for NVIDIA-hosted inference and "
-            "nvidia/nemotron-parse-v1.2 for a self-hosted NIM. "
+            "nvidia/nemotron-parse-v1.2 for the default self-hosted NIM, or "
+            "nvidia/nemotron-parse-v2.0 for an explicitly selected Parse 2.0 NIM. "
             "Server-owned — clients cannot override the deployed Parse SKU."
         ),
     )

--- a/nemo_retriever/tests/test_actor_operators.py
+++ b/nemo_retriever/tests/test_actor_operators.py
@@ -445,8 +445,12 @@ class TestNemotronParseActor:
         assert client.kwargs["extra_body"] == {"max_tokens": 8192}
         assert client.kwargs["repetition_penalty"] == 1.1
 
-    def test_remote_chat_completions_supports_legacy_tool_call_protocol(self):
-        from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
+    def test_remote_chat_completions_uses_v2_protocol(self):
+        from nemo_retriever.operators.extract.parse.nemotron_parse import (
+            NEMOTRON_PARSE_DEFAULT_TASK_PROMPT,
+            NEMOTRON_PARSE_V2_MODEL,
+            nemotron_parse_pages,
+        )
 
         class _FakeNIMClient:
             def __init__(self):
@@ -454,9 +458,7 @@ class TestNemotronParseActor:
 
             def invoke_chat_completions_images(self, **kwargs):
                 self.kwargs = kwargs
-                return [
-                    '[{"type": "Text", "bbox": {"xmin": 0, "ymin": 0, "xmax": 1, "ymax": 1}, ' '"text": "Legacy text"}]'
-                ]
+                return ["<x_0><y_0>Chart text<x_1><y_1><class_Chart>"]
 
         client = _FakeNIMClient()
         df = pd.DataFrame({"page_image": [{"image_b64": "aW1hZ2U="}]})
@@ -464,20 +466,22 @@ class TestNemotronParseActor:
         result = nemotron_parse_pages(
             df,
             invoke_url="http://nemotron-parse:8000/v1/chat/completions",
-            nemotron_parse_model="nvidia/nemotron-parse-v1.1",
-            extract_text=True,
+            nemotron_parse_model=NEMOTRON_PARSE_V2_MODEL,
+            extract_charts=True,
             nim_client=client,
         )
 
-        assert result["text"].tolist() == ["Legacy text"]
-        assert client.kwargs["task_prompt"] is None
+        assert len(result.at[0, "chart"]) == 1
+        assert client.kwargs["model"] == NEMOTRON_PARSE_V2_MODEL
+        assert client.kwargs["task_prompt"] == NEMOTRON_PARSE_DEFAULT_TASK_PROMPT
         assert client.kwargs["extra_body"] == {
-            "max_tokens": 8192,
-            "tools": [{"type": "function", "function": {"name": "markdown_bbox"}}],
+            "max_tokens": 9000,
+            "top_k": 1,
+            "skip_special_tokens": False,
         }
         assert client.kwargs["repetition_penalty"] == 1.1
 
-    def test_remote_chat_completions_does_not_treat_v1_10_as_legacy(self):
+    def test_remote_chat_completions_uses_tagged_protocol_for_unknown_version(self):
         from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
 
         class _FakeNIMClient:
@@ -554,15 +558,9 @@ class TestNemotronParseActor:
             ),
             (
                 "http://parse:8000/v1/chat/completions",
-                "nvidia/nemotron-parse-v1.0",
-                "nvidia/nemotron-parse-v1.0",
-                "legacy_tool_call",
-            ),
-            (
-                "http://parse:8000/v1/chat/completions",
-                "nvidia/nemotron-parse-v1.1",
-                "nvidia/nemotron-parse-v1.1",
-                "legacy_tool_call",
+                "nvidia/nemotron-parse-v2.0",
+                "nvidia/nemotron-parse-v2.0",
+                "v2_0_tagged",
             ),
             (
                 "http://parse:8000/v1/chat/completions",
@@ -618,6 +616,27 @@ class TestNemotronParseActor:
         assert "nvidia/nemotron-parse" in error["message"]
         assert "RuntimeError: Content cannot be a plain string" in error["traceback"]
         assert "ValueError: Nemotron Parse model/contract mismatch" in error["traceback"]
+
+    def test_forced_v2_build_text_rejection_reports_contract_mismatch(self):
+        from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
+
+        class _RejectingNIMClient:
+            def invoke_chat_completions_images(self, **kwargs):
+                raise RuntimeError("Content cannot be a plain string; model does not support text input")
+
+        df = pd.DataFrame({"page_image": [{"image_b64": "aW1hZ2U="}]})
+        result = nemotron_parse_pages(
+            df,
+            invoke_url="https://integrate.api.nvidia.com/v1/chat/completions",
+            nemotron_parse_model="nvidia/nemotron-parse-v2.0",
+            nim_client=_RejectingNIMClient(),
+        )
+
+        error = result.at[0, "nemotron_parse_v1_2"]["error"]
+        assert error["type"] == "ValueError"
+        assert "model/contract mismatch" in error["message"]
+        assert "nvidia/nemotron-parse-v2.0" in error["message"]
+        assert "tagged text-control-token contract" in error["message"]
 
     def test_image_wrapper_can_omit_repetition_penalty(self):
         from nemo_retriever.models.nim.nim import NIMClient

--- a/nemo_retriever/tests/test_helm_nemotron_parse_endpoint.py
+++ b/nemo_retriever/tests/test_helm_nemotron_parse_endpoint.py
@@ -82,7 +82,23 @@ def test_helm_template_autowires_operator_parse_endpoint() -> None:
         api_versions=("apps.nvidia.com/v1alpha1",),
     )
     assert f'nemotron_parse_invoke_url: "http://{PARSE_SERVICE}:8000{PARSE_PATH}"' in rendered
-    assert "nemotron_parse_model: null" in rendered
+    assert 'nemotron_parse_model: "nvidia/nemotron-parse-v1.2"' in rendered
+
+
+def test_helm_template_autowires_v2_model_from_parse_image_repository() -> None:
+    rendered = _helm_template(
+        (
+            "--set",
+            "nimOperator.nemotron_parse.enabled=true",
+            "--set",
+            "nimOperator.nemotron_parse.image.repository=registry.example/nemotron-parse-v2.0",
+            "--set",
+            "nimOperator.nemotron_parse.image.tag=2.0.8-variant",
+        ),
+        api_versions=("apps.nvidia.com/v1alpha1",),
+    )
+    assert f'nemotron_parse_invoke_url: "http://{PARSE_SERVICE}:8000{PARSE_PATH}"' in rendered
+    assert 'nemotron_parse_model: "nvidia/nemotron-parse-v2.0"' in rendered
 
 
 def test_helm_template_explicit_hosted_endpoint_and_model_win() -> None:


### PR DESCRIPTION
## Description

Adds an optional self-hosted Nemotron Parse 2.0 contract while retaining Parse v1.2 / `1.7.0-variant` as the Helm default.

Root cause: the chart previously rendered an operator-managed Parse endpoint without a model ID, causing the SDK to resolve it as Parse v1.2 even when the NIM image was explicitly overridden to Parse 2.0. The v2 NIM then rejected the v1.2 model request.

This PR:

- derives the rendered model ID from the selected operator-managed Parse v1.2 or v2.0 image;
- adds the explicit Parse 2.0 tagged-output request profile and decoding options;
- retains NVIDIA Build as the image-only tool-call contract;
- removes the separate legacy self-hosted tool-call profile;
- documents the supported contract matrix and mismatch troubleshooting.

## Validation

- `uv run --project . pytest tests/test_actor_operators.py tests/test_helm_nemotron_parse_endpoint.py -q` (84 passed)
- `git diff --check`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
