### PR TITLE
fix: preserve native Ray blocks during pandas materialization

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -90,17 +90,33 @@ def _normalize_pickled_object_columns(table: Any, frame: pd.DataFrame) -> pd.Dat
     return frame
 
 
+def _normalize_object_tensor_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    """Convert object-backed Ray tensor columns to ordinary pandas objects."""
+    from ray.data.extensions import TensorDtype
+
+    columns = [
+        name for name, dtype in frame.dtypes.items() if isinstance(dtype, TensorDtype) and dtype.element_dtype.hasobject
+    ]
+    if not columns:
+        return frame
+
+    normalized = frame.copy()
+    for name in columns:
+        normalized[name] = pd.Series(frame[name].to_numpy().tolist(), index=frame.index, dtype=object)
+    return normalized
+
+
 def arrow_table_to_pandas(table: Any) -> pd.DataFrame:
     """Convert a Ray Arrow batch to a row-safe pandas DataFrame.
 
     Ray 2.56+ preserves Arrow-backed pandas dtypes. Before conversion, sliced
     nested columns with inferred null children must be compacted. Ray's
-    pickled-object extension columns also need to be materialized as ordinary
-    object columns so pandas row operations do not interpret their payloads as
-    malformed extension arrays.
+    pickled-object and object-backed tensor extension columns also need to be
+    materialized as ordinary object columns so pandas row operations do not
+    interpret their payloads as malformed extension arrays.
     """
     if isinstance(table, pd.DataFrame):
-        return table
+        return _normalize_object_tensor_columns(table)
 
     from ray.data.block import BlockAccessor
 
@@ -114,21 +130,28 @@ def ray_dataset_to_pandas(dataset: ray.data.Dataset) -> pd.DataFrame:
 
     Ray 2.56+ enables Arrow-backed pandas conversion by default. Calling
     ``Dataset.to_pandas()`` directly can therefore expose sliced nested Arrow
-    columns whose child offsets are invalid for pandas row access. Convert
-    each Arrow block through :func:`arrow_table_to_pandas` before concatenating
-    so the public SDK result is safe to consume with standard pandas APIs.
+    columns whose child offsets are invalid for pandas row access. Forcing a
+    pandas block to Arrow can also fail for object-backed tensor columns. Read
+    each block in its native format and convert it through
+    :func:`arrow_table_to_pandas` before concatenating so the public SDK result
+    is safe to consume with standard pandas APIs.
 
     Parameters
     ----------
     dataset
-        Ray dataset to materialize as Arrow batches.
+        Ray dataset to materialize in its native block formats.
 
     Returns
     -------
     pandas.DataFrame
         Row-safe DataFrame containing all rows from ``dataset``.
     """
-    frames = [arrow_table_to_pandas(batch) for batch in dataset.iter_batches(batch_format="pyarrow")]
+    import ray
+
+    frames = []
+    for ref_bundle in dataset.iter_internal_ref_bundles():
+        blocks = ray.get([entry.ref for entry in ref_bundle.blocks])
+        frames.extend(arrow_table_to_pandas(block) for block in blocks)
     if frames:
         return pd.concat(frames, ignore_index=True)
 

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -100,9 +100,9 @@ def _normalize_object_tensor_columns(frame: pd.DataFrame) -> pd.DataFrame:
     if not columns:
         return frame
 
-    normalized = frame.copy()
+    normalized = frame.copy(deep=False)
     for name in columns:
-        normalized[name] = pd.Series(frame[name].to_numpy().tolist(), index=frame.index, dtype=object)
+        normalized[name] = frame[name].astype(object)
     return normalized
 
 
@@ -146,12 +146,7 @@ def ray_dataset_to_pandas(dataset: ray.data.Dataset) -> pd.DataFrame:
     pandas.DataFrame
         Row-safe DataFrame containing all rows from ``dataset``.
     """
-    import ray
-
-    frames = []
-    for ref_bundle in dataset.iter_internal_ref_bundles():
-        blocks = ray.get([entry.ref for entry in ref_bundle.blocks])
-        frames.extend(arrow_table_to_pandas(block) for block in blocks)
+    frames = [arrow_table_to_pandas(block) for block in dataset.iter_batches(batch_format=None, batch_size=None)]
     if frames:
         return pd.concat(frames, ignore_index=True)
 

--- a/nemo_retriever/tests/test_executor_arrow_pandas.py
+++ b/nemo_retriever/tests/test_executor_arrow_pandas.py
@@ -5,13 +5,12 @@
 """Regression tests for Ray's Arrow-to-pandas operator boundary."""
 
 from functools import partial
-from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-import ray
+import pytest
 from ray.data.block import BlockAccessor
 from ray.data import DataContext
 from ray.data.extensions import TensorArray
@@ -62,7 +61,7 @@ def test_adapter_compacts_sliced_nested_arrow_columns() -> None:
     assert isinstance(result.dtypes["text"], pd.ArrowDtype)
 
 
-def test_dataset_materialization_returns_row_safe_pandas_dataframe(monkeypatch) -> None:
+def test_dataset_materialization_returns_row_safe_pandas_dataframe() -> None:
     table = pa.Table.from_pylist(
         [
             {
@@ -74,54 +73,58 @@ def test_dataset_materialization_returns_row_safe_pandas_dataframe(monkeypatch) 
     )
 
     class _Dataset:
-        def iter_batches(self, *, batch_format: str):
-            assert batch_format == "pyarrow"
+        def iter_batches(self, *, batch_format, batch_size):
+            assert batch_format is None
+            assert batch_size is None
             yield table.slice(1, 1)
-
-        def iter_internal_ref_bundles(self):
-            yield SimpleNamespace(blocks=(SimpleNamespace(ref=table.slice(1, 1)),))
 
         def schema(self):
             return table.schema
 
-    monkeypatch.setattr(ray, "get", lambda refs: refs)
     result = ray_dataset_to_pandas(_Dataset())
 
     assert [row.text for row in result.itertuples(index=False)] == ["page 1"]
     assert result.to_dict("records") == [{"metadata": {"error": None, "timing": None}, "text": "page 1"}]
 
 
-def test_dataset_materialization_preserves_object_tensor_pandas_blocks(monkeypatch) -> None:
-    frame = pd.DataFrame(
-        {
-            "table": pd.Series(
-                TensorArray(
-                    [
-                        np.array([{"text": "table text"}], dtype=object),
-                        np.array([], dtype=object),
-                    ]
-                )
-            )
-        }
-    )
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        pytest.param(
+            [
+                np.array([{"text": "first table"}], dtype=object),
+                np.array([{"text": "second table"}], dtype=object),
+            ],
+            [[{"text": "first table"}], [{"text": "second table"}]],
+            id="fixed-shape",
+        ),
+        pytest.param(
+            [
+                np.array([{"text": "table text"}], dtype=object),
+                np.array([], dtype=object),
+            ],
+            [[{"text": "table text"}], []],
+            id="ragged",
+        ),
+    ],
+)
+def test_dataset_materialization_normalizes_object_tensor_pandas_blocks(values, expected) -> None:
+    frame = pd.DataFrame({"table": pd.Series(TensorArray(values))})
 
     class _Dataset:
-        def iter_batches(self, *, batch_format: str):
-            assert batch_format == "pyarrow"
-            yield BlockAccessor.for_block(frame).to_arrow()
-
-        def iter_internal_ref_bundles(self):
-            yield SimpleNamespace(blocks=(SimpleNamespace(ref=frame),))
+        def iter_batches(self, *, batch_format, batch_size):
+            assert batch_format is None
+            assert batch_size is None
+            yield frame
 
         def schema(self):
             return pa.schema([pa.field("table", pa.list_(pa.struct([pa.field("text", pa.string())])))])
 
-    monkeypatch.setattr(ray, "get", lambda refs: refs)
     result = ray_dataset_to_pandas(_Dataset())
 
     assert result["table"].dtype == object
-    assert result["table"].iloc[0].tolist() == [{"text": "table text"}]
-    assert result["table"].iloc[1].tolist() == []
+    assert all(isinstance(value, np.ndarray) for value in result["table"])
+    assert [value.tolist() for value in result["table"]] == expected
 
 
 def test_adapter_preserves_ray_pandas_conversion_policy() -> None:

--- a/nemo_retriever/tests/test_executor_arrow_pandas.py
+++ b/nemo_retriever/tests/test_executor_arrow_pandas.py
@@ -5,11 +5,13 @@
 """Regression tests for Ray's Arrow-to-pandas operator boundary."""
 
 from functools import partial
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import ray
 from ray.data.block import BlockAccessor
 from ray.data import DataContext
 from ray.data.extensions import TensorArray
@@ -60,7 +62,7 @@ def test_adapter_compacts_sliced_nested_arrow_columns() -> None:
     assert isinstance(result.dtypes["text"], pd.ArrowDtype)
 
 
-def test_dataset_materialization_returns_row_safe_pandas_dataframe() -> None:
+def test_dataset_materialization_returns_row_safe_pandas_dataframe(monkeypatch) -> None:
     table = pa.Table.from_pylist(
         [
             {
@@ -76,13 +78,50 @@ def test_dataset_materialization_returns_row_safe_pandas_dataframe() -> None:
             assert batch_format == "pyarrow"
             yield table.slice(1, 1)
 
+        def iter_internal_ref_bundles(self):
+            yield SimpleNamespace(blocks=(SimpleNamespace(ref=table.slice(1, 1)),))
+
         def schema(self):
             return table.schema
 
+    monkeypatch.setattr(ray, "get", lambda refs: refs)
     result = ray_dataset_to_pandas(_Dataset())
 
     assert [row.text for row in result.itertuples(index=False)] == ["page 1"]
     assert result.to_dict("records") == [{"metadata": {"error": None, "timing": None}, "text": "page 1"}]
+
+
+def test_dataset_materialization_preserves_object_tensor_pandas_blocks(monkeypatch) -> None:
+    frame = pd.DataFrame(
+        {
+            "table": pd.Series(
+                TensorArray(
+                    [
+                        np.array([{"text": "table text"}], dtype=object),
+                        np.array([], dtype=object),
+                    ]
+                )
+            )
+        }
+    )
+
+    class _Dataset:
+        def iter_batches(self, *, batch_format: str):
+            assert batch_format == "pyarrow"
+            yield BlockAccessor.for_block(frame).to_arrow()
+
+        def iter_internal_ref_bundles(self):
+            yield SimpleNamespace(blocks=(SimpleNamespace(ref=frame),))
+
+        def schema(self):
+            return pa.schema([pa.field("table", pa.list_(pa.struct([pa.field("text", pa.string())])))])
+
+    monkeypatch.setattr(ray, "get", lambda refs: refs)
+    result = ray_dataset_to_pandas(_Dataset())
+
+    assert result["table"].dtype == object
+    assert result["table"].iloc[0].tolist() == [{"text": "table text"}]
+    assert result["table"].iloc[1].tolist() == []
 
 
 def test_adapter_preserves_ray_pandas_conversion_policy() -> None:

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -1379,13 +1379,9 @@ class TestRayDataExecutor:
         pdf_path.write_bytes(b"pdf")
 
         class _FakeDataset:
-            def iter_batches(self, *, batch_format):
-                assert batch_format == "pyarrow"
-                return iter([])
+            pass
 
-            def schema(self):
-                return SimpleNamespace(names=[])
-
+        fake_dataset = _FakeDataset()
         captured: dict[str, object] = {}
 
         class _FakeDataContext:
@@ -1399,7 +1395,11 @@ class TestRayDataExecutor:
         def _fake_read_binary_files(paths, include_paths=True):
             captured["paths"] = list(paths)
             captured["include_paths"] = include_paths
-            return _FakeDataset()
+            return fake_dataset
+
+        def _fake_ray_dataset_to_pandas(dataset):
+            assert dataset is fake_dataset
+            return pd.DataFrame()
 
         fake_ray_data = SimpleNamespace(
             Dataset=_FakeDataset,
@@ -1415,6 +1415,7 @@ class TestRayDataExecutor:
             lambda ray: SimpleNamespace(available_gpu_count=lambda: 0),
         )
         monkeypatch.setattr("nemo_retriever.graph.executor.resolve_graph", lambda graph, cluster: graph)
+        monkeypatch.setattr("nemo_retriever.graph.executor.ray_dataset_to_pandas", _fake_ray_dataset_to_pandas)
 
         executor = RayDataExecutor(Graph())
         result = executor.ingest([str(tmp_path / "**" / "*.pdf")])


### PR DESCRIPTION
## Summary

- materialize each Ray Dataset block in its native Arrow or pandas representation
- retain the row-safe Arrow compaction introduced by #2523
- normalize object-backed Ray tensor columns before final SDK pandas concatenation

## Root cause

`ray_dataset_to_pandas()` forced every final dataset block through `iter_batches(batch_format="pyarrow")`. After text splitting, structured content can live in a native pandas block as `TensorDtype(object)`. Converting that block back to Arrow calls `pa.from_numpy_dtype(object)` and raises `ArrowNotImplementedError: Unsupported numpy type 17`.

The split had completed successfully; the crash occurred only while materializing the final SDK result. This fix keeps native block ownership at that boundary and avoids both the new pandas-to-Arrow failure and the sliced-Arrow row-access failure addressed by #2523.

Fixes NVBug 6628603.

## Validation

- exact `multimodal_test.pdf` batch reproduction: extract returns 3 rows, split returns 9 rows, and row iteration succeeds
- reproduced and fixed on Ray 2.57.0
- verified the regression and fix on the locked Ray 2.56.1 environment
- `uv run pytest -q tests/test_executor_arrow_pandas.py`: 17 passed
- `test_batch_inline_text_matches_text_file`: passed
- repository pre-commit checks: passed

This is intentionally a boundary-local fix. It does not mutate Ray `DataContext`, add an operator-specific exception, or change the sticky pandas-output policy.