### PR TITLE
docs(api): point CLI splitter link at Local and batch ingest (NVBug 6621348)

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -168,7 +168,7 @@ actions, and escalation criteria, refer to
 
 Large PDFs are split into page batches before Ray processing so extraction can run in parallel. This happens on the default ingest path; you do not need extra configuration for typical workloads.
 
-To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). Refer to [Text chunking and PDF page batches](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli#text-chunking-and-pdf-page-batches) in the CLI reference.
+To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). Refer to [Local and batch ingest](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli#local-and-batch-ingest) in the CLI reference.
 
 **Python client (`pdf_split_config`):** Only `create_ingestor(run_mode="service")` implements `.pdf_split_config(pages_per_chunk=...)`, which records page-chunking settings in the request pipeline spec for the remote gateway. Local graph ingest (`run_mode="inprocess"` or `"batch"`) raises `NotImplementedError` if you call this method; PDFs are split automatically on the default ingest path without client-side configuration.
 


### PR DESCRIPTION
## Summary
- Retarget the Python API guide CLI link for `--pdf-split-batch-size` from the stale `#text-chunking-and-pdf-page-batches` fragment to `#local-and-batch-ingest`, the section that documents the option.
- Leave `### Text chunking` unchanged. That heading no longer covers PDF page batches or this flag.

Fixes NVBug 6621348.

## Test plan
- [x] Confirm `### Local and batch ingest` exists in `nemo_retriever/docs/cli/README.md` and documents `--pdf-split-batch-size`.
- [x] Confirm `### Text chunking` does not document `--pdf-split-batch-size`.
- [x] Confirm the API guide link text and fragment match the target heading.
- [ ] After merge, follow the published API guide link and land on Local and batch ingest.

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** `docs/docs/extraction/nemo-retriever-api-reference.md`

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — this file has no `see [` CTAs and no `nimOperator` / `nvcr.io/nim` / `installFfmpeg` on faq, overview, or multimodal-extraction. The leakage script vs `origin/main` failed on leftover `custom-metadata.md` (not in this diff). |
| Allowed paths | PASS — 1 documentation file |
| mkdocs --strict | PASS for this change — `nemo-retriever-api-reference.md` had no warnings. Strict aborted (exit 1) on untracked leftover pages `custom-metadata.md` and `user-defined-stages.md`, which are not in this diff. |
| ::a audit | PASS — 3 claims verified (CLI option exists; `#local-and-batch-ingest` exists; that section documents `--pdf-split-batch-size`). Parenthetical “Ray actor batch size for the splitter stage” is unverified wiring (see code drift). |
| ::p polish | none needed — one-line link retarget; already uses “Refer to” and heading-matched link text |
| ::r style | 95% — no blocking issues on the changed sentence |

**Code drift (not in this docs PR):** `pdf_split_batch_size` is stored on `BatchTuningParams` (`nemo_retriever/src/nemo_retriever/common/params/models.py:475`, CLI `options.py:321`) and tests only assert the flag is stored (`tests/test_root_cli_workflow.py:822`). `batch_tuning_to_node_overrides` in `ingestor_runtime.py` does not apply it to `PDFSplitActor`.

**PR:** this draft