### PR TITLE
fix: return row-safe pandas frames for Arrow null-child store results

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -56,35 +56,34 @@ def _contains_null_arrow_child(data_type: Any) -> bool:
     return False
 
 
-def _compact_vulnerable_arrow_columns(table: Any) -> Any:
-    """Reset offsets before Ray converts nested null children to pandas."""
+def _is_row_unsafe_arrow_column(field: Any) -> bool:
+    """Return whether pandas must not back a column with its Arrow array.
+
+    Two column shapes leave pandas unable to read rows once Arrow-backed dtypes
+    are preserved:
+
+    * Nested types carrying an inferred ``null`` child, such as a ``page_image``
+      struct whose ``image_b64`` was stripped. pandas indexes the null child at
+      the parent's row offset, but pyarrow sizes null children independently of
+      their parent, so row access raises ``ArrowIndexError`` and an Arrow
+      roundtrip reports a child shorter than its parent.
+    * Ray's pickled-object extension columns, whose payloads pandas would
+      otherwise interpret as malformed extension arrays.
+    """
+    if getattr(field.type, "extension_name", None) == "ray.data.arrow_pickled_object":
+        return True
+    return _contains_null_arrow_child(field.type)
+
+
+def _materialize_row_unsafe_columns(table: Any, frame: pd.DataFrame) -> pd.DataFrame:
+    """Rewrite Arrow columns pandas cannot index as plain object columns."""
     import pyarrow as pa
-    import pyarrow.compute as pc
 
-    if not isinstance(table, pa.Table) or table.num_rows == 0:
-        return table
-
-    indices = None
-    compacted = table
-    for index, field in enumerate(table.schema):
-        column = table.column(index)
-        if not _contains_null_arrow_child(field.type) or not any(chunk.offset for chunk in column.chunks):
-            continue
-        if indices is None:
-            indices = pa.array(range(table.num_rows), type=pa.int64())
-        compacted = compacted.set_column(index, field, pc.take(column, indices))
-    return compacted
-
-
-def _normalize_pickled_object_columns(table: Any, frame: pd.DataFrame) -> pd.DataFrame:
-    """Convert Ray's pickled-object extension columns to plain pandas objects."""
-    import pyarrow as pa
-
-    if not isinstance(table, pa.Table):
+    if not isinstance(table, (pa.Table, pa.RecordBatch)):
         return frame
 
     for index, field in enumerate(table.schema):
-        if getattr(field.type, "extension_name", None) != "ray.data.arrow_pickled_object":
+        if not _is_row_unsafe_arrow_column(field):
             continue
         frame[field.name] = pd.Series(table.column(index).to_pylist(), index=frame.index, dtype=object)
     return frame
@@ -93,30 +92,27 @@ def _normalize_pickled_object_columns(table: Any, frame: pd.DataFrame) -> pd.Dat
 def arrow_table_to_pandas(table: Any) -> pd.DataFrame:
     """Convert a Ray Arrow batch to a row-safe pandas DataFrame.
 
-    Ray 2.56+ preserves Arrow-backed pandas dtypes. Before conversion, sliced
-    nested columns with inferred null children must be compacted. Ray's
-    pickled-object extension columns also need to be materialized as ordinary
-    object columns so pandas row operations do not interpret their payloads as
-    malformed extension arrays.
+    Ray 2.56+ preserves Arrow-backed pandas dtypes, so columns pandas cannot
+    index through their Arrow arrays are materialized as ordinary object
+    columns. Every other column keeps its Arrow-backed dtype.
     """
     if isinstance(table, pd.DataFrame):
         return table
 
     from ray.data.block import BlockAccessor
 
-    table = _compact_vulnerable_arrow_columns(table)
     frame = BlockAccessor.for_block(table).to_pandas()
-    return _normalize_pickled_object_columns(table, frame)
+    return _materialize_row_unsafe_columns(table, frame)
 
 
 def ray_dataset_to_pandas(dataset: ray.data.Dataset) -> pd.DataFrame:
     """Materialize a Ray Dataset without returning malformed Arrow arrays.
 
     Ray 2.56+ enables Arrow-backed pandas conversion by default. Calling
-    ``Dataset.to_pandas()`` directly can therefore expose sliced nested Arrow
-    columns whose child offsets are invalid for pandas row access. Convert
-    each Arrow block through :func:`arrow_table_to_pandas` before concatenating
-    so the public SDK result is safe to consume with standard pandas APIs.
+    ``Dataset.to_pandas()`` directly can therefore expose nested Arrow columns
+    that pandas cannot index by row. Convert each Arrow block through
+    :func:`arrow_table_to_pandas` before concatenating so the public SDK result
+    is safe to consume with standard pandas APIs.
 
     Parameters
     ----------

--- a/nemo_retriever/tests/test_executor_arrow_pandas.py
+++ b/nemo_retriever/tests/test_executor_arrow_pandas.py
@@ -38,7 +38,49 @@ class _PassthroughOperator(AbstractOperator):
         return data
 
 
-def test_adapter_compacts_sliced_nested_arrow_columns() -> None:
+def _stored_image_table(page_count: int = 3) -> pa.Table:
+    """Build the Arrow shape a stored-image batch produces: null-typed image_b64 children."""
+    return pa.Table.from_pylist(
+        [
+            {
+                "text": f"page {page_number}",
+                "page_image": {
+                    "image_b64": None,
+                    "encoding": "png",
+                    "orig_shape_hw": [10, 20],
+                    "stored_image_uri": f"file:///images/page-{page_number}.png",
+                },
+                # Pages carrying more than one image make the null child shorter
+                # than the struct array that owns it.
+                "images": [
+                    {
+                        "image_b64": None,
+                        "stored_image_uri": f"file:///images/image-{page_number}-{index}.png",
+                    }
+                    for index in range(2)
+                ],
+                "tables": [],
+            }
+            for page_number in range(page_count)
+        ]
+    )
+
+
+def test_adapter_returns_row_safe_frames_for_null_child_arrow_columns() -> None:
+    table = _stored_image_table()
+
+    result = _ArrowPandasOperatorAdapter(_PassthroughOperator, {})(table)
+
+    assert [row.text for row in result.itertuples(index=False)] == ["page 0", "page 1", "page 2"]
+    assert result.to_dict("records")[1]["images"] == [
+        {"image_b64": None, "stored_image_uri": "file:///images/image-1-0.png"},
+        {"image_b64": None, "stored_image_uri": "file:///images/image-1-1.png"},
+    ]
+    pa.Table.from_pandas(result, preserve_index=False).validate(full=True)
+    assert isinstance(result.dtypes["text"], pd.ArrowDtype)
+
+
+def test_adapter_returns_row_safe_frames_for_sliced_nested_arrow_columns() -> None:
     table = pa.Table.from_pylist(
         [
             {
@@ -57,6 +99,9 @@ def test_adapter_compacts_sliced_nested_arrow_columns() -> None:
     roundtripped = pa.Table.from_pandas(result, preserve_index=False)
 
     roundtripped.validate(full=True)
+    assert result.to_dict("records") == [
+        {"metadata": {"has_text": True, "source_path": "document.pdf", "error": None}, "text": "page 2"}
+    ]
     assert isinstance(result.dtypes["text"], pd.ArrowDtype)
 
 
@@ -83,6 +128,30 @@ def test_dataset_materialization_returns_row_safe_pandas_dataframe() -> None:
 
     assert [row.text for row in result.itertuples(index=False)] == ["page 1"]
     assert result.to_dict("records") == [{"metadata": {"error": None, "timing": None}, "text": "page 1"}]
+
+
+def test_dataset_materialization_concatenates_stored_image_batches() -> None:
+    table = _stored_image_table(2)
+
+    class _Dataset:
+        def iter_batches(self, *, batch_format: str):
+            assert batch_format == "pyarrow"
+            yield table.slice(0, 1)
+            yield table.slice(1, 1)
+
+        def schema(self):
+            return table.schema
+
+    result = ray_dataset_to_pandas(_Dataset())
+
+    records = result.to_dict("records")
+    assert [record["text"] for record in records] == ["page 0", "page 1"]
+    assert [record["page_image"]["stored_image_uri"] for record in records] == [
+        "file:///images/page-0.png",
+        "file:///images/page-1.png",
+    ]
+    assert all(record["page_image"]["image_b64"] is None for record in records)
+    assert [row.text for row in result.itertuples(index=False)] == ["page 0", "page 1"]
 
 
 def test_adapter_preserves_ray_pandas_conversion_policy() -> None:


### PR DESCRIPTION
## Description
- Fixes the remaining RC4/RC6 batch `.store()` failure where the pipeline completes and images are written, but the returned DataFrame cannot be consumed via `itertuples()` / `to_dict("records")` (`ArrowIndexError: index ... out-of-bounds`).
- Root cause: after `strip_base64=True`, nested `image_b64` fields become Arrow `null` children. Ray 2.56+ keeps those columns Arrow-backed; pandas indexes them as if child length matched the parent, which it does not. 
- Fix: at the shared Arrow→pandas boundary, materialize any column whose type contains a null child (and Ray pickled-object columns) as plain object dtype; leave other columns Arrow-backed.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
