### PR TITLE
fix(models): update approved Hugging Face checkpoint pins

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
+++ b/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
@@ -26,9 +26,9 @@ logger = logging.getLogger(__name__)
 HF_MODEL_REVISIONS: dict[str, str] = {
     "nvidia/llama-3.2-nv-embedqa-1b-v2": "cefc2394cc541737b7867df197984cf23f05367f",
     "nvidia/llama-nemotron-embed-1b-v2": "113abe4acafa848e77ead9c0623205e511932348",
-    "nvidia/parakeet-ctc-1.1b": "a707e818195cb97c8f7da2fc36b221a29f69a5db",
+    "nvidia/parakeet-ctc-1.1b": "20e63a0fed6aedba145b74b826dbd41df0941730",
     "nvidia/NVIDIA-Nemotron-Parse-v1.2": "f42c8040b12ee64370922d108778ab655b722c5d",
-    "nvidia/llama-nemotron-embed-vl-1b-v2": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
+    "nvidia/llama-nemotron-embed-vl-1b-v2": "582e3bf72aee355e3c59ed89de53543c5b0657ee",
     "meta-llama/Llama-3.2-1B": "4e20de362430cd3b72f300e6b0f18e50e7166e08",
     "intfloat/e5-large-unsupervised": "15af9288f69a6291f37bfb89b47e71abc747b206",
     "nvidia/llama-nemotron-rerank-1b-v2": "8fd3e5d962d44cfe65d4ba0784eebed44cf136b0",
@@ -41,8 +41,9 @@ HF_MODEL_REVISIONS: dict[str, str] = {
     "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4": "dc5f0b0bfddf8b6e0f5891475be9af05b80126fe",
     "nvidia/Llama-3.1-Nemotron-Nano-8B-v1": "54641c1611fcff44fa4865626462445e0a153fc7",
     "nvidia/Llama-3_3-Nemotron-Super-49B-v1": "387156d8d6868c19f3472fa607aa9bfc4f662333",
+    "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5": "420ba7d28211abf116b8b103ab700d92619daf98",
     "nvidia/nemotron-ocr-v1": "8657d08d3279f4864002d5fd3fdcd47ad8c96bcb",
-    "nvidia/nemotron-ocr-v2": "86cacb0467fa4f7ce54342fdb250825e0d928ae7",
+    "nvidia/nemotron-ocr-v2": "0e83e83f17943524b90afa6c0fd82ac2bc1a40ca",
     "nvidia/nemotron-page-elements-v3": "df62dbb631502575ac4d43b44d700b1674ab1d56",
     "nvidia/nemotron-table-structure-v1": "9350162faa1110320af62699105780b0c87b73ad",
 }

--- a/nemo_retriever/src/nemo_retriever/models/local/agent_llm.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/agent_llm.py
@@ -30,7 +30,8 @@ def _normalize_name(name: str) -> str:
 
 
 _NANO_8B_MODEL_ID = "nvidia/Llama-3.1-Nemotron-Nano-8B-v1"
-_SUPER_49B_MODEL_ID = "nvidia/Llama-3_3-Nemotron-Super-49B-v1"
+_SUPER_49B_MODEL_ID = "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5"
+_LEGACY_SUPER_49B_MODEL_ID = "nvidia/Llama-3_3-Nemotron-Super-49B-v1"
 _NANO_8B_ALIASES = (
     "llama-3.1-nemotron-nano-8b-v1",
     "nemotron-nano-8b",
@@ -38,9 +39,13 @@ _NANO_8B_ALIASES = (
     "nvidia/llama-3.1-nemotron-nano-8b-v1",
 )
 _SUPER_49B_ALIASES = (
-    "llama-3.3-nemotron-super-49b-v1",
+    "llama-3.3-nemotron-super-49b-v1.5",
     "nemotron-super-49b",
     "super-49b",
+    "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+)
+_LEGACY_SUPER_49B_ALIASES = (
+    "llama-3.3-nemotron-super-49b-v1",
     "nvidia/llama-3.3-nemotron-super-49b-v1",
     "nvidia/llama-3_3-nemotron-super-49b-v1",
 )
@@ -53,8 +58,23 @@ _AGENT_LLM_MODEL_ALIASES: dict[str, str] = {
 _AGENT_LLM_MODEL_ALIASES.update(
     {_normalize_name(name): _SUPER_49B_MODEL_ID for name in (_SUPER_49B_MODEL_ID, *_SUPER_49B_ALIASES)}
 )
+_AGENT_LLM_MODEL_ALIASES.update(
+    {
+        _normalize_name(name): _LEGACY_SUPER_49B_MODEL_ID
+        for name in (_LEGACY_SUPER_49B_MODEL_ID, *_LEGACY_SUPER_49B_ALIASES)
+    }
+)
 _SUPPORTED_AGENT_LLM_NAMES = tuple(
-    sorted((_NANO_8B_MODEL_ID, *_NANO_8B_ALIASES, _SUPER_49B_MODEL_ID, *_SUPER_49B_ALIASES))
+    sorted(
+        (
+            _NANO_8B_MODEL_ID,
+            *_NANO_8B_ALIASES,
+            _SUPER_49B_MODEL_ID,
+            *_SUPER_49B_ALIASES,
+            _LEGACY_SUPER_49B_MODEL_ID,
+            *_LEGACY_SUPER_49B_ALIASES,
+        )
+    )
 )
 _NEMOTRON_JSON_TOOL_PROMPT_EXTRAS = {"chat_template_kwargs": {"tools_in_user_message": True}}
 

--- a/nemo_retriever/tests/test_agentic_local_llm.py
+++ b/nemo_retriever/tests/test_agentic_local_llm.py
@@ -11,10 +11,18 @@ from unittest.mock import MagicMock
 
 
 def test_resolve_agent_llm_profile_aliases() -> None:
-    from nemo_retriever.models.local.agent_llm import resolve_agent_llm_model_name
+    from nemo_retriever.models.hf_model_registry import get_hf_revision
+    from nemo_retriever.models.local.agent_llm import is_supported_agent_llm_model, resolve_agent_llm_model_name
 
     assert resolve_agent_llm_model_name("nemotron-8b") == "nvidia/Llama-3.1-Nemotron-Nano-8B-v1"
-    assert resolve_agent_llm_model_name("nemotron-super-49b") == "nvidia/Llama-3_3-Nemotron-Super-49B-v1"
+    resolved_super = resolve_agent_llm_model_name("nemotron-super-49b")
+    assert resolved_super == "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5"
+    assert get_hf_revision(resolved_super) == "420ba7d28211abf116b8b103ab700d92619daf98"
+    assert is_supported_agent_llm_model("nvidia/Llama-3_3-Nemotron-Super-49B-v1_5")
+    assert (
+        resolve_agent_llm_model_name("nvidia/Llama-3_3-Nemotron-Super-49B-v1")
+        == "nvidia/Llama-3_3-Nemotron-Super-49B-v1"
+    )
 
 
 def test_local_agent_llm_config_carries_vllm_resource_options() -> None:

--- a/nemo_retriever/tests/test_hf_model_registry.py
+++ b/nemo_retriever/tests/test_hf_model_registry.py
@@ -13,7 +13,7 @@ from nemo_retriever.models import hf_model_registry as registry
 
 def test_extraction_hf_repos_have_pinned_revisions():
     assert registry.HF_MODEL_REVISIONS["nvidia/nemotron-ocr-v1"] == "8657d08d3279f4864002d5fd3fdcd47ad8c96bcb"
-    assert registry.HF_MODEL_REVISIONS["nvidia/nemotron-ocr-v2"] == "86cacb0467fa4f7ce54342fdb250825e0d928ae7"
+    assert registry.HF_MODEL_REVISIONS["nvidia/nemotron-ocr-v2"] == "0e83e83f17943524b90afa6c0fd82ac2bc1a40ca"
     assert registry.HF_MODEL_REVISIONS["nvidia/nemotron-page-elements-v3"] == "df62dbb631502575ac4d43b44d700b1674ab1d56"
     assert (
         registry.HF_MODEL_REVISIONS["nvidia/nemotron-table-structure-v1"] == "9350162faa1110320af62699105780b0c87b73ad"
@@ -49,8 +49,20 @@ def test_local_hf_nemotron_models_use_transformers_5_compatible_revisions() -> N
         registry.HF_MODEL_REVISIONS["nvidia/llama-nemotron-embed-1b-v2"] == "113abe4acafa848e77ead9c0623205e511932348"
     )
     assert (
+        registry.HF_MODEL_REVISIONS["nvidia/llama-nemotron-embed-vl-1b-v2"]
+        == "582e3bf72aee355e3c59ed89de53543c5b0657ee"
+    )
+    assert (
         registry.HF_MODEL_REVISIONS["nvidia/llama-nemotron-rerank-vl-1b-v2"]
         == "9c20c4aedf9ec87b6b7346c3bc4754ea030dab35"
+    )
+
+
+def test_local_hf_asr_and_agent_models_use_approved_revisions() -> None:
+    assert registry.HF_MODEL_REVISIONS["nvidia/parakeet-ctc-1.1b"] == "20e63a0fed6aedba145b74b826dbd41df0941730"
+    assert (
+        registry.HF_MODEL_REVISIONS["nvidia/Llama-3_3-Nemotron-Super-49B-v1_5"]
+        == "420ba7d28211abf116b8b103ab700d92619daf98"
     )
 
 

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -231,7 +231,7 @@ def test_local_ocr_v2_wrapper_passes_package_lang_selector_with_model_dir(monkey
 @pytest.mark.parametrize(
     ("selector", "repo_id", "revision"),
     [
-        ("multi", "nvidia/nemotron-ocr-v2", "86cacb0467fa4f7ce54342fdb250825e0d928ae7"),
+        ("multi", "nvidia/nemotron-ocr-v2", "0e83e83f17943524b90afa6c0fd82ac2bc1a40ca"),
         ("legacy", "nvidia/nemotron-ocr-v1", "8657d08d3279f4864002d5fd3fdcd47ad8c96bcb"),
     ],
 )

--- a/nemo_retriever/tests/test_parakeet_ctc_hf_compat.py
+++ b/nemo_retriever/tests/test_parakeet_ctc_hf_compat.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 import pytest
 
+from nemo_retriever.models.hf_model_registry import get_hf_revision
+
 MODEL_ID = os.environ.get("PARAKEET_CTC_MODEL_ID", "nvidia/parakeet-ctc-1.1b")
+MODEL_REVISION = get_hf_revision(MODEL_ID, strict=False)
 DEFAULT_AUDIO_PATH = "/datasets/nv-ingest/audio_retrieval_data_mp3/How_to_Convert_a_Word_Document_to_PDF_Dropbox.mp3"
 AUDIO_PATH = Path(os.environ.get("PARAKEET_CTC_TEST_AUDIO", DEFAULT_AUDIO_PATH))
 DEFAULT_EXPECTED_PHRASES = (
@@ -44,13 +47,14 @@ def test_parakeet_ctc_hf_transcribes_single_audio_file() -> None:
     if not AUDIO_PATH.exists():
         pytest.skip(f"Test audio file does not exist: {AUDIO_PATH}")
     device_map = "cuda" if torch.cuda.is_available() else "cpu"
-    processor = AutoProcessor.from_pretrained(MODEL_ID)
+    processor = AutoProcessor.from_pretrained(MODEL_ID, revision=MODEL_REVISION)
     model = None
     inputs = None
     output_ids = None
     try:
         model = AutoModelForCTC.from_pretrained(
             MODEL_ID,
+            revision=MODEL_REVISION,
             torch_dtype="auto",
             device_map=device_map,
         )

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -162,7 +162,7 @@ def test_root_ingest_runs_default_execution_chain(monkeypatch, tmp_path) -> None
         "table_name": "nemo-retriever",
         "overwrite": True,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
+        "embedding_model_revision": "582e3bf72aee355e3c59ed89de53543c5b0657ee",
     }
     assert "Ingested 1 file(s) → 7 row(s) in LanceDB lancedb/nemo-retriever." in result.output
 
@@ -204,7 +204,7 @@ def test_root_ingest_without_mode_accepts_local_options_before_documents(monkeyp
         "table_name": "nemo-retriever",
         "overwrite": False,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
+        "embedding_model_revision": "582e3bf72aee355e3c59ed89de53543c5b0657ee",
     }
 
 
@@ -401,7 +401,7 @@ def test_root_ingest_passes_vdb_options_and_run_mode(monkeypatch, tmp_path) -> N
         "table_name": "docs",
         "overwrite": True,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
+        "embedding_model_revision": "582e3bf72aee355e3c59ed89de53543c5b0657ee",
     }
     assert "Ingested 2 file(s) → 12 row(s) in LanceDB /tmp/lancedb/docs." in result.output
 
@@ -421,7 +421,7 @@ def test_root_ingest_append_forwards_overwrite_false(monkeypatch, tmp_path) -> N
         "table_name": "nemo-retriever",
         "overwrite": False,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
+        "embedding_model_revision": "582e3bf72aee355e3c59ed89de53543c5b0657ee",
     }
 
 
@@ -1716,7 +1716,7 @@ def test_root_ingest_index_mode_hybrid_passes_hybrid_into_vdb_kwargs(monkeypatch
         "overwrite": True,
         "hybrid": True,
         "embedding_model_name": "nvidia/llama-nemotron-embed-vl-1b-v2",
-        "embedding_model_revision": "171968f5db67b2d16aac89b820d53b4eb6a7ab44",
+        "embedding_model_revision": "582e3bf72aee355e3c59ed89de53543c5b0657ee",
     }
 
 


### PR DESCRIPTION
## Description

Updates stale Hugging Face checkpoint revisions for Parakeet ASR, VL embedding, and Nemotron OCR v2. It also advances the generic Super 49B aliases to v1.5 while preserving explicit v1 compatibility.

This PR intentionally preserves the existing text-embedding and Nemotron Parse defaults because the newer generations have known performance and recall concerns. 

The VL reranker revision was already updated on `main` and remains unchanged.

## Checklist

- [x] I am familiar with the [[Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.