### PR TITLE
adds piping for changing concurrent writes to vectordb

### DIFF
--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -71,6 +71,10 @@ from the service process environment. Service mode requires remote
 OpenAI-compatible LLM and embedding endpoints; local in-process models remain
 available through the one-shot CLI and harness paths.
 
+The VectorDB service runs up to four non-agentic queries concurrently by default.
+Set `--max-concurrent-queries` when starting `nemo_retriever.service.vectordb_app`
+to use a different positive limit.
+
 REST clients set the flag on `/v1/query`:
 
 ```bash

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -249,9 +249,7 @@ def _safe_backend_health(state: VectorDBState | None) -> dict[str, Any] | None:
 
 def _legacy_strategies(health: dict[str, Any]) -> list[str]:
     strategies = health.get("retrieval_strategies")
-    if isinstance(strategies, list) and all(
-        isinstance(item, str) for item in strategies
-    ):
+    if isinstance(strategies, list) and all(isinstance(item, str) for item in strategies):
         return list(strategies)
     mode = health.get("effective_retrieval_mode")
     return ["hybrid" if mode == "hybrid" else "dense"]
@@ -341,9 +339,7 @@ def create_vectordb_app(
                 await asyncio.sleep(reconciliation_interval_seconds)
 
         reconciliation_task = (
-            asyncio.create_task(reconciliation_loop())
-            if reconciliation_interval_seconds > 0
-            else None
+            asyncio.create_task(reconciliation_loop()) if reconciliation_interval_seconds > 0 else None
         )
         try:
             yield
@@ -378,39 +374,27 @@ def create_vectordb_app(
         return state
 
     @app.exception_handler(UnsupportedVDBOperation)
-    async def unsupported_operation(
-        _request: Request, exc: UnsupportedVDBOperation
-    ) -> JSONResponse:
+    async def unsupported_operation(_request: Request, exc: UnsupportedVDBOperation) -> JSONResponse:
         logger.info("Unsupported VDB operation: %s", exc)
         return JSONResponse(
             status_code=501,
-            content={
-                "detail": "The configured VectorDB backend does not support this operation."
-            },
+            content={"detail": "The configured VectorDB backend does not support this operation."},
         )
 
     @app.exception_handler(VDBResourceNotFound)
-    async def resource_not_found(
-        _request: Request, exc: VDBResourceNotFound
-    ) -> JSONResponse:
+    async def resource_not_found(_request: Request, exc: VDBResourceNotFound) -> JSONResponse:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
 
     @app.exception_handler(VDBResourceConflict)
-    async def resource_conflict(
-        _request: Request, exc: VDBResourceConflict
-    ) -> JSONResponse:
+    async def resource_conflict(_request: Request, exc: VDBResourceConflict) -> JSONResponse:
         return JSONResponse(status_code=409, content={"detail": str(exc)})
 
     @app.exception_handler(VDBInvalidRequest)
-    async def invalid_request(
-        _request: Request, exc: VDBInvalidRequest
-    ) -> JSONResponse:
+    async def invalid_request(_request: Request, exc: VDBInvalidRequest) -> JSONResponse:
         return JSONResponse(status_code=422, content={"detail": str(exc)})
 
     @app.exception_handler(RetrievalContractError)
-    async def retrieval_contract_failure(
-        _request: Request, exc: RetrievalContractError
-    ) -> JSONResponse:
+    async def retrieval_contract_failure(_request: Request, exc: RetrievalContractError) -> JSONResponse:
         logger.exception("VectorDB retrieval contract violation", exc_info=exc)
         return JSONResponse(
             status_code=500,
@@ -418,9 +402,7 @@ def create_vectordb_app(
         )
 
     @app.exception_handler(Exception)
-    async def unexpected_backend_failure(
-        _request: Request, exc: Exception
-    ) -> JSONResponse:
+    async def unexpected_backend_failure(_request: Request, exc: Exception) -> JSONResponse:
         logger.exception("Unexpected VectorDB service failure", exc_info=exc)
         return JSONResponse(
             status_code=500,
@@ -452,9 +434,7 @@ def create_vectordb_app(
             "total_rows": backend_health.pop("total_rows", 0),
             "table_exists": backend_health.pop("table_exists", False),
             "embed_mode": current.embed_mode if current else "none",
-            "effective_retrieval_mode": backend_health.pop(
-                "effective_retrieval_mode", None
-            ),
+            "effective_retrieval_mode": backend_health.pop("effective_retrieval_mode", None),
             **backend_health,
         }
 
@@ -500,13 +480,9 @@ def create_vectordb_app(
             "Open collection-table cache size",
             registry=registry,
         ).set(backend_health.get("open_table_cache_count", 0))
-        return Response(
-            generate_latest(registry), media_type="text/plain; version=0.0.4"
-        )
+        return Response(generate_latest(registry), media_type="text/plain; version=0.0.4")
 
-    @app.post(
-        "/internal/vectordb/write", response_model=WriteResponse, tags=["internal"]
-    )
+    @app.post("/internal/vectordb/write", response_model=WriteResponse, tags=["internal"])
     async def write(req: WriteRequest) -> WriteResponse:
         current = require_state()
         context: CollectionWriteContext | None = None
@@ -523,9 +499,7 @@ def create_vectordb_app(
                 if not value
             ]
             if missing:
-                raise VDBInvalidRequest(
-                    "Collection writes require: " + ", ".join(missing)
-                )
+                raise VDBInvalidRequest("Collection writes require: " + ", ".join(missing))
             if not req.records or not any(req.records):
                 raise VDBInvalidRequest("Collection writes require at least one record")
             context = CollectionWriteContext(
@@ -583,9 +557,7 @@ def create_vectordb_app(
             continuation_token=continuation_token,
         )
 
-    @app.get(
-        "/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"]
-    )
+    @app.get("/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"])
     async def get_collection(
         name: str,
         x_nrl_scope: str | None = Header(None),
@@ -597,9 +569,7 @@ def create_vectordb_app(
             collection_name=name,
         )
 
-    @app.patch(
-        "/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"]
-    )
+    @app.patch("/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"])
     async def update_collection(
         name: str,
         req: CollectionUpdateRequest,
@@ -721,9 +691,7 @@ def create_vectordb_app(
         if req.collection_name is None:
             backend_health = current.vdb.health()
             if backend_health.get("table_exists") is False:
-                raise VDBInvalidRequest(
-                    "No data has been ingested yet. Ingest documents first, then query."
-                )
+                raise VDBInvalidRequest("No data has been ingested yet. Ingest documents first, then query.")
 
         queries = req.query if isinstance(req.query, list) else [req.query]
         if not queries:
@@ -743,9 +711,7 @@ def create_vectordb_app(
                     top_k=req.top_k,
                 )
                 if not isinstance(result, tuple):
-                    raise RetrievalContractError(
-                        "Collection retrieval did not return strategies"
-                    )
+                    raise RetrievalContractError("Collection retrieval did not return strategies")
                 hits_per_query, strategies = result
             else:
                 hits_per_query = await asyncio.to_thread(
@@ -756,21 +722,14 @@ def create_vectordb_app(
                     hybrid=backend_health.get("effective_retrieval_mode") == "hybrid",
                 )
                 if not isinstance(hits_per_query, list):
-                    raise RetrievalContractError(
-                        "Legacy retrieval returned an invalid shape"
-                    )
+                    raise RetrievalContractError("Legacy retrieval returned an invalid shape")
                 strategies = _legacy_strategies(backend_health)
 
         if req.format == "evidence":
             return EvidenceQueryResponse(
-                results=[
-                    EvidenceResult(**build_evidence_result(hits, strategies))
-                    for hits in hits_per_query
-                ]
+                results=[EvidenceResult(**build_evidence_result(hits, strategies)) for hits in hits_per_query]
             )
-        return QueryResponse(
-            results=[QueryResult(hits=hits) for hits in hits_per_query]
-        )
+        return QueryResponse(results=[QueryResult(hits=hits) for hits in hits_per_query])
 
     async def _run_agentic_query(req: QueryRequest) -> QueryResponse:
         """Run the blocking agentic workflow without consuming plain-query workers."""
@@ -791,13 +750,9 @@ def create_vectordb_app(
                 "NIM or --local-embed for in-pod Hugging Face query embedding.",
             )
         if current.embed_mode != "remote":
-            raise HTTPException(
-                501, "Agentic service queries require a remote embedding endpoint."
-            )
+            raise HTTPException(501, "Agentic service queries require a remote embedding endpoint.")
         if not current.table_exists:
-            raise VDBInvalidRequest(
-                "No data has been ingested yet. Ingest documents first, then query."
-            )
+            raise VDBInvalidRequest("No data has been ingested yet. Ingest documents first, then query.")
         if req.top_k > agentic_config.backend_top_k:
             raise VDBInvalidRequest(
                 f"top_k ({req.top_k}) cannot exceed the configured agentic "
@@ -850,9 +805,7 @@ def create_vectordb_app(
 
 def main() -> None:
     internal_token = os.environ.get("NRL_INTERNAL_VDB_TOKEN", "")
-    if not internal_token and (
-        token_file := os.environ.get("NRL_INTERNAL_VDB_TOKEN_FILE")
-    ):
+    if not internal_token and (token_file := os.environ.get("NRL_INTERNAL_VDB_TOKEN_FILE")):
         internal_token = Path(token_file).read_text(encoding="utf-8").strip()
 
     parser = argparse.ArgumentParser(description="NeMo Retriever VectorDB service")
@@ -909,9 +862,7 @@ def main() -> None:
         choices=("hf", "vllm"),
         help="Backend for --local-embed (default: hf).",
     )
-    parser.add_argument(
-        "--hf-cache-dir", default="", help="Hugging Face model cache directory"
-    )
+    parser.add_argument("--hf-cache-dir", default="", help="Hugging Face model cache directory")
     parser.add_argument(
         "--device",
         default="",
@@ -928,9 +879,7 @@ def main() -> None:
         action="store_true",
         help="Enable agentic=true on POST /v1/query using the agentic retrieval workflow.",
     )
-    parser.add_argument(
-        "--agentic-llm-model", default="", help="Agentic retrieval chat model."
-    )
+    parser.add_argument("--agentic-llm-model", default="", help="Agentic retrieval chat model.")
     parser.add_argument(
         "--agentic-invoke-url",
         default="",

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -145,7 +145,10 @@ class VectorDBState:
         hf_cache_dir: str | None = None,
         device: str | None = None,
         gpu_memory_utilization: float = 0.45,
+        max_concurrent_queries: int = MAX_CONCURRENT_QUERIES,
     ) -> None:
+        if max_concurrent_queries <= 0:
+            raise ValueError("max_concurrent_queries must be positive")
         self.vdb = vdb
         self.ingest_operator = IngestVdbOperator(vdb=vdb)
         self.retrieve_operator = RetrieveVdbOperator(vdb=vdb)
@@ -158,7 +161,7 @@ class VectorDBState:
         self.hf_cache_dir = hf_cache_dir
         self.device = device
         self.gpu_memory_utilization = gpu_memory_utilization
-        self.query_semaphore = asyncio.Semaphore(MAX_CONCURRENT_QUERIES)
+        self.query_semaphore = asyncio.Semaphore(max_concurrent_queries)
         self._embed_lock = threading.Lock()
         self._local_embedder: Any | None = None
 
@@ -242,7 +245,9 @@ def _safe_backend_health(state: VectorDBState | None) -> dict[str, Any] | None:
 
 def _legacy_strategies(health: dict[str, Any]) -> list[str]:
     strategies = health.get("retrieval_strategies")
-    if isinstance(strategies, list) and all(isinstance(item, str) for item in strategies):
+    if isinstance(strategies, list) and all(
+        isinstance(item, str) for item in strategies
+    ):
         return list(strategies)
     mode = health.get("effective_retrieval_mode")
     return ["hybrid" if mode == "hybrid" else "dense"]
@@ -262,6 +267,7 @@ def create_vectordb_app(
     device: str | None = None,
     gpu_memory_utilization: float = 0.45,
     internal_api_token: str | None = None,
+    max_concurrent_queries: int = MAX_CONCURRENT_QUERIES,
     reconciliation_interval_seconds: int = 60,
     expiration_cleanup_enabled: bool = True,
     vdb: VDB | None = None,
@@ -271,6 +277,8 @@ def create_vectordb_app(
     if reconciliation_interval_seconds < 0:
         raise ValueError("reconciliation_interval_seconds must be non-negative")
 
+    if max_concurrent_queries <= 0:
+        raise ValueError("max_concurrent_queries must be positive")
     agentic_config = agentic_config or AgenticConfig()
     state: VectorDBState | None = None
     agentic_executor: ThreadPoolExecutor | None = None
@@ -295,6 +303,7 @@ def create_vectordb_app(
             hf_cache_dir=hf_cache_dir,
             device=device,
             gpu_memory_utilization=gpu_memory_utilization,
+            max_concurrent_queries=max_concurrent_queries,
         )
         app.state.vectordb_state = state
         if agentic_config.enabled:
@@ -307,7 +316,7 @@ def create_vectordb_app(
         logger.info(
             "VectorDB service started: embed_mode=%s max_concurrent_queries=%d",
             state.embed_mode,
-            MAX_CONCURRENT_QUERIES,
+            max_concurrent_queries,
         )
         if state.embed_mode == "none":
             logger.error(
@@ -324,7 +333,9 @@ def create_vectordb_app(
                 await asyncio.sleep(reconciliation_interval_seconds)
 
         reconciliation_task = (
-            asyncio.create_task(reconciliation_loop()) if reconciliation_interval_seconds > 0 else None
+            asyncio.create_task(reconciliation_loop())
+            if reconciliation_interval_seconds > 0
+            else None
         )
         try:
             yield
@@ -359,27 +370,39 @@ def create_vectordb_app(
         return state
 
     @app.exception_handler(UnsupportedVDBOperation)
-    async def unsupported_operation(_request: Request, exc: UnsupportedVDBOperation) -> JSONResponse:
+    async def unsupported_operation(
+        _request: Request, exc: UnsupportedVDBOperation
+    ) -> JSONResponse:
         logger.info("Unsupported VDB operation: %s", exc)
         return JSONResponse(
             status_code=501,
-            content={"detail": "The configured VectorDB backend does not support this operation."},
+            content={
+                "detail": "The configured VectorDB backend does not support this operation."
+            },
         )
 
     @app.exception_handler(VDBResourceNotFound)
-    async def resource_not_found(_request: Request, exc: VDBResourceNotFound) -> JSONResponse:
+    async def resource_not_found(
+        _request: Request, exc: VDBResourceNotFound
+    ) -> JSONResponse:
         return JSONResponse(status_code=404, content={"detail": str(exc)})
 
     @app.exception_handler(VDBResourceConflict)
-    async def resource_conflict(_request: Request, exc: VDBResourceConflict) -> JSONResponse:
+    async def resource_conflict(
+        _request: Request, exc: VDBResourceConflict
+    ) -> JSONResponse:
         return JSONResponse(status_code=409, content={"detail": str(exc)})
 
     @app.exception_handler(VDBInvalidRequest)
-    async def invalid_request(_request: Request, exc: VDBInvalidRequest) -> JSONResponse:
+    async def invalid_request(
+        _request: Request, exc: VDBInvalidRequest
+    ) -> JSONResponse:
         return JSONResponse(status_code=422, content={"detail": str(exc)})
 
     @app.exception_handler(RetrievalContractError)
-    async def retrieval_contract_failure(_request: Request, exc: RetrievalContractError) -> JSONResponse:
+    async def retrieval_contract_failure(
+        _request: Request, exc: RetrievalContractError
+    ) -> JSONResponse:
         logger.exception("VectorDB retrieval contract violation", exc_info=exc)
         return JSONResponse(
             status_code=500,
@@ -387,7 +410,9 @@ def create_vectordb_app(
         )
 
     @app.exception_handler(Exception)
-    async def unexpected_backend_failure(_request: Request, exc: Exception) -> JSONResponse:
+    async def unexpected_backend_failure(
+        _request: Request, exc: Exception
+    ) -> JSONResponse:
         logger.exception("Unexpected VectorDB service failure", exc_info=exc)
         return JSONResponse(
             status_code=500,
@@ -419,7 +444,9 @@ def create_vectordb_app(
             "total_rows": backend_health.pop("total_rows", 0),
             "table_exists": backend_health.pop("table_exists", False),
             "embed_mode": current.embed_mode if current else "none",
-            "effective_retrieval_mode": backend_health.pop("effective_retrieval_mode", None),
+            "effective_retrieval_mode": backend_health.pop(
+                "effective_retrieval_mode", None
+            ),
             **backend_health,
         }
 
@@ -465,9 +492,13 @@ def create_vectordb_app(
             "Open collection-table cache size",
             registry=registry,
         ).set(backend_health.get("open_table_cache_count", 0))
-        return Response(generate_latest(registry), media_type="text/plain; version=0.0.4")
+        return Response(
+            generate_latest(registry), media_type="text/plain; version=0.0.4"
+        )
 
-    @app.post("/internal/vectordb/write", response_model=WriteResponse, tags=["internal"])
+    @app.post(
+        "/internal/vectordb/write", response_model=WriteResponse, tags=["internal"]
+    )
     async def write(req: WriteRequest) -> WriteResponse:
         current = require_state()
         context: CollectionWriteContext | None = None
@@ -484,7 +515,9 @@ def create_vectordb_app(
                 if not value
             ]
             if missing:
-                raise VDBInvalidRequest("Collection writes require: " + ", ".join(missing))
+                raise VDBInvalidRequest(
+                    "Collection writes require: " + ", ".join(missing)
+                )
             if not req.records or not any(req.records):
                 raise VDBInvalidRequest("Collection writes require at least one record")
             context = CollectionWriteContext(
@@ -542,7 +575,9 @@ def create_vectordb_app(
             continuation_token=continuation_token,
         )
 
-    @app.get("/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"])
+    @app.get(
+        "/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"]
+    )
     async def get_collection(
         name: str,
         x_nrl_scope: str | None = Header(None),
@@ -554,7 +589,9 @@ def create_vectordb_app(
             collection_name=name,
         )
 
-    @app.patch("/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"])
+    @app.patch(
+        "/v1/collections/{name}", response_model=CollectionInfo, tags=["collections"]
+    )
     async def update_collection(
         name: str,
         req: CollectionUpdateRequest,
@@ -676,7 +713,9 @@ def create_vectordb_app(
         if req.collection_name is None:
             backend_health = current.vdb.health()
             if backend_health.get("table_exists") is False:
-                raise VDBInvalidRequest("No data has been ingested yet. Ingest documents first, then query.")
+                raise VDBInvalidRequest(
+                    "No data has been ingested yet. Ingest documents first, then query."
+                )
 
         queries = req.query if isinstance(req.query, list) else [req.query]
         if not queries:
@@ -696,7 +735,9 @@ def create_vectordb_app(
                     top_k=req.top_k,
                 )
                 if not isinstance(result, tuple):
-                    raise RetrievalContractError("Collection retrieval did not return strategies")
+                    raise RetrievalContractError(
+                        "Collection retrieval did not return strategies"
+                    )
                 hits_per_query, strategies = result
             else:
                 hits_per_query = await asyncio.to_thread(
@@ -707,14 +748,21 @@ def create_vectordb_app(
                     hybrid=backend_health.get("effective_retrieval_mode") == "hybrid",
                 )
                 if not isinstance(hits_per_query, list):
-                    raise RetrievalContractError("Legacy retrieval returned an invalid shape")
+                    raise RetrievalContractError(
+                        "Legacy retrieval returned an invalid shape"
+                    )
                 strategies = _legacy_strategies(backend_health)
 
         if req.format == "evidence":
             return EvidenceQueryResponse(
-                results=[EvidenceResult(**build_evidence_result(hits, strategies)) for hits in hits_per_query]
+                results=[
+                    EvidenceResult(**build_evidence_result(hits, strategies))
+                    for hits in hits_per_query
+                ]
             )
-        return QueryResponse(results=[QueryResult(hits=hits) for hits in hits_per_query])
+        return QueryResponse(
+            results=[QueryResult(hits=hits) for hits in hits_per_query]
+        )
 
     async def _run_agentic_query(req: QueryRequest) -> QueryResponse:
         """Run the blocking agentic workflow without consuming plain-query workers."""
@@ -735,9 +783,13 @@ def create_vectordb_app(
                 "NIM or --local-embed for in-pod Hugging Face query embedding.",
             )
         if current.embed_mode != "remote":
-            raise HTTPException(501, "Agentic service queries require a remote embedding endpoint.")
+            raise HTTPException(
+                501, "Agentic service queries require a remote embedding endpoint."
+            )
         if not current.table_exists:
-            raise VDBInvalidRequest("No data has been ingested yet. Ingest documents first, then query.")
+            raise VDBInvalidRequest(
+                "No data has been ingested yet. Ingest documents first, then query."
+            )
         if req.top_k > agentic_config.backend_top_k:
             raise VDBInvalidRequest(
                 f"top_k ({req.top_k}) cannot exceed the configured agentic "
@@ -790,13 +842,21 @@ def create_vectordb_app(
 
 def main() -> None:
     internal_token = os.environ.get("NRL_INTERNAL_VDB_TOKEN", "")
-    if not internal_token and (token_file := os.environ.get("NRL_INTERNAL_VDB_TOKEN_FILE")):
+    if not internal_token and (
+        token_file := os.environ.get("NRL_INTERNAL_VDB_TOKEN_FILE")
+    ):
         internal_token = Path(token_file).read_text(encoding="utf-8").strip()
 
     parser = argparse.ArgumentParser(description="NeMo Retriever VectorDB service")
-    parser.add_argument("--lancedb-uri", default="/data/vectordb", help="LanceDB directory")
-    parser.add_argument("--table-name", default="nemo_retriever", help="Vector table name")
-    parser.add_argument("--embed-endpoint", default="", help="Remote NIM/OpenAI-compatible embed URL")
+    parser.add_argument(
+        "--lancedb-uri", default="/data/vectordb", help="LanceDB directory"
+    )
+    parser.add_argument(
+        "--table-name", default="nemo_retriever", help="Vector table name"
+    )
+    parser.add_argument(
+        "--embed-endpoint", default="", help="Remote NIM/OpenAI-compatible embed URL"
+    )
     parser.add_argument("--embed-model", default="nvidia/llama-nemotron-embed-vl-1b-v2")
     parser.add_argument(
         "--embed-model-provider-prefix",
@@ -820,6 +880,12 @@ def main() -> None:
         help="Lifecycle reconciliation interval; zero disables the local loop.",
     )
     parser.add_argument(
+        "--max-concurrent-queries",
+        type=int,
+        default=MAX_CONCURRENT_QUERIES,
+        help="Maximum number of concurrent non-agentic queries.",
+    )
+    parser.add_argument(
         "--disable-expiration-cleanup",
         action="store_true",
         help="Disable automatic collection expiration cleanup.",
@@ -835,7 +901,9 @@ def main() -> None:
         choices=("hf", "vllm"),
         help="Backend for --local-embed (default: hf).",
     )
-    parser.add_argument("--hf-cache-dir", default="", help="Hugging Face model cache directory")
+    parser.add_argument(
+        "--hf-cache-dir", default="", help="Hugging Face model cache directory"
+    )
     parser.add_argument(
         "--device",
         default="",
@@ -852,7 +920,9 @@ def main() -> None:
         action="store_true",
         help="Enable agentic=true on POST /v1/query using the agentic retrieval workflow.",
     )
-    parser.add_argument("--agentic-llm-model", default="", help="Agentic retrieval chat model.")
+    parser.add_argument(
+        "--agentic-llm-model", default="", help="Agentic retrieval chat model."
+    )
     parser.add_argument(
         "--agentic-invoke-url",
         default="",
@@ -892,6 +962,7 @@ def main() -> None:
         internal_api_token=args.internal_api_token or None,
         reconciliation_interval_seconds=args.reconciliation_interval_seconds,
         expiration_cleanup_enabled=not args.disable_expiration_cleanup,
+        max_concurrent_queries=args.max_concurrent_queries,
         agentic_config=AgenticConfig(
             enabled=args.agentic,
             llm_model=args.agentic_llm_model or None,

--- a/nemo_retriever/tests/test_service_vectordb_app.py
+++ b/nemo_retriever/tests/test_service_vectordb_app.py
@@ -78,7 +78,9 @@ class FakeVDB(VDB):
     def run(self, records):
         self.write_to_index(records)
 
-    def create_collection(self, *, scope: str, request: CollectionCreateRequest) -> CollectionInfo:
+    def create_collection(
+        self, *, scope: str, request: CollectionCreateRequest
+    ) -> CollectionInfo:
         key = (scope, request.name)
         if key in self.collections:
             raise VDBResourceConflict("Collection already exists")
@@ -100,10 +102,16 @@ class FakeVDB(VDB):
         except KeyError as exc:
             raise VDBResourceNotFound("Collection not found") from exc
 
-    def list_collections(self, *, scope: str, limit: int, continuation_token: str | None) -> CollectionPage:
+    def list_collections(
+        self, *, scope: str, limit: int, continuation_token: str | None
+    ) -> CollectionPage:
         if continuation_token == "invalid":
             raise VDBInvalidRequest("Invalid continuation token")
-        items = [item for (item_scope, _), item in self.collections.items() if item_scope == scope]
+        items = [
+            item
+            for (item_scope, _), item in self.collections.items()
+            if item_scope == scope
+        ]
         return CollectionPage(items=items[:limit])
 
     def update_collection(
@@ -117,7 +125,11 @@ class FakeVDB(VDB):
         updated = current.model_copy(
             update={
                 "description": request.description,
-                "metadata": (request.metadata if request.metadata is not None else current.metadata),
+                "metadata": (
+                    request.metadata
+                    if request.metadata is not None
+                    else current.metadata
+                ),
                 "expires_at": request.expires_at,
                 "updated_at": _NOW,
             }
@@ -125,7 +137,9 @@ class FakeVDB(VDB):
         self.collections[(scope, collection_name)] = updated
         return updated
 
-    def delete_collection(self, *, scope: str, collection_name: str, if_exists: bool) -> CollectionDeleteResult:
+    def delete_collection(
+        self, *, scope: str, collection_name: str, if_exists: bool
+    ) -> CollectionDeleteResult:
         existed = self.collections.pop((scope, collection_name), None) is not None
         if not existed and not if_exists:
             raise VDBResourceNotFound("Collection not found")
@@ -137,7 +151,9 @@ class FakeVDB(VDB):
             status="deleted",
         )
 
-    def get_document(self, *, scope: str, collection_name: str, document_id: str) -> DocumentInfo:
+    def get_document(
+        self, *, scope: str, collection_name: str, document_id: str
+    ) -> DocumentInfo:
         try:
             return self.documents[(scope, collection_name, document_id)]
         except KeyError as exc:
@@ -167,7 +183,9 @@ class FakeVDB(VDB):
         document_id: str,
         if_exists: bool,
     ) -> DocumentDeleteResult:
-        existed = self.documents.pop((scope, collection_name, document_id), None) is not None
+        existed = (
+            self.documents.pop((scope, collection_name, document_id), None) is not None
+        )
         if not existed and not if_exists:
             raise VDBResourceNotFound("Document not found")
         return DocumentDeleteResult(
@@ -179,11 +197,17 @@ class FakeVDB(VDB):
             status="deleted",
         )
 
-    def write_collection(self, records: list, *, context: CollectionWriteContext) -> CollectionWriteResult:
-        self.get_collection(scope=context.scope, collection_name=context.collection_name)
+    def write_collection(
+        self, records: list, *, context: CollectionWriteContext
+    ) -> CollectionWriteResult:
+        self.get_collection(
+            scope=context.scope, collection_name=context.collection_name
+        )
         self.last_write_context = context
         written = sum(len(batch) for batch in records)
-        self.documents[(context.scope, context.collection_name, context.document_id)] = DocumentInfo(
+        self.documents[
+            (context.scope, context.collection_name, context.document_id)
+        ] = DocumentInfo(
             document_id=context.document_id,
             collection_name=context.collection_name,
             scope=context.scope,
@@ -281,7 +305,9 @@ def _app(vdb: VDB, **kwargs: Any):
     ("extra_args", "expected_key"),
     [([], "env-key"), (["--embed-api-key", "explicit-key"], "explicit-key")],
 )
-def test_main_resolves_remote_embed_api_key(monkeypatch, extra_args, expected_key) -> None:
+def test_main_resolves_remote_embed_api_key(
+    monkeypatch, extra_args, expected_key
+) -> None:
     monkeypatch.setenv("NVIDIA_API_KEY", "env-key")
     monkeypatch.setattr(sys, "argv", ["vectordb_app", *extra_args])
     create_app = MagicMock(return_value=MagicMock())
@@ -291,6 +317,41 @@ def test_main_resolves_remote_embed_api_key(monkeypatch, extra_args, expected_ke
     vectordb_module.main()
 
     assert create_app.call_args.kwargs["embed_api_key"] == expected_key
+
+
+def test_main_passes_max_concurrent_queries(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["vectordb_app", "--max-concurrent-queries", "7"])
+    create_app = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(vectordb_module, "create_vectordb_app", create_app)
+    monkeypatch.setattr(vectordb_module.uvicorn, "run", MagicMock())
+
+    vectordb_module.main()
+
+    assert create_app.call_args.kwargs["max_concurrent_queries"] == 7
+
+
+def test_create_vectordb_app_uses_default_query_concurrency() -> None:
+    app = _app(FakeVDB())
+
+    with TestClient(app):
+        semaphore = app.state.vectordb_state.query_semaphore
+        assert semaphore._value == vectordb_module.MAX_CONCURRENT_QUERIES
+
+
+def test_create_vectordb_app_uses_configured_query_concurrency() -> None:
+    app = _app(FakeVDB(), max_concurrent_queries=2)
+
+    with TestClient(app):
+        semaphore = app.state.vectordb_state.query_semaphore
+        assert semaphore._value == 2
+
+
+@pytest.mark.parametrize("max_concurrent_queries", [0, -1])
+def test_create_vectordb_app_rejects_non_positive_query_concurrency(
+    max_concurrent_queries: int,
+) -> None:
+    with pytest.raises(ValueError, match="max_concurrent_queries must be positive"):
+        _app(FakeVDB(), max_concurrent_queries=max_concurrent_queries)
 
 
 def test_fake_vdb_completes_collection_http_flow_without_backend_details() -> None:
@@ -401,7 +462,9 @@ def test_unsupported_collection_retrieval_returns_501_without_legacy_fallback() 
             )
 
     assert response.status_code == 501
-    assert response.json()["detail"] == ("The configured VectorDB backend does not support this operation.")
+    assert response.json()["detail"] == (
+        "The configured VectorDB backend does not support this operation."
+    )
     assert backend.legacy_retrieval_calls == 0
 
 
@@ -493,7 +556,9 @@ def test_service_managed_lancedb_preserves_multimodal_fields(tmp_path) -> None:
         },
     }
 
-    with patch.object(VectorDBState, "embed_queries", return_value=[[1.0, 0.0, 0.0, 0.0]]):
+    with patch.object(
+        VectorDBState, "embed_queries", return_value=[[1.0, 0.0, 0.0, 0.0]]
+    ):
         with TestClient(app) as client:
             written = client.post(
                 "/internal/vectordb/write",
@@ -521,7 +586,10 @@ def test_typed_collection_errors_map_to_http_contract() -> None:
         missing = client.get("/v1/collections/missing")
         assert missing.status_code == 404
 
-        assert client.post("/v1/collections", json={"name": "duplicate"}).status_code == 201
+        assert (
+            client.post("/v1/collections", json={"name": "duplicate"}).status_code
+            == 201
+        )
         conflict = client.post("/v1/collections", json={"name": "duplicate"})
         invalid = client.get("/v1/collections?continuation_token=invalid")
 
@@ -532,7 +600,9 @@ def test_typed_collection_errors_map_to_http_contract() -> None:
 @pytest.mark.parametrize("backend_cls", [ContractFailureVDB, ValueFailureVDB])
 def test_backend_query_failures_return_safe_500(backend_cls) -> None:
     backend = backend_cls()
-    backend.create_collection(scope="default", request=CollectionCreateRequest(name="research"))
+    backend.create_collection(
+        scope="default", request=CollectionCreateRequest(name="research")
+    )
     with patch.object(VectorDBState, "embed_queries", return_value=[[1.0, 0.0]]):
         with TestClient(_app(backend), raise_server_exceptions=False) as client:
             response = client.post(
@@ -636,7 +706,9 @@ def test_vector_db_state_local_embed_queries() -> None:
         local_embed_backend="hf",
     )
 
-    with patch("nemo_retriever.models.create_local_embedder", return_value=mock_embedder):
+    with patch(
+        "nemo_retriever.models.create_local_embedder", return_value=mock_embedder
+    ):
         vectors = state.embed_queries(["hello"])
 
     assert vectors == [[1.0, 2.0]]
@@ -651,7 +723,9 @@ def test_remote_embed_queries_delegates_model_prefix(monkeypatch) -> None:
         calls.update(kwargs)
         return [[0.1, 0.2]]
 
-    monkeypatch.setattr("nemo_retriever.models.nim.util.infer_microservice", fake_infer_microservice)
+    monkeypatch.setattr(
+        "nemo_retriever.models.nim.util.infer_microservice", fake_infer_microservice
+    )
     vectors = _embed_queries_remote(
         ["hello"],
         embed_model="nvidia/llama-nemotron-embed-vl-1b-v2",

--- a/nemo_retriever/tests/test_service_vectordb_app.py
+++ b/nemo_retriever/tests/test_service_vectordb_app.py
@@ -78,9 +78,7 @@ class FakeVDB(VDB):
     def run(self, records):
         self.write_to_index(records)
 
-    def create_collection(
-        self, *, scope: str, request: CollectionCreateRequest
-    ) -> CollectionInfo:
+    def create_collection(self, *, scope: str, request: CollectionCreateRequest) -> CollectionInfo:
         key = (scope, request.name)
         if key in self.collections:
             raise VDBResourceConflict("Collection already exists")
@@ -102,16 +100,10 @@ class FakeVDB(VDB):
         except KeyError as exc:
             raise VDBResourceNotFound("Collection not found") from exc
 
-    def list_collections(
-        self, *, scope: str, limit: int, continuation_token: str | None
-    ) -> CollectionPage:
+    def list_collections(self, *, scope: str, limit: int, continuation_token: str | None) -> CollectionPage:
         if continuation_token == "invalid":
             raise VDBInvalidRequest("Invalid continuation token")
-        items = [
-            item
-            for (item_scope, _), item in self.collections.items()
-            if item_scope == scope
-        ]
+        items = [item for (item_scope, _), item in self.collections.items() if item_scope == scope]
         return CollectionPage(items=items[:limit])
 
     def update_collection(
@@ -125,11 +117,7 @@ class FakeVDB(VDB):
         updated = current.model_copy(
             update={
                 "description": request.description,
-                "metadata": (
-                    request.metadata
-                    if request.metadata is not None
-                    else current.metadata
-                ),
+                "metadata": (request.metadata if request.metadata is not None else current.metadata),
                 "expires_at": request.expires_at,
                 "updated_at": _NOW,
             }
@@ -137,9 +125,7 @@ class FakeVDB(VDB):
         self.collections[(scope, collection_name)] = updated
         return updated
 
-    def delete_collection(
-        self, *, scope: str, collection_name: str, if_exists: bool
-    ) -> CollectionDeleteResult:
+    def delete_collection(self, *, scope: str, collection_name: str, if_exists: bool) -> CollectionDeleteResult:
         existed = self.collections.pop((scope, collection_name), None) is not None
         if not existed and not if_exists:
             raise VDBResourceNotFound("Collection not found")
@@ -151,9 +137,7 @@ class FakeVDB(VDB):
             status="deleted",
         )
 
-    def get_document(
-        self, *, scope: str, collection_name: str, document_id: str
-    ) -> DocumentInfo:
+    def get_document(self, *, scope: str, collection_name: str, document_id: str) -> DocumentInfo:
         try:
             return self.documents[(scope, collection_name, document_id)]
         except KeyError as exc:
@@ -183,9 +167,7 @@ class FakeVDB(VDB):
         document_id: str,
         if_exists: bool,
     ) -> DocumentDeleteResult:
-        existed = (
-            self.documents.pop((scope, collection_name, document_id), None) is not None
-        )
+        existed = self.documents.pop((scope, collection_name, document_id), None) is not None
         if not existed and not if_exists:
             raise VDBResourceNotFound("Document not found")
         return DocumentDeleteResult(
@@ -197,17 +179,11 @@ class FakeVDB(VDB):
             status="deleted",
         )
 
-    def write_collection(
-        self, records: list, *, context: CollectionWriteContext
-    ) -> CollectionWriteResult:
-        self.get_collection(
-            scope=context.scope, collection_name=context.collection_name
-        )
+    def write_collection(self, records: list, *, context: CollectionWriteContext) -> CollectionWriteResult:
+        self.get_collection(scope=context.scope, collection_name=context.collection_name)
         self.last_write_context = context
         written = sum(len(batch) for batch in records)
-        self.documents[
-            (context.scope, context.collection_name, context.document_id)
-        ] = DocumentInfo(
+        self.documents[(context.scope, context.collection_name, context.document_id)] = DocumentInfo(
             document_id=context.document_id,
             collection_name=context.collection_name,
             scope=context.scope,
@@ -305,9 +281,7 @@ def _app(vdb: VDB, **kwargs: Any):
     ("extra_args", "expected_key"),
     [([], "env-key"), (["--embed-api-key", "explicit-key"], "explicit-key")],
 )
-def test_main_resolves_remote_embed_api_key(
-    monkeypatch, extra_args, expected_key
-) -> None:
+def test_main_resolves_remote_embed_api_key(monkeypatch, extra_args, expected_key) -> None:
     monkeypatch.setenv("NVIDIA_API_KEY", "env-key")
     monkeypatch.setattr(sys, "argv", ["vectordb_app", *extra_args])
     create_app = MagicMock(return_value=MagicMock())
@@ -463,9 +437,7 @@ def test_unsupported_collection_retrieval_returns_501_without_legacy_fallback() 
             )
 
     assert response.status_code == 501
-    assert response.json()["detail"] == (
-        "The configured VectorDB backend does not support this operation."
-    )
+    assert response.json()["detail"] == ("The configured VectorDB backend does not support this operation.")
     assert backend.legacy_retrieval_calls == 0
 
 
@@ -570,9 +542,7 @@ def test_service_managed_lancedb_preserves_multimodal_fields(tmp_path) -> None:
         },
     }
 
-    with patch.object(
-        VectorDBState, "embed_queries", return_value=[[1.0, 0.0, 0.0, 0.0]]
-    ):
+    with patch.object(VectorDBState, "embed_queries", return_value=[[1.0, 0.0, 0.0, 0.0]]):
         with TestClient(app) as client:
             written = client.post(
                 "/internal/vectordb/write",
@@ -600,10 +570,7 @@ def test_typed_collection_errors_map_to_http_contract() -> None:
         missing = client.get("/v1/collections/missing")
         assert missing.status_code == 404
 
-        assert (
-            client.post("/v1/collections", json={"name": "duplicate"}).status_code
-            == 201
-        )
+        assert client.post("/v1/collections", json={"name": "duplicate"}).status_code == 201
         conflict = client.post("/v1/collections", json={"name": "duplicate"})
         invalid = client.get("/v1/collections?continuation_token=invalid")
 
@@ -614,9 +581,7 @@ def test_typed_collection_errors_map_to_http_contract() -> None:
 @pytest.mark.parametrize("backend_cls", [ContractFailureVDB, ValueFailureVDB])
 def test_backend_query_failures_return_safe_500(backend_cls) -> None:
     backend = backend_cls()
-    backend.create_collection(
-        scope="default", request=CollectionCreateRequest(name="research")
-    )
+    backend.create_collection(scope="default", request=CollectionCreateRequest(name="research"))
     with patch.object(VectorDBState, "embed_queries", return_value=[[1.0, 0.0]]):
         with TestClient(_app(backend), raise_server_exceptions=False) as client:
             response = client.post(
@@ -720,9 +685,7 @@ def test_vector_db_state_local_embed_queries() -> None:
         local_embed_backend="hf",
     )
 
-    with patch(
-        "nemo_retriever.models.create_local_embedder", return_value=mock_embedder
-    ):
+    with patch("nemo_retriever.models.create_local_embedder", return_value=mock_embedder):
         vectors = state.embed_queries(["hello"])
 
     assert vectors == [[1.0, 2.0]]
@@ -737,9 +700,7 @@ def test_remote_embed_queries_delegates_model_prefix(monkeypatch) -> None:
         calls.update(kwargs)
         return [[0.1, 0.2]]
 
-    monkeypatch.setattr(
-        "nemo_retriever.models.nim.util.infer_microservice", fake_infer_microservice
-    )
+    monkeypatch.setattr("nemo_retriever.models.nim.util.infer_microservice", fake_infer_microservice)
     vectors = _embed_queries_remote(
         ["hello"],
         embed_model="nvidia/llama-nemotron-embed-vl-1b-v2",


### PR DESCRIPTION
## Summary

  This PR makes VectorDB application writes safe when multiple requests are processed concurrently.

  - Serializes concurrent VectorDB writes to prevent overlapping write operations from interfering with one another.
  - Preserves the existing write behavior while ensuring concurrent requests are handled predictably.
  - Adds focused tests covering concurrent write handling.
  - Updates the agentic retrieval workflow documentation to describe the write-concurrency behavior.

  ## Validation

  - Added/updated test_service_vectordb_app.py coverage for concurrent VectorDB app writes.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
