### PR TITLE
Fix generation error precedence in failure classification

### DIFF
--- a/nemo_retriever/src/nemo_retriever/tools/evaluation/scoring.py
+++ b/nemo_retriever/src/nemo_retriever/tools/evaluation/scoring.py
@@ -255,6 +255,9 @@ def classify_failure(
     if gen_error == "thinking_truncated":
         return "thinking_truncated"
 
+    if gen_error is not None:
+        return "generation_error"
+
     if judge_score is None:
         return "judge_error"
 
@@ -308,7 +311,8 @@ def score_dataframe(df: pd.DataFrame) -> pd.DataFrame:
 
         judge_score_raw = row.get("judge_score")
         judge_score = None if pd.isna(judge_score_raw) else float(judge_score_raw)
-        gen_error = row.get("gen_error")
+        gen_error_raw = row.get("gen_error")
+        gen_error = None if pd.isna(gen_error_raw) else str(gen_error_raw)
         fm = classify_failure(
             ref_in_chunks=aic,
             judge_score=judge_score,

--- a/nemo_retriever/tests/test_live_rag.py
+++ b/nemo_retriever/tests/test_live_rag.py
@@ -438,6 +438,62 @@ class TestRetrieveBatch:
 class TestPipelineBuilder:
     """Retriever.pipeline() fluent builder composition."""
 
+    @pytest.mark.parametrize(
+        ("gen_error", "answer", "judge_score", "judge_error", "expected_failure_mode"),
+        [
+            ("transport_error", "", None, "empty_candidate", "generation_error"),
+            ("request_error", "", None, "empty_candidate", "generation_error"),
+            ("thinking_truncated", "", None, "empty_candidate", "thinking_truncated"),
+            (None, "reference answer", None, "transport_error", "judge_error"),
+            (None, "reference answer", 1.0, None, "correct"),
+        ],
+    )
+    def test_failure_mode_uses_originating_stage(
+        self,
+        gen_error,
+        answer,
+        judge_score,
+        judge_error,
+        expected_failure_mode,
+    ):
+        """Generation errors take precedence in the supported operator order."""
+        from nemo_retriever.models.llm.types import GenerationResult, JudgeResult, RetrievalResult
+
+        class _Generator:
+            supports_concurrent_calls = False
+            model = "deterministic/generator"
+
+            def generate(self, query, chunks, *, reasoning_enabled=None):
+                return GenerationResult(
+                    answer=answer,
+                    latency_s=0.0,
+                    model=self.model,
+                    error=gen_error,
+                )
+
+        class _Judge:
+            def judge(self, query, reference, candidate):
+                if not candidate.strip():
+                    return JudgeResult(score=None, reasoning="Candidate answer was empty.", error="empty_candidate")
+                return JudgeResult(score=judge_score, reasoning="", error=judge_error)
+
+        r = _make_retriever()
+        retrieved = RetrievalResult(
+            chunks=["reference answer"],
+            metadata=[{"source": "deterministic"}],
+        )
+
+        with patch.object(r, "retrieve_batch", return_value=[retrieved]):
+            builder = r.pipeline().generate(_build_fake_llm_client()).judge(_build_fake_judge()).score()
+            builder._steps[0]._client = _Generator()
+            builder._steps[1]._judge = _Judge()
+            out = builder.run(["query"], reference=["reference answer"])
+
+        row = out.iloc[0]
+        assert row.gen_error == gen_error
+        assert row.judge_error == judge_error
+        assert row.failure_mode == expected_failure_mode
+
     def test_builder_composition_runs_expected_steps(self):
         """generate -> score -> judge builds and executes the full chain."""
         r = _make_retriever()


### PR DESCRIPTION
## Description

NVBug 6622224.

Batch Live RAG evaluation currently classifies generic generation failures such as `transport_error` and `request_error` as `judge_error` when generation produces an empty candidate and no judge score is available. This incorrectly attributes the failure to the judge stage even though `gen_error` identifies generation as the originating stage.

This change gives generation errors precedence when deriving `failure_mode`. The existing `thinking_truncated` classification remains unchanged, while other non-null generation errors now use the stable `generation_error` bucket. `judge_error` is reserved for cases where generation succeeded but judging did not produce a score. The DataFrame scoring path also normalizes missing generation-error values before classification.

This affects only batch/operator evaluation and reporting. Single-query `Retriever.answer()` already returns before judging or scoring after a generation failure.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
