### PR TITLE
ci(docs): publish 26.08 docs.nvidia.com from main as 26.8.0

### DIFF
--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -142,11 +142,13 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the current 26.08 docs from main under the 26.8.0 label.
+      # Publish the current 26.08 docs from the triggering main commit under the
+      # 26.8.0 label. Use github.sha (not the floating main tip) so a delayed run
+      # cannot publish a newer tip under flags resolved for an earlier commit.
       - name: Checkout main docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -11,22 +11,35 @@
 #   Variables (optional): DOCS_AWS_REGION, NRL_DOCS_PUBLISH_VERSION, DOCS_RELEASE_EMAILS
 #
 # S3 layout written under developer/docs/nemo/retriever/:
-#   index.html, versions.json, latest/, <version>/ (e.g. 26.5.0/)
+#   index.html, versions.json, latest/, <version>/ (e.g. 26.8.0/)
 #
-# Manual publish only (workflow_dispatch). Do not re-enable push/tag auto-publish
-# while docs.nvidia.com 26.5.0 / latest are frozen to the 26.05 release docs.
+# 26.08 current-docs model:
+#   - Build content from main (docs + library used by mkdocstrings).
+#   - Publish folder label is 26.8.0; versions.json on main owns the "latest" alias.
+#   - Auto-publish on main pushes is limited to docs/** and this workflow file so
+#     unrelated nemo_retriever code merges do not republish production docs.
 #
-# Operator steps when ready to publish:
-#   1. Merge doc changes to the 26.05 branch (content source for the build).
-#   2. Keep docs/publish/versions.json on main accurate (version picker + latest alias).
-#   3. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
-#        dry-run: false
-#        docs-version-override: 26.5.0 (or leave empty to use NRL_DOCS_PUBLISH_VERSION / default)
-#        publish-as-latest: true only when intentionally refreshing latest/
-# Backports: publish-as-latest: false; do not move the "latest" alias in versions.json.
+# Operator steps (first 26.08 go-live):
+#   1. Confirm this workflow is Enabled in Actions (it may still be Disabled manually).
+#   2. Keep docs/publish/versions.json on main with 26.8.0 aliases: ["latest"].
+#   3. Optional: set repo variable NRL_DOCS_PUBLISH_VERSION=26.8.0.
+#   4. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
+#        dry-run: true   (verify build)
+#        then dry-run: false
+#        docs-version-override: 26.8.0
+#        publish-as-latest: true
+#   5. Verify /26.8.0/ and /latest/, and that 26.5.0 remains in the picker without latest.
+# Backports to older trains: workflow_dispatch with publish-as-latest: false
+# (or /not-latest in the commit message); do not move the "latest" alias.
 name: NRL documentation — docs.nvidia.com publish
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/nrl-docs-nvidia-publish.yml"
   workflow_dispatch:
     inputs:
       dry-run:
@@ -35,7 +48,7 @@ on:
         type: boolean
         default: true
       docs-version-override:
-        description: Version folder to publish (e.g. 26.5.0). Empty uses NRL_DOCS_PUBLISH_VERSION, or 26.5.0.
+        description: Version folder to publish (e.g. 26.8.0). Empty uses NRL_DOCS_PUBLISH_VERSION, or 26.8.0.
         required: false
         type: string
         default: ""
@@ -78,25 +91,38 @@ jobs:
       - name: Resolve publish inputs
         id: publish
         env:
-          DISPATCH_DRY_RUN: ${{ inputs.dry-run }}
-          VERSION_INPUT: ${{ inputs.docs-version-override }}
-          PUBLISH_LATEST_INPUT: ${{ inputs.publish-as-latest }}
-          NOTIFY_INPUT: ${{ inputs.notify-emails }}
+          DISPATCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
+          VERSION_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.docs-version-override || '' }}
+          PUBLISH_LATEST_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.publish-as-latest }}
+          NOTIFY_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.notify-emails || '' }}
           NRL_DOCS_PUBLISH_VERSION_VAR: ${{ vars.NRL_DOCS_PUBLISH_VERSION }}
           DOCS_RELEASE_EMAILS_VAR: ${{ vars.DOCS_RELEASE_EMAILS }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message || '' }}
+          GITHUB_REF_NAME: ${{ github.ref }}
         run: |
-          echo "dry_run=${DISPATCH_DRY_RUN}" >> "$GITHUB_OUTPUT"
-          echo "publish_latest=${PUBLISH_LATEST_INPUT}" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "dry_run=${DISPATCH_DRY_RUN}" >> "$GITHUB_OUTPUT"
+            echo "publish_latest=${PUBLISH_LATEST_INPUT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "publish_latest=true" >> "$GITHUB_OUTPUT"
+          fi
 
           VERSION="${VERSION_INPUT}"
           if [[ -z "${VERSION}" ]]; then
             VERSION="${NRL_DOCS_PUBLISH_VERSION_VAR}"
           fi
           if [[ -z "${VERSION}" ]]; then
-            VERSION="26.5.0"
+            VERSION="26.8.0"
           fi
           echo "docs_version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "site_url=${{ env.DOCS_SITE_URL_BASE }}/${VERSION}/" >> "$GITHUB_OUTPUT"
+
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            if [[ "${HEAD_COMMIT_MSG}" =~ /not-latest ]] || [[ "${GITHUB_REF_NAME}" =~ not-latest ]]; then
+              echo "publish_latest=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
 
           EMAILS="${DOCS_RELEASE_EMAILS_VAR}"
           if [[ -n "${NOTIFY_INPUT}" ]]; then
@@ -116,23 +142,11 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the doc pages from the 26.05 release branch, not main. main keeps
-      # moving toward the next release, so its docs must not be published under the
-      # 26.5.0 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.05.
-      - name: Checkout 26.05 docs content
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: "26.05"
-
-      # versions.json (the version picker + "latest" alias) is canonical on main and
-      # does not exist on 26.05, so fetch just that file from main into a side path.
-      - name: Checkout version-picker metadata from main
+      # Publish the current 26.08 docs from main under the 26.8.0 label.
+      - name: Checkout main docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
-          path: .docs-main-meta
-          sparse-checkout: docs/publish/versions.json
-          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -156,9 +170,9 @@ jobs:
 
       # MkDocs does not emit versions.json. publish-docs uploads the artifact copy to S3
       # (it does not merge with the live S3 file). versions.json is canonical on main.
-      - name: Stage version picker metadata for publish-docs
+      - name: Copy versions.json into site artifact
         run: |
-          cp .docs-main-meta/docs/publish/versions.json docs/site/versions.json
+          cp docs/publish/versions.json docs/site/versions.json
 
       - name: Upload docs.nvidia.com site artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/docs/publish/versions.json
+++ b/docs/publish/versions.json
@@ -1,8 +1,13 @@
 [
   {
+    "version": "26.8.0",
+    "title": "26.8.0",
+    "aliases": ["latest"]
+  },
+  {
     "version": "26.5.0",
     "title": "26.5.0",
-    "aliases": ["latest"]
+    "aliases": []
   },
   {
     "version": "26.3.0",


### PR DESCRIPTION
## Summary

Retarget docs.nvidia.com publishing from frozen 26.05 (`26.5.0`) to current 26.08 docs built from **`main`**, published as **`26.8.0`** / **`latest`**.

- Build content from `main` (not `26.05`)
- Default publish folder: `26.8.0`
- Move the `latest` alias to `26.8.0` in `versions.json`; keep `26.5.0` and `26.3.0` in the picker
- Restore auto-publish on `main` pushes, but only for `docs/**` and this workflow file (not `nemo_retriever/**`)
- Keep manual `workflow_dispatch` (dry-run defaults to true)

## Operator runbook (for Sohail — Kurt OOO)

Do these steps in order after this PR merges.

### 0. Preconditions
- Confirm this PR is merged to `main`
- Confirm you have access to Actions for `NVIDIA/NeMo-Retriever` and the `docs-nvidia-prod` environment

### 1. Enable the workflow (required)
The workflow was previously **Disabled manually**. Enabling is a one-time UI step:

1. Open: https://github.com/NVIDIA/NeMo-Retriever/actions/workflows/nrl-docs-nvidia-publish.yml
2. If you see **This workflow was disabled manually**, click **Enable workflow**
3. Do **not** skip this step — a merged workflow file does not auto-enable a manually disabled workflow

### 2. Dry-run build (safe)
1. Actions → **NRL documentation — docs.nvidia.com publish** → **Run workflow**
2. Branch: `main`
3. Inputs:
   - **Skip S3 sync and Akamai flush**: checked (`dry-run: true`)
   - **Version folder**: `26.8.0`
   - **Also sync to latest/**: checked
4. Confirm the build job succeeds

### 3. First live publish (writes S3 + Akamai)
1. Run workflow again from `main` with:
   - **Skip S3 sync and Akamai flush**: **unchecked** (`dry-run: false`)
   - **Version folder**: `26.8.0`
   - **Also sync to latest/**: **checked**
2. Wait for the publish job and Akamai flush to complete

### 4. Verify production
Check:
- https://docs.nvidia.com/nemo/retriever/26.8.0/extraction/overview/
- https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/
- Version picker shows **26.8.0 latest**
- **26.5.0** and **26.3.0** remain available and are not labeled latest
- Banner from an older version (for example 26.3.0 / 26.5.0) reaches `/latest/...` correctly

### 5. After go-live (auto-publish)
Subsequent merges to `main` that touch `docs/**` (or this workflow file) will publish automatically to `26.8.0/` and `latest/`.

To publish without updating `latest/`, either:
- use `workflow_dispatch` with **Also sync to latest/** unchecked, or
- include `/not-latest` in the merge commit message

### Optional
- Set repository variable `NRL_DOCS_PUBLISH_VERSION=26.8.0` so empty override defaults stay aligned
- Notify Kurt if dry-run fails on missing docs/mkdocs config, secrets, or `docs-nvidia-prod` approval

## Test plan
- [ ] Workflow is Enabled in Actions after merge
- [ ] Dry-run with `26.8.0` succeeds
- [ ] Live publish with `publish-as-latest: true` succeeds
- [ ] `/26.8.0/` and `/latest/` show current main docs
- [ ] `/26.5.0/` remains reachable and is no longer latest
- [ ] A docs-only merge to `main` triggers auto-publish
- [ ] A non-docs `nemo_retriever/**` merge does **not** trigger publish
