### PR TITLE
feat: add Ministral 3 embedding support

### DIFF
--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -349,23 +349,29 @@ Tested official checkpoints:
 - `nvidia/llama-nemotron-embed-vl-1b-v2-fp8`
 - `nvidia/llama-nv-embed-reasoning-3b`
 - `nvidia/llama-embed-nemotron-8b`
+- `nvidia/Nemotron-3-Embed-1B-BF16`
+- `nvidia/Nemotron-3-Embed-8B-BF16`
+- `nvidia/Nemotron-3-Embed-1B-NVFP4`
 
 Equivalent local checkpoints and weight-only fine-tunes are supported. A
-compatible checkpoint must be complete and loadable, use
-`LlamaBidirectionalModel` or `LlamaNemotronVLModel`, and declare average
-pooling with a positive output width. LanceDB infers the schema from the
-produced vectors; the tested official checkpoints use 2048, 3072, and 4096
-dimensions. Query and document prompts are read from
+compatible checkpoint must be complete and loadable, declare average pooling,
+and expose a positive output width. Supported architectures include
+`LlamaBidirectionalModel`, `LlamaNemotronVLModel`, and compatible Ministral 3
+dense encoders. A compatible Ministral 3 dense checkpoint must declare
+`model_type: "ministral3"`, `architectures: ["Ministral3Model"]`,
+`is_causal: false`, `pooling: "avg"`, and a positive `hidden_size`. LanceDB
+infers the schema from the produced vectors; the tested official checkpoints
+use 2048, 3072, and 4096 dimensions. Query and document prompts are read from
 `config_sentence_transformers.json` when the checkpoint supplies it.
 Fine-tunes that require prefixes other than `query: ` and `passage: ` must
 retain that prompt metadata.
 
-This does not add support for every model in the Nemotron RAG collection,
-including rerankers, ColEmbed late-interaction models, Omni Embed, OCR, or
-parsing models. Nemotron 3 Embed is also excluded because its Ministral3
-architecture requires a newer Transformers stack than this project currently
-supports. Those models require different dependencies, outputs, modalities,
-or operator contracts.
+General Mistral 3 Base, Instruct, and vision-language model (VLM) generation
+checkpoints remain unsupported because they do not match the dense encoder
+contract. NeMo AutoModel `ministral3_bidirec` checkpoints also remain
+unsupported. Other unsupported Nemotron RAG models include rerankers, ColEmbed
+late-interaction models, Omni Embed, OCR, and parsing models. These models
+require different dependencies, outputs, modalities, or operator contracts.
 
 Unregistered Hub repositories are resolved to an immutable commit and loaded
 with `trust_remote_code=True`; only use repositories you trust. The resolved

--- a/nemo_retriever/src/nemo_retriever/models/embed_model_spec.py
+++ b/nemo_retriever/src/nemo_retriever/models/embed_model_spec.py
@@ -20,6 +20,7 @@ EmbedModelFamily = Literal["text", "vl"]
 _MODEL_PROFILES: dict[str, tuple[EmbedModelFamily, str]] = {
     "llama_bidirec": ("text", "LlamaBidirectionalModel"),
     "llama_nemotron_vl": ("vl", "LlamaNemotronVLModel"),
+    "ministral3": ("text", "Ministral3Model"),
 }
 _DEFAULT_QUERY_PREFIX = "query: "
 _DEFAULT_DOCUMENT_PREFIX = "passage: "
@@ -150,6 +151,12 @@ def _spec_from_config(
         raise ValueError(
             f"Embedding model {model_id!r} uses unsupported architectures {architectures!r}; "
             f"expected [{expected_architecture!r}] for the {family} dense embedding profile."
+        )
+
+    if model_type == "ministral3" and config.get("is_causal") is not False:
+        raise ValueError(
+            f"Embedding model {model_id!r} uses unsupported is_causal={config.get('is_causal')!r}; "
+            "dense Ministral3 embedding profiles require is_causal=false."
         )
 
     dimension_config = config.get("llm_config") if family == "vl" else config

--- a/nemo_retriever/tests/test_create_local_embedder.py
+++ b/nemo_retriever/tests/test_create_local_embedder.py
@@ -312,6 +312,8 @@ def test_query_embedder_vl_vllm_uses_vllm_vl(_patch_embedders):
         pytest.param("llama_nemotron_vl", "hf", 2, id="vl-hf"),
         pytest.param("llama_bidirec", "vllm", 0, id="text-vllm"),
         pytest.param("llama_bidirec", "hf", 1, id="text-hf"),
+        pytest.param("ministral3", "vllm", 0, id="ministral3-vllm"),
+        pytest.param("ministral3", "hf", 1, id="ministral3-hf"),
     ],
 )
 def test_local_checkpoint_routes_from_config(

--- a/nemo_retriever/tests/test_embed_model_spec.py
+++ b/nemo_retriever/tests/test_embed_model_spec.py
@@ -40,6 +40,18 @@ def _text_config(**overrides):
     return config
 
 
+def _ministral_config(**overrides):
+    config = {
+        "model_type": "ministral3",
+        "architectures": ["Ministral3Model"],
+        "hidden_size": 2048,
+        "is_causal": False,
+        "pooling": "avg",
+    }
+    config.update(overrides)
+    return config
+
+
 def _vl_config(**overrides):
     config = {
         "model_type": "llama_nemotron_vl",
@@ -77,6 +89,12 @@ def test_local_text_checkpoint_is_resolved_from_model_type(tmp_path):
             "NVFP4",
             id="text-nvfp4",
         ),
+        pytest.param(
+            _ministral_config(quantization_config={"quant_method": "modelopt", "quant_algo": "NVFP4"}),
+            "text",
+            "NVFP4",
+            id="ministral3-nvfp4",
+        ),
     ],
 )
 def test_local_modelopt_checkpoint_requires_vllm(tmp_path, config, family, quantization):
@@ -108,6 +126,7 @@ def test_text_reranker_architecture_is_rejected(tmp_path):
     ("config", "family"),
     [
         pytest.param(_text_config(hidden_size=4096), "text", id="text"),
+        pytest.param(_ministral_config(hidden_size=4096), "text", id="ministral3"),
         pytest.param(_vl_config(llm_config={"hidden_size": 4096}), "vl", id="vl"),
     ],
 )
@@ -127,19 +146,72 @@ def test_invalid_embedding_dimension_is_rejected(tmp_path):
         resolve_embed_model_spec(str(tmp_path))
 
 
-def test_ministral_checkpoint_is_rejected(tmp_path):
-    _write_config(
+def test_ministral_checkpoint_is_resolved_with_prompt_metadata(tmp_path):
+    _write_config(tmp_path, _ministral_config())
+    _write_prompt_config(
         tmp_path,
         {
-            "model_type": "ministral3",
-            "architectures": ["Ministral3Model"],
-            "hidden_size": 2048,
-            "is_causal": False,
-            "pooling": "avg",
+            "query": "query: ",
+            "document": "passage: ",
         },
     )
 
-    with pytest.raises(ValueError, match="unsupported model_type 'ministral3'"):
+    spec = resolve_embed_model_spec(str(tmp_path))
+
+    assert spec.family == "text"
+    assert spec.output_dimension == 2048
+    assert spec.query_prefix == "query: "
+    assert spec.document_prefix == "passage: "
+    assert spec.requires_vllm is False
+
+
+def test_ministral_checkpoint_rejects_wrong_architecture(tmp_path):
+    _write_config(
+        tmp_path,
+        _ministral_config(architectures=["Mistral3ForConditionalGeneration"]),
+    )
+
+    with pytest.raises(ValueError, match="unsupported architectures"):
+        resolve_embed_model_spec(str(tmp_path))
+
+
+@pytest.mark.parametrize("is_causal", [True, None])
+def test_ministral_checkpoint_requires_explicit_non_causal_config(tmp_path, is_causal):
+    _write_config(tmp_path, _ministral_config(is_causal=is_causal))
+
+    with pytest.raises(ValueError, match="dense Ministral3 embedding profiles require is_causal=false"):
+        resolve_embed_model_spec(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(
+            {
+                "model_type": "mistral3",
+                "architectures": ["Mistral3ForConditionalGeneration"],
+                "hidden_size": 2048,
+                "is_causal": True,
+                "pooling": "avg",
+            },
+            id="mistral3-conditional-generation",
+        ),
+        pytest.param(
+            {
+                "model_type": "ministral3_bidirec",
+                "architectures": ["Ministral3BidirectionalModel"],
+                "hidden_size": 2048,
+                "is_causal": False,
+                "pooling": "avg",
+            },
+            id="nemo-automodel-bidirectional",
+        ),
+    ],
+)
+def test_other_mistral_checkpoint_formats_remain_rejected(tmp_path, config):
+    _write_config(tmp_path, config)
+
+    with pytest.raises(ValueError, match="unsupported model_type"):
         resolve_embed_model_spec(str(tmp_path))
 
 
@@ -159,8 +231,15 @@ def test_checkpoint_prompt_metadata_is_resolved(tmp_path):
     assert spec.document_prefix == ""
 
 
-def test_non_average_pooling_is_rejected(tmp_path):
-    _write_config(tmp_path, _text_config(pooling="last"))
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(_text_config(pooling="last"), id="text"),
+        pytest.param(_ministral_config(pooling="last"), id="ministral3"),
+    ],
+)
+def test_non_average_pooling_is_rejected(tmp_path, config):
+    _write_config(tmp_path, config)
 
     with pytest.raises(ValueError, match="unsupported pooling 'last'"):
         resolve_embed_model_spec(str(tmp_path))
@@ -186,6 +265,15 @@ def test_local_directory_requires_config_json(tmp_path):
         ),
         ("nvidia/llama-embed-nemotron-8b", _text_config(hidden_size=4096), "text", 4096, False),
         ("nvidia/llama-nv-embed-reasoning-3b", _text_config(hidden_size=3072), "text", 3072, False),
+        ("nvidia/Nemotron-3-Embed-1B-BF16", _ministral_config(), "text", 2048, False),
+        ("nvidia/Nemotron-3-Embed-8B-BF16", _ministral_config(hidden_size=4096), "text", 4096, False),
+        (
+            "nvidia/Nemotron-3-Embed-1B-NVFP4",
+            _ministral_config(quantization_config={"quant_method": "modelopt", "quant_algo": "NVFP4"}),
+            "text",
+            2048,
+            True,
+        ),
     ],
 )
 def test_supported_hub_models_resolve_immutable_revisions(


### PR DESCRIPTION
## Description

Add embed-router support for compatible `Ministral3Model` dense embedding checkpoints, including Nemotron 3 Embed 1B BF16, 8B BF16, and 1B NVFP4.

The router reuses the existing HF and vLLM embedding paths while requiring:

- Architecture `Ministral3Model`
- `is_causal: false`
- `pooling: avg`
- A positive `hidden_size`

Causal, VLM, and conditional-generation checkpoints remain unsupported. ModelOpt/NVFP4 checkpoints continue to require vLLM.

### Validation

- 65 focused router and embedder-factory tests passed.
- 61 generic vLLM embedding tests passed.
- 71 retrieval and LanceDB regression tests passed with the patch applied to current `upstream/main`.
- H200 ingestion and retrieval passed for:
  - 1B BF16 through HF and vLLM
  - 8B BF16 through HF
  - 1B NVFP4 through vLLM
- BF16 vLLM embeddings matched bidirectional HF embeddings at greater than 0.9999 cosine similarity.
- NVFP4 produced finite, normalized 2,048-dimensional vectors and successful retrieval.
- `malteos/most-embed-de` and `minetta/nemotron-3-embed-8b-legal` also passed end-to-end ingestion and retrieval.
- Strict documentation build and `git diff --check` passed.

On H200, NVFP4 uses vLLM’s Marlin weight-only fallback. This validates functional correctness, not native Blackwell FP4/CUTLASS performance. Cross-backend equivalence was executed at the default 8,192-token context length; longer contexts were not live-tested.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.