### PR TITLE
docs(extraction): correct 26.08 release notes OCR default and POR delta (NVBug 6628502)

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -212,7 +212,31 @@ titles = GenericGenerationOperator(
 ).run(pd.DataFrame({"style": ["concise"], "document": ["Quarterly results"]}))
 ```
 
-`SummarizationOperator` defaults to `text`, `summary`, `summary_latency_s`, `summary_model`, and `summary_error`. `GenericGenerationOperator` maps each named prompt placeholder to a physical DataFrame column and derives the metadata column names from `output_column`. Prompt contracts are validated when the operator is constructed, before any provider request runs.
+`SummarizationOperator` defaults to `text`, `summary`, `summary_latency_s`, `summary_model`, and `summary_error`. `GenericGenerationOperator` maps each named prompt placeholder to a physical DataFrame column and derives the metadata column names from `output_column`. Prompt contracts are validated when the operator is constructed, before any provider request runs. `SummarizeTask` inherits from `TextGenerationTask` and supplies the built-in summarization prompt unless you override `prompt` on `TextGenerationParams`.
+
+### TextGenerationParams configuration { #textgenerationparams-configuration }
+
+Construct `TextGenerationParams` with `TextGenerationParams.from_kwargs(...)`. The following fields are supported.
+
+| Field | Purpose |
+|-------|---------|
+| `model` | Required provider model identifier. |
+| `api_base` | Optional OpenAI-compatible API base URL. |
+| `api_key` | Optional credential or `os.environ/<NAME>` reference. Literal keys are not written to persisted graph JSON. |
+| `temperature` | Optional sampling override. Valid values are 0.0 through 2.0. |
+| `top_p` | Optional sampling override. Valid values are 0.0 through 1.0. |
+| `max_tokens` | Optional positive token-limit override. Omit the field to inherit the task default. |
+| `extra_params` | Optional provider-specific request keys. Dedicated fields such as `model`, `messages`, sampling, and credentials must not be duplicated here. |
+| `num_retries` | Transport retry count. The default is 3. The value must be 0 or greater. |
+| `timeout` | Transport timeout in seconds. The default is 120.0. The value must be greater than 0. |
+| `prompt` | Optional user prompt or prompt template. `GenericGenerationOperator` requires this field. |
+| `system_prompt` | Optional system prompt. |
+| `rag_system_prompt` | Optional retrieval-augmented generation (RAG) system prompt. |
+| `rag_system_prompt_prefix` | Optional prefix applied to the RAG system prompt. |
+| `reasoning_enabled` | Optional reasoning toggle. When unset, transport reasoning defaults to true. |
+| `max_workers` | Concurrent row workers. The default is 8. The value must be 1 or greater. |
+
+Sampling fields that you omit inherit the task defaults. `temperature`, `top_p`, and `max_tokens` are applied only when you pass them explicitly.
 
 To define another one-request/one-text-result task, subclass `TextGenerationTask`, declare `required_inputs`, and implement `build_request()`. Then construct it from a `TextGenerationOperator` subclass with explicit logical-input-to-DataFrame-column mappings. This abstraction is intentionally text-only; use a separate operator family for embeddings, captioning, tools, streaming, or structured domain results.
 

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -4,104 +4,140 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 ## 26.08 Release Notes (26.8.0) { #release-2608 }
 
-NVIDIA® NeMo Retriever Library version 26.08 builds on the 26.05 foundation with a graph-based ingest architecture, expanded multimodal and tabular capabilities, production-oriented service deployment, and documentation aligned to a Helm-first supported path.
+NVIDIA® NeMo Retriever Library version 26.08 adds a shared text-generation task API, configurable large language model (LLM) settings, grounded answer-generation model paths, agentic retrieval, and updated Helm NIM defaults. It continues the 26.05 graph ingest, multimodal extraction, and Helm-first deployment foundation.
 
 To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
 
-Highlights for the 26.08 release include:
+The following sections summarize user-visible changes introduced in 26.08. Capabilities first documented in 26.05 that remain current are listed under [Continuing from 26.05](#continuing-from-2605).
 
 ### Upgrade notes { #upgrade-notes }
 
-- Nemotron OCR v2 is now the default OCR engine for local Hugging Face, hosted CPU actors, and Helm NIM deployments (26.05 kept Helm on OCR v1)
-- Helm replaces separate page-elements and table-structure NIMs with the combined `nemotron-object-detection:2.0.1` image and Nemotron OCR v2 `2.0.1`. Development Compose uses the same combined object-detection image and OCR v2, but still defaults to `2.0.0` tags unless you override `NIM_*_TAG`
-- Default VLM image captioning is Nemotron 3 Nano Omni for local and hosted paths; chart-classified PDF regions remain on the layout and OCR path
-- Helm default VL embed and VL rerank NIM images bump to `2.3.0` (26.05 used `1.12.0` / `1.11.0`). Development Compose still defaults to `1.12.0` / `1.11.0` unless you override `NIM_EMBED_TAG` / `NIM_RERANK_TAG`
-- Hosted Nemotron Parse and self-hosted Nemotron Parse use distinct HTTP contracts—select the matching client path for your endpoint
-- macOS Intel (x86_64) is no longer supported for package installs; use Apple Silicon (arm64) macOS, Windows x64, or Linux. Refer to [Packaging and platform](#packaging-and-platform)
-- Text splitting for graph and library ingest moved into `.extract(split_config=...)` instead of standalone `.split()` on the graph ingest path (the service ingestor API may still expose `.split()` separately)  
-- Direct `Retriever(...)` construction uses `vdb_kwargs`, `embed_kwargs`, and `rerank` instead of flat `lancedb_uri`, `lancedb_table`, `embedder`, `embedding_endpoint`, `local_query_embed_backend`, and `reranker` arguments  
-- For Helm audio and video extraction, set `service.installFfmpeg: true` in `values.yaml` (or pass `--set service.installFfmpeg=true`) when images no longer bundle `ffmpeg` and `ffprobe` by default  
-- Self-hosted Parakeet on Helm requires both `nimOperator.audio.enabled=true` and `serviceConfig.nimEndpoints.audioGrpcEndpoint=audio:50051`; enabling the audio NIM alone does not wire the service ASR endpoint  
+- Nemotron OCR v2 is now the default OCR engine for local Hugging Face, hosted CPU actors, and Helm NIM deployments. 26.05 kept Helm on OCR v1. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`.
+- Helm replaces separate page-elements and table-structure NIMs with the combined `nemotron-object-detection:2.0.1` image. Development Compose uses the same combined object-detection image and OCR v2, but still defaults to `2.0.0` tags unless you override `NIM_*_TAG`.
+- Helm default VL embed and VL rerank NIM images bump to `2.3.0`. 26.05 used `1.12.0` and `1.11.0`. Development Compose still defaults to `1.12.0` and `1.11.0` unless you override `NIM_EMBED_TAG` and `NIM_RERANK_TAG`.
+- Default VLM image captioning is Nemotron 3 Nano Omni for local and hosted paths. Chart-classified PDF regions remain on the layout and OCR path.
+- Hosted Nemotron Parse and self-hosted Nemotron Parse use distinct HTTP contracts. Select the matching client path for your endpoint.
+- macOS Intel (x86_64) is no longer supported for package installs. Use Apple Silicon (arm64) macOS, Windows x64, or Linux. Refer to [Packaging and platform](#packaging-and-platform).
+- Legacy `nv-ingest` and compatibility pipeline CLI code paths are removed. Use `retriever ingest` and the graph stage registry.
+- Self-hosted Parakeet on Helm requires both `nimOperator.audio.enabled=true` and `serviceConfig.nimEndpoints.audioGrpcEndpoint=audio:50051`. Enabling the audio NIM alone does not wire the service ASR endpoint.
 - Changing a Helm NIM image repository or tag on an existing release cannot patch `NIMCache` `spec.source.ngc.modelPuller`. Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
-- `nemo_retriever` requires Python 3.12  
+- Retriever Service OpenAPI `info.version` no longer reports a stale `26.5.0` value. The service reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.
+
+### Text generation and LLM configuration { #text-generation-and-llm-configuration }
+
+- 26.08 introduces a shared one-request-per-row text-generation abstraction: `TextGenerationTask` plus `TextGenerationOperator`. `GenericGenerationOperator` accepts a validated custom prompt. Refer to [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation).
+- `SummarizeTask` inherits from `TextGenerationTask`. `SummarizationOperator` provides the built-in summarization behavior with the default prompt or a custom prompt.
+- Configure those operators with `TextGenerationParams.from_kwargs(...)`. Supported fields include `model`, `api_base`, `api_key`, `temperature`, `top_p`, `max_tokens`, `extra_params`, `num_retries`, `timeout`, `prompt`, `system_prompt`, `rag_system_prompt`, `rag_system_prompt_prefix`, `reasoning_enabled`, and `max_workers`. Refer to [TextGenerationParams configuration](nemo-retriever-api-reference.md#textgenerationparams-configuration).
+
+### Answer generation { #answer-generation }
+
+- `Retriever.answer()` and optional `POST /v1/answer` remain the grounded answer-generation path. The default LLM is `nvidia/llama-3.3-nemotron-super-49b-v1.5` (Helm `nimOperator.answer_llm` image `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5`). The generic slot also accepts another OpenAI-compatible LLM or vision-language model (VLM), including `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`.
+- Enabling the Omni caption Helm key does not enable `/v1/answer`. Use Omni as the answer backend by overriding the generic `answer_llm` slot or by pointing `serviceConfig.llm` at an Omni chat-completions endpoint. Refer to [Answer generation](prerequisites-support-matrix.md#answer-generation) and [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#answer-generation-llm).
+
+### Agentic retrieval { #agentic-retrieval }
+
+- Agentic retrieval is a 26.08 user-facing feature. An LLM agent issues multiple searches, fuses candidates, and returns a document-level ranking. The CLI, Python query workflow, REST, and MCP surfaces share this path. Refer to [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
+- `retriever query --agentic` runs that ReAct loop over the same LanceDB table as one-pass retrieval. Local CLI and harness runs default to in-process vLLM (`nemotron-8b`). Remote OpenAI-compatible NIM or NVIDIA-hosted endpoints use `--agentic-invoke-url`.
+- Retriever Service exposes agentic retrieval on `POST /v1/query` with `agentic=true` and an `agentic_query` MCP tool when `agentic.enabled` is true. Service mode requires a remote OpenAI-compatible LLM endpoint. Agentic remains opt-in through `serviceConfig.agentic.enabled`.
+- Configurable auto-retrieval is available on the service query path, with evidence and coverage output formats on `/v1/query`. MCP query-method selection and rerank tools are available.
+
+### Models, OCR, and NIM artifacts { #models-ocr-and-captioning }
+
+- Nemotron OCR v2 is unified across library, hosted, and Helm defaults. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration).
+- Local OCR crop batching runs across page rows for throughput. Helm extraction NIMs (OCR and object detection) enable performance mode by default. The VL embed NIM does not.
+- 26.08 Helm default and optional NIM images that affect mirroring, allowlisting, and troubleshooting include the following:
+    - Combined object detection for page elements and table structure: `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1`
+    - VL embedding: `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0`
+    - VL reranking (optional): `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0`
+    - Optional Omni caption and configurable answer VLM: `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant`
+    - Optional answer-generation LLM: `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5`
+- The `page_elements` and `table_structure` services share the combined object-detection image and select distinct models. Pull that image once for air-gapped or allowlisted deployments.
+- Nemotron 3 Nano Omni is the canonical caption model. It is opt-in on Helm and has a larger GPU footprint than Nano caption profiles.
+- Nemotron Parse endpoint wiring is available in service extraction workers, with documented hosted versus self-hosted contract selection.
+- An embedder model router supports additional Llama Nemotron embedding checkpoints, including 1B, 3B, 8B, local, fine-tuned, and ModelOpt.
 
 ### Pipeline and ingestion { #pipeline-and-ingestion }
 
-- Legacy `nv-ingest` and compatibility pipeline CLI code paths removed; `retriever ingest` and the graph stage registry are the canonical ingestion paths
-- Manifest-based ingest routing replaces input-type routing; `retriever ingest` is input-aware for PDF, image, audio, video, text, HTML, DOCX/PPTX, SVG, and related types  
-- `allow_no_gpu` option to skip GPU requirement during ingest for CPU-only experimentation  
-- Documented Markdown, JSON, and shell text inputs, plus inline text ingestion support
-- Service-mode TXT and HTML chunking
-- `return_failures` supported across in-process and batch ingest modes
-- Tabular ingestion and embedding improvements, including table-type handling
-- PDF render parameters forwarded through ingestion graphs
+- `retriever ingest` and the graph stage registry are the canonical ingestion paths. The compatibility pipeline CLI is retired.
+- Documented Markdown, JSON, and shell text inputs, plus inline text ingestion support.
+- Service-mode TXT and HTML chunking.
+- `return_failures` is supported across in-process and batch ingest modes.
+- Tabular ingestion and embedding improvements, including table-type handling.
+- PDF render parameters are forwarded through ingestion graphs.
 
 ### CLI { #cli }
 
-- Root CLI adds first-class `retriever ingest` and `retriever query` commands with NIM URL flags, batch tuning, and LanceDB overwrite/append controls
-- `retriever query --agentic` runs an LLM-driven ReAct retrieval loop over the same LanceDB table as one-pass retrieval. Local CLI and harness runs default to in-process vLLM (`nemotron-8b`). Remote OpenAI-compatible NIM or NVIDIA-hosted endpoints use `--agentic-invoke-url`. Refer to [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
-- `retriever ingest` and `retriever query` replace the retired compatibility pipeline command. Other top-level subcommands—including `eval`, `benchmark`, `harness`, and `skill-eval`—are development and experimental
+- `retriever ingest` and `retriever query` replace the retired compatibility pipeline command. Other top-level subcommands, including `eval`, `benchmark`, `harness`, and `skill-eval`, are development and experimental.
+- `retriever query --agentic` is the CLI entry point for agentic retrieval. Refer to [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
 
 ### Retriever Service and deployment { #retriever-service-and-deployment }
 
-- Retriever Service v2 adds a scalable multi-pod architecture with gateway, process isolation, and VectorDB integration
-- Retriever Service exposes agentic retrieval on `POST /v1/query` with `agentic=true` and an `agentic_query` MCP tool when `agentic.enabled` is true. Service mode requires a remote OpenAI-compatible LLM endpoint. Refer to [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
-- OpenTelemetry basic support for pipeline and service observability  
-- Expanded air-gapped deployment guidance in [deployment options](deployment-options.md) and the Helm chart README  
-- Helm maps `serviceConfig.nimEndpoints.rerankInvokeUrl` / `rerankModelName` into `nim_endpoints.rerank_invoke_url` / `rerank_model_name`, and auto-wires those fields when `nimOperator.rerankqa.enabled=true`, so `/v1/query` with `rerank=true` works in split topology
-- Fixed Retriever Service OpenAPI `info.version` reporting a stale `26.5.0` value. The service now reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.
-- Gateway worker pull scheduling replaces push routing
-- Development Docker Compose deployment for local service stacks
-- Zipkin tracing parity alongside OpenTelemetry
-- Helm maximum upload size configuration and OpenShift deployment follow-ups
-- Secret-backed Helm authentication for public and internal service tokens (inline tokens are gated for insecure development only)
+- Helm maps `serviceConfig.nimEndpoints.rerankInvokeUrl` / `rerankModelName` into `nim_endpoints.rerank_invoke_url` / `rerank_model_name`, and auto-wires those fields when `nimOperator.rerankqa.enabled=true`, so `/v1/query` with `rerank=true` works in split topology.
+- Retriever Service exposes agentic retrieval on `POST /v1/query` when `agentic.enabled` is true. Refer to [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
+- Gateway worker pull scheduling replaces push routing.
+- Development Docker Compose deployment is available for local service stacks.
+- Zipkin tracing parity is available alongside OpenTelemetry.
+- Helm maximum upload size configuration and OpenShift deployment follow-ups.
+- Secret-backed Helm authentication for public and internal service tokens. Inline tokens are gated for insecure development only.
 
-### Models, OCR, and captioning { #models-ocr-and-captioning }
+### Multimodal extraction { #multimodal-extraction }
 
-- OCR v2 is unified across library, hosted, and Helm defaults; hosted OCR uses its own language behavior
-- Local OCR crop batching across page rows for throughput
-- Nemotron 3 Nano Omni is the canonical caption model (opt-in on Helm; larger GPU footprint than Nano caption profiles)
-- Nemotron Parse endpoint wiring in service extraction workers, with documented hosted versus self-hosted contract selection
-- Embedder model router for additional Llama Nemotron embedding checkpoints (including 1B, 3B, 8B, local, fine-tuned, and ModelOpt)
-- Helm extraction NIMs (OCR and object detection) enable performance mode by default; the VL embed NIM does not
-
-### Agentic retrieval and query { #agentic-retrieval-and-query }
-
-- Agentic retrieval as a first-class retrieval mode through the CLI (`retriever query --agentic`), SDK helpers, and service HTTP / MCP endpoints
-- Local in-process vLLM agent LLMs by default for agentic query paths; optional OpenAI-compatible remote endpoints
-- Optional Helm NIM for the agentic / answer LLM (`llama-3.3-nemotron-super-49b-v1.5`); agentic remains opt-in (`serviceConfig.agentic.enabled`)
-- Configurable auto-retrieval on the service query path; evidence and coverage output formats on `/v1/query`
-- Service-mode `Retriever.answer` support and FastMCP integration for local and remote agents
-- MCP query-method selection and rerank tools
+- Fixed an issue that could cause local Hugging Face batch audio extraction to hang in interactive terminals when FFmpeg inherited the parent process's standard input.
 
 ### Retrieval and RAG { #retrieval-and-rag }
 
-- Live RAG SDK with `Retriever.retrieve()`, reference answer generation `Retriever.answer()`, and optional batch operator graphs through LiteLLM (`[llm]` extra)
-- Agentic retrieval: an LLM agent issues multiple searches, fuses candidates, and returns a document-level ranking. The CLI, Python query workflow, REST, and MCP surfaces share this path. Refer to [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
+- `Retriever.answer()` supports the Super-49B default LLM path and the Omni VLM-capable path documented under [Answer generation](#answer-generation).
+- Service-mode `Retriever.answer` support and FastMCP integration are available for local and remote agents.
+- Agentic retrieval is available on the CLI, Python query workflow, REST, and MCP surfaces. Refer to [Agentic retrieval](#agentic-retrieval).
 
 ### Vector database and retrieval { #vector-database-and-retrieval }
 
-- True LanceDB hybrid retrieval
-- LanceDB retrieval-mode autodetection and persisted embedding identity for automatic local queries
-- Dense image-only VDB records retained where applicable
-- Scope-isolated collection and document lifecycle APIs (`/v1/collections`) for create, ingest, replace, query, and cleanup without exposing LanceDB table names
-
+- True LanceDB hybrid retrieval.
+- LanceDB retrieval-mode autodetection and persisted embedding identity for automatic local queries.
+- Dense image-only VDB records are retained where applicable.
+- Scope-isolated collection and document lifecycle APIs (`/v1/collections`) support create, ingest, replace, query, and cleanup without exposing LanceDB table names.
 
 ### Packaging and platform { #packaging-and-platform }
 
-- Public nightlies published to PyPI while keeping local install extras stable
-- Ray raised to `>=2.56.1` for CVE remediation (26.05 used `>=2.49.0`). Ray no longer publishes wheels for macOS Intel (x86_64), so `pip`/`uv` installs fail on Intel Macs (including in-process library mode). Apple Silicon (arm64) macOS remains supported for slim remote/NIM-only installs, alongside Windows x64.
-- Optional install extras (`[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and others), including slim remote/NIM-only installs on Mac and Windows  
+- Public nightlies are published to PyPI while local install extras remain stable.
+- Ray is raised to `>=2.56.1` for CVE remediation. 26.05 used `>=2.49.0`. Ray no longer publishes wheels for macOS Intel (x86_64), so `pip` and `uv` installs fail on Intel Macs, including in-process library mode. Apple Silicon (arm64) macOS remains supported for slim remote or NIM-only installs, alongside Windows x64.
 
 ### Helm chart { #helm-chart }
 
-- Helm chart refresh under `nemo_retriever/helm/` with VL embedder defaults and optional Nemotron Parse and Omni caption NIMs  
+- The Helm chart under `nemo_retriever/helm/` defaults to OCR v2, the combined object-detection NIM, and VL embedder 2.3.0. Optional NIMs include VL rerank 2.3.0, Omni `2.0.4-variant`, Nemotron Parse, and the Super-49B `answer_llm` slot. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims).
 
 ### Documentation { #documentation }
 
-- Documentation aligned to a Helm-first supported path for NIM and service deployment
-- Published [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md) for CLI, service, REST, and MCP usage
-- Documentation consolidates extraction concepts, ingest workflow, embeddings, audio/video guides, prerequisites and support matrix, and UDF/custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)  
+- Published [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md) for CLI, service, REST, and MCP usage.
+- Published [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation) for `TextGenerationTask`, `GenericGenerationOperator`, `SummarizationOperator`, and `TextGenerationParams`.
+- Clarified Super-49B and Omni answer-generation paths on this page and in [Answer generation](prerequisites-support-matrix.md#answer-generation). For Helm enablement and slot overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#answer-generation-llm).
+
+### Continuing from 26.05 { #continuing-from-2605 }
+
+The following capabilities shipped in 26.05 and remain current in 26.08. They are not new 26.08 highlights. For the original 26.05 wording, refer to the [26.05 Release Notes](https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/releasenotes-nv-ingest/).
+
+- Text splitting for graph and library ingest uses `.extract(split_config=...)` instead of standalone `.split()` on the graph ingest path. The service ingestor API can still expose `.split()` separately.
+- Direct `Retriever(...)` construction uses `vdb_kwargs`, `embed_kwargs`, and `rerank` instead of flat `lancedb_uri`, `lancedb_table`, `embedder`, `embedding_endpoint`, `local_query_embed_backend`, and `reranker` arguments.
+- For Helm audio and video extraction, set `service.installFfmpeg: true` in `values.yaml` (or pass `--set service.installFfmpeg=true`) when images no longer bundle `ffmpeg` and `ffprobe` by default.
+- `nemo_retriever` requires Python 3.12.
+- Manifest-based ingest routing replaces input-type routing. `retriever ingest` is input-aware for PDF, image, audio, video, text, HTML, DOCX, PPTX, SVG, and related types.
+- `allow_no_gpu` skips the GPU requirement during ingest for CPU-only experimentation.
+- Root CLI includes `retriever ingest` and `retriever query` with NIM URL flags, batch tuning, and LanceDB overwrite or append controls.
+- Retriever Service v2 provides a scalable multi-pod architecture with gateway, process isolation, and VectorDB integration.
+- OpenTelemetry provides basic pipeline and service observability.
+- Air-gapped deployment guidance is in [deployment options](deployment-options.md) and the Helm chart README.
+- Nemotron Parse is an alternate PDF extraction method (v1.2 HTTP interface, optional Helm NIM, and local inference through vLLM where configured).
+- VLM image captioning through vLLM, including Omni caption model profiles, is available.
+- vLLM-backed text and vision-language embedders, a multimodal VL reranker, and torch 2.11 are available for local GPU installs.
+- The video retrieval pipeline includes frame extraction, OCR, audio-visual fusion, and text deduplication.
+- Long-audio Parakeet chunking provides time-aligned segments, punctuation-based audio segmenting, and ASR batch and streaming improvements.
+- The live RAG SDK includes `Retriever.retrieve()`, reference answer generation through `Retriever.answer()`, and optional batch operator graphs through LiteLLM (`[llm]` extra).
+- Vector database operators are integrated in the pipeline, with custom metadata support and updated LanceDB hybrid search guidance.
+- LanceDB is the first-party vector path for new deployments. Milvus and MinIO guidance is removed from the primary extraction doc set.
+- Evaluation includes a BEIR-centric overhaul and the experimental `retriever skill-eval` benchmark CLI.
+- Text-to-SQL agent graph and tabular tooling support structured data retrieval, including tabular data ingestion.
+- Optional install extras include `[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and slim remote or NIM-only installs on Mac and Windows.
+- Documentation is aligned to a Helm-first supported path and consolidates extraction concepts, ingest workflow, embeddings, audio and video guides, prerequisites and support matrix, and UDF or custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
 
 ## Release Notes for Previous Versions { #previous-versions }
 
@@ -120,5 +156,8 @@ Release notes for 24.12.1 and 24.12.0 are on the [25.3.0 archived release notes]
 ## Related Topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
+- [Answer generation](prerequisites-support-matrix.md#answer-generation)
+- [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation)
+- [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Deployment options](deployment-options.md)
 - [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)


### PR DESCRIPTION
## Summary
- Correct the 26.08 Release Notes Helm OCR default to `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` (the page still said OCR v1).
- Summarize the 26.08 POR delta: text-generation task/operator abstraction, `TextGenerationParams` contract, Super-49B and Omni answer-generation paths, agentic retrieval, and current Helm NIM images.
- Move inherited 26.05 capabilities into a Continuing from 26.05 section so they are not presented as 26.08 highlights.

## Test plan
- [ ] Open the Release Notes page and confirm Helm OCR default text is `nemotron-ocr-v2:2.0.1`.
- [ ] Search the page for `TextGenerationTask`, `GenericGenerationOperator`, `TextGenerationParams`, agentic retrieval, Super-49B, and Omni.
- [ ] Confirm Continuing from 26.05 lists inherited bullets and links to the 26.05 notes.
- [ ] Follow links to one-shot text generation, Default Helm NIMs, agentic workflow, and Helm answer-generation.

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** `docs/docs/extraction/releasenotes.md`, `docs/docs/extraction/nemo-retriever-api-reference.md`, `docs/docs/extraction/prerequisites-support-matrix.md`

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — no `see [` CTAs on the three changed files; faq/overview/multimodal-extraction were not in this diff |
| Allowed paths | PASS — 3 documentation files |
| mkdocs --strict | PASS for this diff — no new warnings from these files; exit 1 on untracked leftover pages `custom-metadata.md` and `user-defined-stages.md` that are not in this diff |
| ::a audit | PASS — Helm OCR v2 `2.0.1`, Super-49B `2.0.5`, Omni `1.7.0-variant`, and `TextGenerationParams.from_kwargs` fields match `values.yaml` and `models.py` |
| ::p polish | Applied — spelled out LLM/VLM on first use, dropped internal Photon wording, retargeted broken `#answer-generation` links to Default Helm NIMs and the Helm README |
| ::r style | 90% — no blocking issues |

**Code drift (not in this docs PR):** Helm README `#answer-generation-llm` still uses Nemotron 3 Nano, not Omni, as the worked `answer_llm` override example.

**PR:** this draft

Fixes NVBug 6628502.