### PR TITLE
fix(agentic): restore failure and candidate contracts

### DIFF
--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -33,6 +33,10 @@ Providing `--agentic-invoke-url` routes the agent to that remote endpoint; the L
 client defaults to `callable`, which calls the endpoint over the shared
 chat-completions HTTP client and needs no LLM SDK installed.
 
+Operational failures from the agent LLM or retrieval tool, including embedding,
+vector database, and reranker endpoint failures, terminate the query with an
+error instead of returning a successful empty result.
+
 ## MCP access for agents
 
 `retriever service start` mounts a FastMCP HTTP endpoint at `/mcp` by default.

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
@@ -20,7 +20,14 @@ from typing import Any, Callable, Dict, List, Optional
 
 import pandas as pd
 
-from nemo_retriever._agentic.nemo_agent import Agent, AgentConfig, create_retrieve_tool
+from nemo_retriever._agentic.nemo_agent import (
+    ERROR_LLM_CALL_FAILED,
+    ERROR_TOOL_FAILED,
+    ERROR_UNEXPECTED,
+    Agent,
+    AgentConfig,
+    create_retrieve_tool,
+)
 from nemo_retriever._agentic.nemo_agent.llm import create_llm, create_llm_config
 from nemo_retriever.operators.abstract_operator import AbstractOperator
 from nemo_retriever.operators.cpu_operator import CPUOperator
@@ -29,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 _LOG_PREVIEW_CHARS = 300
 _LOG_DOC_ID_LIMIT = 20
+_FATAL_AGENT_ERROR_CATEGORIES = frozenset({ERROR_LLM_CALL_FAILED, ERROR_TOOL_FAILED, ERROR_UNEXPECTED})
 
 #: Output DataFrame columns emitted by :func:`_build_output_rows` / this operator.
 _OUTPUT_COLUMNS = [
@@ -301,7 +309,7 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
     # ------------------------------------------------------------------
 
     def _run_single_query(self, query_id: str, query_text: str) -> List[Dict[str, Any]]:
-        """Run the agent for one query and translate its result into output rows."""
+        """Run one query, raising fatal agent errors while preserving recoverable fallback rows."""
         agent = self._ensure_agent()
         logger.info(
             "ReActAgentOperator: query=%s start max_steps=%d target_top_k=%d query=%r",
@@ -311,6 +319,9 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             _preview_text(query_text),
         )
         result = agent.run_sync(str(query_text), query_id=str(query_id), raw_log_dir=None)
+
+        if result.error is not None and result.error.category in _FATAL_AGENT_ERROR_CATEGORIES:
+            raise RuntimeError(f"Agentic retrieval failed ({result.error.category}): {result.error.message}")
 
         # Private agent retrieval_log entries are {"input", "tool_name",
         # "query_type", "output": [ {id, score, text|note, ...} ]}. The exploded

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
@@ -38,6 +38,11 @@ _LOG_PREVIEW_CHARS = 300
 _LOG_DOC_ID_LIMIT = 20
 _FATAL_AGENT_ERROR_CATEGORIES = frozenset({ERROR_LLM_CALL_FAILED, ERROR_TOOL_FAILED, ERROR_UNEXPECTED})
 
+
+class _FatalAgentError(RuntimeError):
+    """Fatal recorded agent error that must abort single-query and batch execution."""
+
+
 #: Output DataFrame columns emitted by :func:`_build_output_rows` / this operator.
 _OUTPUT_COLUMNS = [
     "query_id",
@@ -291,6 +296,8 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
                     qid = futures[future]
                     try:
                         results_by_qid[qid] = future.result()
+                    except _FatalAgentError:
+                        raise
                     except Exception as exc:  # production: one bad query must not kill the batch
                         logger.warning("ReActAgentOperator: query %r failed: %s", qid, exc, exc_info=True)
             for qid, _qtxt in query_rows:
@@ -321,7 +328,10 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
         result = agent.run_sync(str(query_text), query_id=str(query_id), raw_log_dir=None)
 
         if result.error is not None and result.error.category in _FATAL_AGENT_ERROR_CATEGORIES:
-            raise RuntimeError(f"Agentic retrieval failed ({result.error.category}): {result.error.message}")
+            raise _FatalAgentError(
+                f"Agentic retrieval failed ({result.error.category}): {result.error.message} "
+                "Check the configured agent LLM, embedding, vector database, and reranker settings and connectivity."
+            )
 
         # Private agent retrieval_log entries are {"input", "tool_name",
         # "query_type", "output": [ {id, score, text|note, ...} ]}. The exploded

--- a/nemo_retriever/src/nemo_retriever/query/agentic.py
+++ b/nemo_retriever/src/nemo_retriever/query/agentic.py
@@ -176,6 +176,8 @@ class AgenticRetrievalConfig:
     # Drives the ReAct target, the RRF/selection cut, and the per-hop fetch depth
     # (which is raised to at least this). Defaults to 10.
     top_k: int = AGENTIC_TARGET_TOP_K
+    # Wider pre-filter and pre-rerank candidate pool for each retrieval hop.
+    candidate_k: Optional[int] = None
 
     def __post_init__(self) -> None:
         invoke_url = _none_if_empty(self.invoke_url)
@@ -256,6 +258,15 @@ class AgenticRetrievalConfig:
             if integer_error:
                 raise ValueError(integer_error)
             object.__setattr__(self, field_name, agentic_int_value(value, field_name=field_name))
+
+        if self.candidate_k is not None:
+            candidate_error = agentic_int_min_error(self.candidate_k, field_name="candidate_k", min_value=1)
+            if candidate_error:
+                raise ValueError(candidate_error)
+            candidate_k = agentic_int_value(self.candidate_k, field_name="candidate_k")
+            if candidate_k < int(self.top_k):
+                raise ValueError(f"candidate_k ({candidate_k}) must be greater than or equal to top_k ({self.top_k}).")
+            object.__setattr__(self, "candidate_k", candidate_k)
 
         local_tp_error = agentic_int_min_error(
             self.local_tensor_parallel_size, field_name="local_tensor_parallel_size", min_value=1
@@ -486,8 +497,9 @@ class AgenticRetriever:
         which still run concurrently under ``num_concurrent > 1``.
         """
 
+        candidate_k = max(int(self._cfg.candidate_k), int(top_k)) if self._cfg.candidate_k is not None else None
         with self._lock:
-            hits = self._retriever.query(str(query_text), top_k=int(top_k))
+            hits = self._retriever.query(str(query_text), top_k=int(top_k), candidate_k=candidate_k)
 
         docs: list[dict[str, Any]] = []
         doc_id_field = getattr(self, "_doc_id_field", None)

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -171,6 +171,7 @@ def build_agentic_config(request: QueryRequest, *, top_k: int | None = None) -> 
         "vdb_op": "lancedb",
         "vdb_kwargs": vdb_kwargs,
         "top_k": int(top_k if top_k is not None else request.retrieval.top_k),
+        "candidate_k": request.retrieval.candidate_k,
         "embedding_endpoint": request.embed.embed_invoke_url,
         "embedding_api_key": api_key or "",
         "llm_model": request.agentic.llm_model,

--- a/nemo_retriever/tests/test_agentic_eval.py
+++ b/nemo_retriever/tests/test_agentic_eval.py
@@ -36,8 +36,10 @@ class FakeRetriever:
         self.kwargs = kwargs
         self.graph = kwargs.get("graph")
         self.top_k = int(kwargs.get("top_k", 10))
+        self.query_calls = []
 
-    def query(self, query: str, *, top_k: int | None = None):
+    def query(self, query: str, *, top_k: int | None = None, candidate_k: int | None = None):
+        self.query_calls.append({"query": query, "top_k": top_k, "candidate_k": candidate_k})
         if self.graph is not None:
             return self.queries([query], top_k=top_k)[0]
         _ = query
@@ -148,6 +150,22 @@ def test_agentic_retriever_honors_top_k():
         result = AgenticRetriever(cfg, match_mode="pdf_page").retrieve(["0"], ["find doc"])
 
     assert result["rank"].tolist() == list(range(1, 6))  # 5 rows, honoring top_k=5
+
+
+@patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
+def test_agentic_retriever_forwards_candidate_k_per_hop():
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    cfg = AgenticRetrievalConfig(llm_model="m", invoke_url=_REMOTE_URL, top_k=10, candidate_k=20)
+    retriever = AgenticRetriever(cfg, match_mode="pdf_page")
+
+    retriever._retrieve_for_agent("first", 10)
+    retriever._retrieve_for_agent("later", 25)
+
+    assert retriever._retriever.query_calls == [
+        {"query": "first", "top_k": 10, "candidate_k": 20},
+        {"query": "later", "top_k": 25, "candidate_k": 25},
+    ]
 
 
 @patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
@@ -307,6 +325,16 @@ def test_agentic_config_rejects_noninteger_top_k():
 
     with pytest.raises(ValueError, match="top_k must be an integer"):
         AgenticRetrievalConfig(llm_model="m", invoke_url=_REMOTE_URL, top_k=1.5)
+
+
+def test_agentic_config_rejects_candidate_k_below_top_k():
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig
+
+    with pytest.raises(
+        ValueError,
+        match=r"candidate_k \(3\) must be greater than or equal to top_k \(10\)",
+    ):
+        AgenticRetrievalConfig(llm_model="m", invoke_url=_REMOTE_URL, top_k=10, candidate_k=3)
 
 
 def test_agentic_config_normalizes_integer_like_values():

--- a/nemo_retriever/tests/test_agentic_operators.py
+++ b/nemo_retriever/tests/test_agentic_operators.py
@@ -268,7 +268,10 @@ class TestReActAgentOperator:
         with patch.object(ReActAgentOperator, "_ensure_agent", return_value=mock_agent):
             with pytest.raises(
                 RuntimeError,
-                match=rf"Agentic retrieval failed \({error_category}\).*retrieve.*127\.0\.0\.1:9",
+                match=(
+                    rf"Agentic retrieval failed \({error_category}\).*retrieve.*127\.0\.0\.1:9.*"
+                    r"Check the configured agent LLM, embedding, vector database, and reranker settings"
+                ),
             ):
                 op.run(self._input())
 
@@ -307,6 +310,27 @@ class TestReActAgentOperator:
         # Deterministic input order regardless of thread completion order.
         assert result["query_id"].tolist() == ["qA", "qB", "qC"]
         assert result["doc_id"].tolist() == ["qAd", "qBd", "qCd"]
+
+    def test_fatal_agent_error_aborts_multiple_queries(self):
+        from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
+
+        mock_agent = MagicMock()
+
+        def run_sync(query, *, query_id=None, raw_log_dir=None):
+            if query_id == "qB":
+                return _agent_result(
+                    error_category="tool_failed",
+                    error_message="Tool 'retrieve' failed at http://127.0.0.1:9/v1/ranking",
+                )
+            return _agent_result(retrieval_log=[_step([(f"{query_id}d", 1.0, "x")])])
+
+        mock_agent.run_sync.side_effect = run_sync
+        op = self._op(num_concurrent=2)
+        data = pd.DataFrame({"query_id": ["qA", "qB"], "query_text": ["a", "b"]})
+
+        with patch.object(ReActAgentOperator, "_ensure_agent", return_value=mock_agent):
+            with pytest.raises(RuntimeError, match=r"Agentic retrieval failed \(tool_failed\).*retrieve"):
+                op.run(data)
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_retriever/tests/test_agentic_operators.py
+++ b/nemo_retriever/tests/test_agentic_operators.py
@@ -27,11 +27,11 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _agent_result(*, final_doc_ids=None, retrieval_log=None, error_category=None):
+def _agent_result(*, final_doc_ids=None, retrieval_log=None, error_category=None, error_message="stub"):
     """Build a canned ``AgentRunResult`` like ``Agent.run``/``SelectionAgent.select``."""
     from nemo_retriever._agentic.nemo_agent.results import AgentError, AgentRunResult
 
-    error = AgentError(category=error_category, message="stub") if error_category else None
+    error = AgentError(category=error_category, message=error_message) if error_category else None
     return AgentRunResult(
         final_doc_ids=list(final_doc_ids or []),
         retrieval_log=list(retrieval_log or []),
@@ -253,6 +253,24 @@ class TestReActAgentOperator:
         assert not result["has_valid_final_results"].any()
         assert not result["is_final_result"].any()
         assert result["doc_id"].tolist() == ["d1"]  # retrieval log preserved on failure
+
+    @pytest.mark.parametrize("error_category", ["tool_failed", "llm_call_failed", "unexpected"])
+    def test_fatal_agent_error_raises(self, error_category):
+        from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
+
+        mock_agent = MagicMock()
+        mock_agent.run_sync.return_value = _agent_result(
+            error_category=error_category,
+            error_message="Tool 'retrieve' failed at http://127.0.0.1:9/v1/ranking",
+        )
+        op = self._op()
+
+        with patch.object(ReActAgentOperator, "_ensure_agent", return_value=mock_agent):
+            with pytest.raises(
+                RuntimeError,
+                match=rf"Agentic retrieval failed \({error_category}\).*retrieve.*127\.0\.0\.1:9",
+            ):
+                op.run(self._input())
 
     def test_empty_input_returns_full_schema(self):
         op = self._op()

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -420,6 +420,8 @@ def test_root_query_agentic_passes_config_and_prints_ranked(monkeypatch) -> None
             "--agentic",
             "--top-k",
             "2",
+            "--candidate-k",
+            "4",
             "--lancedb-uri",
             "/tmp/lancedb",
             "--table-name",
@@ -445,11 +447,70 @@ def test_root_query_agentic_passes_config_and_prints_ranked(monkeypatch) -> None
     # --top-k is honored end-to-end: plumbed into the agentic config (drives the
     # ReAct target / RRF / selection cut), not just applied as a post-filter.
     assert cfg["top_k"] == 2
+    assert cfg["candidate_k"] == 4
     # Sorted by rank and truncated to --top-k=2.
     assert json.loads(result.output) == [
         {"rank": 1, "doc_id": "a.pdf", "result_source": "final_results"},
         {"rank": 2, "doc_id": "b.pdf", "result_source": "rrf"},
     ]
+
+
+def test_root_query_agentic_rejects_candidate_k_below_top_k() -> None:
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "q",
+            "--agentic",
+            "--top-k",
+            "10",
+            "--candidate-k",
+            "3",
+            "--agentic-llm-model",
+            "m",
+            "--agentic-invoke-url",
+            "http://localhost:8000/v1/chat/completions",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "candidate_k (3) must be greater than or equal to top_k (10)" in result.output
+
+
+def test_root_query_agentic_unreachable_reranker_is_not_reported_as_empty_success(
+    monkeypatch,
+) -> None:
+    reranker_url = "http://127.0.0.1:9/v1/ranking"
+
+    def fail_agentic_query(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(
+            "Agentic retrieval failed (tool_failed): Tool 'retrieve' failed. "
+            f"ConnectionError: HTTPConnectionPool {reranker_url}"
+        )
+
+    monkeypatch.setattr(query_cli_app, "query_agentic_documents", fail_agentic_query)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "q",
+            "--agentic",
+            "--agentic-llm-model",
+            "m",
+            "--agentic-invoke-url",
+            "http://localhost:8000/v1/chat/completions",
+            "--rerank",
+            "--reranker-invoke-url",
+            reranker_url,
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "[]" not in result.output
+    assert "Agentic retrieval failed (tool_failed)" in result.output
+    assert "retrieve" in result.output
+    assert reranker_url in result.output
 
 
 def test_root_query_agentic_local_tensor_parallel_size_plumbed_into_config(


### PR DESCRIPTION
## Description
Fix two agentic CLI contract issues:

- Fatal retrieval failures now exit nonzero with an actionable error instead of returning `[]`.
- `--candidate-k` is now validated against `--top-k` and applied to every retrieval hop.

Recoverable agent conditions continue to fall back normally. No changes were made to global CLI capture, selection fallback, reranking, REST schemas, or defaults.

## Validation

- Exact invalid `candidate-k` CLI reproduction passes.
- Exact dead-reranker reproduction exits `1` and identifies the failed retrieval stage.
- Focused agentic, workflow, service, and CLI tests pass.
- Black, Flake8, and `git diff --check` pass.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
