### PR TITLE
docs(helm): document leftover per-NIM NGC secret overrides (NVBug 6622878)

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -85,9 +85,9 @@ Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable
 
 ## Why do NIMCache and NIMService still use ngc-secret after I rename ngcImagePullSecret.name? { #helm-nim-secret-rename }
 
-Empty `nimOperator.<key>.image.pullSecrets` and `nimOperator.<key>.authSecret` inherit `ngcImagePullSecret.name` and `ngcApiSecret.name`. Chart defaults leave those fields empty.
+Empty per-NIM `image.pullSecrets` and `authSecret` inherit `ngcImagePullSecret.name` and `ngcApiSecret.name`. Chart defaults leave those fields empty.
 
-A non-empty per-NIM override takes precedence. If you previously set `pullSecrets` or `authSecret` to `ngc-secret` or `ngc-api`, those values remain after you rename the global Secrets. Clear the per-NIM fields, or set them to the new names.
+A non-empty per-NIM override takes precedence. If you previously set those fields to `ngc-secret` or `ngc-api`, those values remain after you rename the global Secrets. Clear the per-NIM fields, or set them to the new names.
 
 `imagePullSecrets` applies only to Retriever Pods. It does not appear on NIMCache or NIMService.
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -83,6 +83,16 @@ The chart keeps the same `NIMCache` name when you change a NIM image repository 
 
 Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Helm upgrade fails when changing a NIM image repository or tag](troubleshoot.md#helm-nimcache-modelpuller-immutable) and [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 
+## Why do NIMCache and NIMService still use ngc-secret after I rename ngcImagePullSecret.name? { #helm-nim-secret-rename }
+
+Empty `nimOperator.<key>.image.pullSecrets` and `nimOperator.<key>.authSecret` inherit `ngcImagePullSecret.name` and `ngcApiSecret.name`. Chart defaults leave those fields empty.
+
+A non-empty per-NIM override takes precedence. If you previously set `pullSecrets` or `authSecret` to `ngc-secret` or `ngc-api`, those values remain after you rename the global Secrets. Clear the per-NIM fields, or set them to the new names.
+
+`imagePullSecrets` applies only to Retriever Pods. It does not appear on NIMCache or NIMService.
+
+Refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [NIMCache or NIMService still uses ngc-secret after a global Secret rename](troubleshoot.md#helm-nim-secret-names).
+
 ## Why are the environment variables different between library mode and self-hosted mode? { #library-vs-self-hosted-env-vars }
 
 ### Self-Hosted Deployments { #self-hosted-deployments }

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -484,13 +484,13 @@ For default cache names, PVC cleanup, and the full upgrade sequence, refer to [C
 
 Retriever Pods inherit `ngcImagePullSecret.name` and `ngcApiSecret.name`. Empty per-NIM `image.pullSecrets` and `authSecret` inherit the same names.
 
-If NIMCache or NIMService still shows `ngc-secret` or `ngc-api` after a rename, a non-empty per-NIM override is still set. The retriever Deployment can become Ready while NIM model-download Jobs and NIM Pods fail because they reference Secrets that do not exist.
+If NIMCache or NIMService still shows `ngc-secret` or `ngc-api` after a rename, you still have a non-empty per-NIM override. The retriever Deployment can become Ready while NIM model-download Jobs and NIM Pods fail because they reference Secrets that do not exist.
 
 Complete the following checks:
 
 1. Render the chart with the NIM Operator CRDs enabled. Inspect `pullSecret` on every `NIMCache` and `pullSecrets` on every `NIMService`, plus `authSecret` on both.
 2. Confirm those fields match Secrets that exist in the release namespace.
-3. If a NIM still lists `ngc-secret` or `ngc-api` after you renamed the globals, clear `nimOperator.<key>.image.pullSecrets` and `nimOperator.<key>.authSecret`, or set them to the new names. Empty values inherit the global names.
+3. If a NIM still lists `ngc-secret` or `ngc-api` after you renamed the global Secret names, clear `nimOperator.<key>.image.pullSecrets` and `nimOperator.<key>.authSecret`, or set them to the new names. Empty values inherit the global names.
 4. Top-level `imagePullSecrets` applies only to Retriever Pods. It does not update NIM Operator custom resources.
 
 For value paths and a rename example, refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#secrets) in the Helm chart README.

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -480,6 +480,21 @@ Changing `service.image.repository` or `service.image.tag` does not use `NIMCach
 
 For default cache names, PVC cleanup, and the full upgrade sequence, refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 
+## NIMCache or NIMService still uses ngc-secret after a global Secret rename { #helm-nim-secret-names }
+
+Retriever Pods inherit `ngcImagePullSecret.name` and `ngcApiSecret.name`. Empty per-NIM `image.pullSecrets` and `authSecret` inherit the same names.
+
+If NIMCache or NIMService still shows `ngc-secret` or `ngc-api` after a rename, a non-empty per-NIM override is still set. The retriever Deployment can become Ready while NIM model-download Jobs and NIM Pods fail because they reference Secrets that do not exist.
+
+Complete the following checks:
+
+1. Render the chart with the NIM Operator CRDs enabled. Inspect `pullSecret` on every `NIMCache` and `pullSecrets` on every `NIMService`, plus `authSecret` on both.
+2. Confirm those fields match Secrets that exist in the release namespace.
+3. If a NIM still lists `ngc-secret` or `ngc-api` after you renamed the globals, clear `nimOperator.<key>.image.pullSecrets` and `nimOperator.<key>.authSecret`, or set them to the new names. Empty values inherit the global names.
+4. Top-level `imagePullSecrets` applies only to Retriever Pods. It does not update NIM Operator custom resources.
+
+For value paths and a rename example, refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#secrets) in the Helm chart README.
+
 ## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
@@ -488,4 +503,5 @@ For default cache names, PVC cleanup, and the full upgrade sequence, refer to [C
 - [Deployment options](deployment-options.md)
 - [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
 - [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag)
+- [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets)
 - [About getting started](getting-started-about.md) (prerequisites and deployment)


### PR DESCRIPTION
## Summary

- Rebases onto `main` after Helm PR #2514. Empty per-NIM `image.pullSecrets` and `authSecret` inherit `ngcImagePullSecret.name` and `ngcApiSecret.name`. The Helm README and `api-keys.md` already document that inheritance, so this PR no longer restates the old "does not propagate" behavior.
- FAQ and troubleshoot keep the NIMCache `modelPuller` upgrade coverage from `main`, and add the remaining pitfall: a non-empty per-NIM override still pins `ngc-secret` / `ngc-api` after a global Secret rename.
- `imagePullSecrets` remains Retriever Pod-only. It does not appear on NIMCache or NIMService.

## Test plan

- [x] `git diff --name-only upstream/main...HEAD` is `faq.md` and `troubleshoot.md` only
- [x] Rebase onto `upstream/main`; PR conflicts resolved
- [x] GitHub reports the PR mergeable
- [x] Leakage scoped to this diff: no `nimOperator` on `faq.md`; no `see [` CTAs
- [ ] Optional: render with a leftover per-NIM `pullSecrets: [ngc-secret]` after renaming `ngcImagePullSecret.name` and confirm NIM CRs keep the old name until the override is cleared

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** faq.md, troubleshoot.md

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — no `nimOperator` on faq.md; no `see [` CTAs in this diff. Script vs `origin/main` is stale (31 files) and also flags untracked leftover `custom-metadata.md`, which is not in this PR. |
| Allowed paths | PASS — 2 documentation files |
| mkdocs --strict | PASS for this diff — workspace `--strict` aborted on 4 warnings from untracked leftover pages `custom-metadata.md` and `user-defined-stages.md`; faq.md and troubleshoot.md did not appear in the warning list |
| ::a audit | PASS — empty per-NIM fields inherit globals; non-empty override pins old names; `imagePullSecrets` is Pod-only (95%) |
| ::p polish | Applied — removed `nimOperator` from FAQ; active voice and "global Secret names" in troubleshoot |
| ::r style | 95% — no blocking issues; question heading is allowed on FAQ |

**Code drift (not in this docs PR):** `nemo_retriever/helm/templates/secrets.yaml` comments still say default names "should not normally be changed" and do not mention the inheritance helpers. Chart behavior is covered by `#2514` and `tests/test_helm_nim_global_secret_names.py`.

**PR:** https://github.com/NVIDIA/NeMo-Retriever/pull/2535
