### PR TITLE
fix(helm): break the split-topology gateway readiness deadlock

### DIFF
--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -26,7 +26,10 @@ The Helm chart uses `GET /v1/live` for startup and liveness probes and
 `GET /v1/health` for readiness. Both endpoints are unauthenticated. In split
 topology, `/v1/health` returns HTTP `503` when the required realtime or batch
 worker is unavailable, so Kubernetes removes the gateway from Service endpoints.
-Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes).
+In split topology, the realtime and batch init containers reach `/v1/live`
+through the chart's internal gateway startup Service
+(`<release>-nemo-retriever-gateway-startup`) so a clean install is not blocked
+by that readiness gate. Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes).
 In split topology, the gateway authenticates public requests. When internal
 service authentication is configured, the gateway uses it for restricted worker
 handoffs instead of forwarding public credentials. Without internal service

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -74,6 +74,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 ### Retriever Service and deployment { #retriever-service-and-deployment }
 
 - Helm maps `serviceConfig.nimEndpoints.rerankInvokeUrl` / `rerankModelName` into `nim_endpoints.rerank_invoke_url` / `rerank_model_name`, and auto-wires those fields when `nimOperator.rerankqa.enabled=true`, so `/v1/query` with `rerank=true` works in split topology.
+- Split topology renders an internal gateway startup Service so realtime and batch init containers can reach `GET /v1/live` before the gateway passes its deep `/v1/health` readiness check. This removes the clean-install deadlock that required manually patching `publishNotReadyAddresses` on the gateway Service.
 - Retriever Service exposes agentic retrieval on `POST /v1/query` when `agentic.enabled` is true. Refer to [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
 - Gateway worker pull scheduling replaces push routing.
 - Development Docker Compose deployment is available for local service stacks.

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -416,6 +416,43 @@ Complete the following checks:
 
 For VRAM versus scheduling, the time-slicing ConfigMap, and ClusterPolicy patch, refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
 
+## Split topology Helm install or upgrade times out with Deployments not ready { #helm-split-topology-startup-deadlock }
+
+`helm upgrade --install --wait` can time out in split topology
+(`topology.mode: split`) with errors similar to the following:
+
+```text
+Release "<release>" failed:
+resource Deployment/<release>-nemo-retriever-gateway not ready
+resource Deployment/<release>-nemo-retriever-realtime not ready
+resource Deployment/<release>-nemo-retriever-batch not ready
+context deadline exceeded
+```
+
+This deadlock occurs when the gateway readiness probe uses deep
+`GET /v1/health`, which returns HTTP `503` until realtime and batch workers are
+healthy, while worker Pods cannot start until their `wait-for-gateway` init
+container reaches the gateway's shallow `GET /v1/live` endpoint. The externally
+exposed gateway Service does not publish endpoints for an unready Pod, so neither
+side can become ready on a clean install.
+
+The chart renders an internal gateway startup Service named
+`<release>-nemo-retriever-gateway-startup` with `publishNotReadyAddresses: true`.
+Worker init containers poll `/v1/live` through that Service so startup completes
+without manual intervention. Client traffic continues to use the
+readiness-gated gateway Service.
+
+If you run an older chart that does not render the startup Service, you can
+unblock the install with a one-time patch on the gateway Service:
+
+```bash
+kubectl patch service <release>-nemo-retriever-gateway --type=merge \
+  -p '{"spec":{"publishNotReadyAddresses":true}}'
+```
+
+Upgrade to a chart version that includes the startup Service so you do not need
+to repeat that patch after every reinstall. Refer to [Health probes](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes) and [Service networking](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#service-networking) in the Helm chart README.
+
 ## Helm upgrade fails when changing a NIM image repository or tag { #helm-nimcache-modelpuller-immutable }
 
 `helm upgrade` can fail when you change `nimOperator.<key>.image.repository` or `nimOperator.<key>.image.tag` on an existing release. The chart reuses the `NIMCache` name, for example `nemotron-page-elements-v3`, while `spec.source.ngc.modelPuller` changes to the new `repository:tag` value.

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -637,10 +637,27 @@ The service exposes unauthenticated health endpoints for Kubernetes probes:
 
 | Endpoint | Purpose | Default Helm use |
 | --- | --- | --- |
-| `GET /v1/live` | Shallow process liveness. The endpoint does not check worker backends or wait for service readiness. | Startup and liveness probes. In split mode, the realtime and batch init containers use this endpoint while waiting for the gateway. |
-| `GET /v1/health` | Deep readiness. In split gateway mode, the endpoint checks the realtime and batch workers. It returns HTTP `503` when either required worker is unreachable or returns a non-2xx health response. | Readiness probe. |
+| `GET /v1/live` | Shallow process liveness. The endpoint does not check worker backends or wait for service readiness. | Startup and liveness probes. In split mode, the realtime and batch `wait-for-gateway` init containers poll this endpoint on the internal gateway startup Service while waiting for the gateway process to start. |
+| `GET /v1/health` | Deep readiness. In split gateway mode, the endpoint checks the realtime and batch workers. It returns HTTP `503` when either required worker is unreachable or returns a non-2xx health response. | Readiness probe on the externally exposed gateway Service. |
 
-When a gateway returns HTTP `503` from `/v1/health`, Kubernetes removes it from the Service endpoints until its required workers are ready. The response includes backend health details to help diagnose the unavailable dependency.
+In split topology, the gateway readiness probe uses `/v1/health`, which returns
+HTTP `503` until realtime and batch workers are healthy. Worker Pods cannot start
+until their `wait-for-gateway` init container reaches the gateway's shallow
+`/v1/live` endpoint. The externally exposed gateway Service does not publish
+endpoints for an unready Pod, which would deadlock a clean install. The chart
+therefore renders an additional cluster-internal Service named
+`<release>-nemo-retriever-gateway-startup` with
+`publishNotReadyAddresses: true`. Init containers reach
+`http://<release>-nemo-retriever-gateway-startup:<networkService.port>/v1/live`
+through that Service so workers can start while the gateway Pod is still
+unready. Client traffic continues to use the readiness-gated gateway Service, so
+`/v1/health` still removes an unhealthy gateway from Service endpoints after
+startup.
+
+When a gateway returns HTTP `503` from `/v1/health`, Kubernetes removes it from
+the readiness-gated gateway Service endpoints until its required workers are
+ready. The response includes backend health details to help diagnose the
+unavailable dependency.
 
 ### Service networking
 
@@ -652,6 +669,22 @@ When a gateway returns HTTP `503` from `/v1/health`, Kubernetes removes it from 
 You can set these values independently. When they differ, Kubernetes Services
 listen on `networkService.port` and route to the container listener on
 `serviceConfig.server.port`.
+
+In standalone mode, the chart renders one Service named
+`<release>-nemo-retriever`.
+
+In split topology (`topology.mode: split`), the chart renders four Services:
+
+| Service | Example name (release `retriever`) | Type | Client entrypoint |
+| --- | --- | --- | --- |
+| Gateway | `retriever-nemo-retriever-gateway` | `networkService.type` (default `NodePort`) | Yes |
+| Gateway startup | `retriever-nemo-retriever-gateway-startup` | ClusterIP (cluster-internal only) | No |
+| Realtime | `retriever-nemo-retriever-realtime` | ClusterIP | No |
+| Batch | `retriever-nemo-retriever-batch` | ClusterIP | No |
+
+The gateway startup Service publishes the gateway Pod address while it is still
+unready so realtime and batch init containers can reach `/v1/live`. It is not a
+client entrypoint. Refer to [Health probes](#health-probes).
 
 ### Service configuration (rendered into `retriever-service.yaml`)
 

--- a/nemo_retriever/helm/templates/_helpers.tpl
+++ b/nemo_retriever/helm/templates/_helpers.tpl
@@ -280,7 +280,7 @@ nemo-retriever.gateway.startupServiceName
   Usage: {{ include "nemo-retriever.gateway.startupServiceName" $ }}
 */}}
 {{- define "nemo-retriever.gateway.startupServiceName" -}}
-{{- printf "%s-startup" (include "nemo-retriever.role.fullname" (dict "context" . "role" "gateway")) | trunc 63 | trimSuffix "-" -}}
+{{- include "nemo-retriever.suffixedFullname" (dict "context" . "suffix" "-gateway-startup") -}}
 {{- end -}}
 
 

--- a/nemo_retriever/helm/templates/_helpers.tpl
+++ b/nemo_retriever/helm/templates/_helpers.tpl
@@ -272,6 +272,17 @@ nemo-retriever.role.configMapName
 {{- printf "%s-config" (include "nemo-retriever.role.fullname" .) -}}
 {{- end -}}
 
+{{/*
+nemo-retriever.gateway.startupServiceName
+  Name of the gateway startup Service. This Service publishes not-ready
+  addresses so worker init containers can reach the gateway's shallow
+  /v1/live endpoint before the gateway's deep readiness probe passes.
+  Usage: {{ include "nemo-retriever.gateway.startupServiceName" $ }}
+*/}}
+{{- define "nemo-retriever.gateway.startupServiceName" -}}
+{{- printf "%s-startup" (include "nemo-retriever.role.fullname" (dict "context" . "role" "gateway")) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 
 {{/*
 =============================================================================

--- a/nemo_retriever/helm/templates/deployment.yaml
+++ b/nemo_retriever/helm/templates/deployment.yaml
@@ -287,7 +287,7 @@ spec:
             - sh
             - -c
             - |
-              GATEWAY="{{ include "nemo-retriever.role.fullname" (dict "context" $ "role" "gateway") }}"
+              GATEWAY="{{ include "nemo-retriever.gateway.startupServiceName" $ }}"
               PORT="{{ $.Values.networkService.port }}"
               echo "Waiting for gateway at ${GATEWAY}:${PORT} ..."
               until wget -qO- --timeout=3 "http://${GATEWAY}:${PORT}/v1/live" >/dev/null 2>&1; do

--- a/nemo_retriever/helm/templates/service.yaml
+++ b/nemo_retriever/helm/templates/service.yaml
@@ -60,6 +60,30 @@ spec:
       nodePort: {{ .Values.networkService.nodePort }}
       {{- end }}
 
+# Gateway startup Service — internal only. The gateway readiness probe is a deep
+# check that requires healthy realtime and batch workers, and the workers wait on
+# the gateway's shallow /v1/live endpoint before they start. Gating every gateway
+# address on readiness therefore deadlocks a clean install, so this Service
+# publishes the gateway address while the Pod is still unready. Client traffic
+# keeps using the readiness-gated Service above.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nemo-retriever.gateway.startupServiceName" . }}
+  labels:
+    {{- include "nemo-retriever.role.labels" (dict "context" $ "role" "gateway-startup") | nindent 4 }}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "nemo-retriever.role.selectorLabels" (dict "context" $ "role" "gateway") | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.networkService.port }}
+      targetPort: {{ .Values.networkService.targetPort }}
+
 # Realtime Service — ClusterIP, used by gateway for internal routing
 ---
 apiVersion: v1

--- a/nemo_retriever/tests/test_helm_split_gateway_startup.py
+++ b/nemo_retriever/tests/test_helm_split_gateway_startup.py
@@ -93,6 +93,32 @@ def test_split_startup_service_is_not_scraped_by_the_gateway_service_monitor() -
         assert not all(startup_labels.get(key) == value for key, value in selector.items())
 
 
+def test_long_release_keeps_the_startup_service_distinct_and_referenced() -> None:
+    documents = _render(
+        "--set",
+        "topology.mode=split",
+        "--set",
+        "serviceMonitor.autoEnableInSplitMode=false",
+        "--set-string",
+        f"fullnameOverride={'b' * 63}",
+    )
+    services = _services(documents)
+
+    startup = next(
+        name
+        for name, service in services.items()
+        if service["metadata"]["labels"].get("app.kubernetes.io/component") == "gateway-startup"
+    )
+    assert startup.endswith("-gateway-startup")
+    assert len(startup) <= 63
+    assert startup not in {
+        name
+        for name, service in services.items()
+        if service["metadata"]["labels"].get("app.kubernetes.io/component") == "gateway"
+    }
+    assert f'GATEWAY="{startup}"' in _init_container_script(documents, "realtime")
+
+
 def test_standalone_renders_no_startup_service_or_init_container() -> None:
     documents = _render()
 

--- a/nemo_retriever/tests/test_helm_split_gateway_startup.py
+++ b/nemo_retriever/tests/test_helm_split_gateway_startup.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helm wiring that keeps split-topology startup free of a readiness deadlock."""
+
+from __future__ import annotations
+
+from tests.test_helm_shared_results import _render, _service_deployments
+
+GATEWAY_SERVICE = "shared-results-test-nemo-retriever-gateway"
+STARTUP_SERVICE = "shared-results-test-nemo-retriever-gateway-startup"
+
+
+def _services(documents: list[dict]) -> dict[str, dict]:
+    return {document["metadata"]["name"]: document for document in documents if document.get("kind") == "Service"}
+
+
+def _init_container_script(documents: list[dict], component: str) -> str:
+    deployment = next(
+        item
+        for item in _service_deployments(documents)
+        if item["metadata"]["labels"]["app.kubernetes.io/component"] == component
+    )
+    init_container = next(
+        item for item in deployment["spec"]["template"]["spec"]["initContainers"] if item["name"] == "wait-for-gateway"
+    )
+    return init_container["command"][-1]
+
+
+def test_split_startup_service_publishes_unready_gateway_address() -> None:
+    documents = _render(
+        "--set",
+        "topology.mode=split",
+        "--set",
+        "serviceMonitor.autoEnableInSplitMode=false",
+    )
+    services = _services(documents)
+
+    startup = services[STARTUP_SERVICE]
+    assert startup["spec"]["type"] == "ClusterIP"
+    assert startup["spec"]["publishNotReadyAddresses"] is True
+    assert startup["spec"]["selector"]["app.kubernetes.io/component"] == "gateway"
+    assert startup["spec"]["ports"] == [{"name": "http", "protocol": "TCP", "port": 7670, "targetPort": "http"}]
+
+    # Client traffic keeps the deep-readiness gate introduced for NVBug 6610671.
+    assert "publishNotReadyAddresses" not in services[GATEWAY_SERVICE]["spec"]
+
+
+def test_split_worker_init_containers_wait_on_startup_service() -> None:
+    documents = _render(
+        "--set",
+        "topology.mode=split",
+        "--set",
+        "serviceMonitor.autoEnableInSplitMode=false",
+    )
+
+    for component in ("realtime", "batch"):
+        script = _init_container_script(documents, component)
+        assert f'GATEWAY="{STARTUP_SERVICE}"' in script
+        assert "/v1/live" in script
+
+
+def test_split_startup_service_follows_network_service_port() -> None:
+    documents = _render(
+        "--set",
+        "topology.mode=split",
+        "--set",
+        "networkService.port=18080",
+        "--set",
+        "serviceMonitor.autoEnableInSplitMode=false",
+    )
+
+    startup = _services(documents)[STARTUP_SERVICE]
+    assert startup["spec"]["ports"][0]["port"] == 18080
+    assert startup["spec"]["ports"][0]["targetPort"] == "http"
+    assert 'PORT="18080"' in _init_container_script(documents, "realtime")
+
+
+def test_split_startup_service_is_not_scraped_by_the_gateway_service_monitor() -> None:
+    documents = _render(
+        "--set",
+        "topology.mode=split",
+        "--set",
+        "serviceMonitor.autoEnableInSplitMode=true",
+    )
+    startup_labels = _services(documents)[STARTUP_SERVICE]["metadata"]["labels"]
+    monitors = [document for document in documents if document.get("kind") == "ServiceMonitor"]
+
+    assert len(monitors) == 3
+    for monitor in monitors:
+        selector = monitor["spec"]["selector"]["matchLabels"]
+        assert not all(startup_labels.get(key) == value for key, value in selector.items())
+
+
+def test_standalone_renders_no_startup_service_or_init_container() -> None:
+    documents = _render()
+
+    assert all(not service["spec"].get("publishNotReadyAddresses") for service in _services(documents).values())
+    assert STARTUP_SERVICE not in _services(documents)
+    assert all(
+        "initContainers" not in deployment["spec"]["template"]["spec"] for deployment in _service_deployments(documents)
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

A clean split-topology Helm install could not start without a manual `kubectl patch`, because gateway readiness and worker startup waited on each other:

- The gateway readiness probe calls the deep `GET /v1/health`, which correctly returns HTTP 503 until the realtime and batch workers are healthy.
- The realtime and batch Pods run a `wait-for-gateway` init container that must reach the gateway's shallow `GET /v1/live` through the gateway ClusterIP Service before the worker containers start.
- Kubernetes publishes no endpoint for an unready Pod, so the init containers could never reach `/v1/live`, the workers never started, and `/v1/health` kept returning 503.

`helm upgrade --install --wait` therefore timed out with all three Deployments reported not ready, and the only recovery was the undocumented `kubectl patch service <release>-nemo-retriever-gateway --type=merge -p '{"spec":{"publishNotReadyAddresses":true}}'`.

This chart adds a second, cluster-internal gateway Service for the startup handshake instead of relaxing readiness on the client-facing Service:

- New `<release>-nemo-retriever-gateway-startup` Service (split topology only): `ClusterIP` with `publishNotReadyAddresses: true`, selecting the gateway Pod and exposing `networkService.port` on `targetPort: http`.
- The `wait-for-gateway` init containers now poll `/v1/live` through that Service.
- The externally exposed gateway Service is unchanged and keeps its readiness gate, so the deep readiness behavior added for NVBug 6610671 still removes an unhealthy gateway from client-facing endpoints after startup.
- The startup Service is labeled `app.kubernetes.io/component: gateway-startup` so the gateway `ServiceMonitor` selector does not match it and Prometheus does not scrape the gateway Pod twice.
- The name comes from the existing suffix-preserving `nemo-retriever.suffixedFullname` helper, so a long release name cannot truncate the startup Service onto the gateway Service name that the init containers also resolve.

No new Helm values are introduced, and standalone topology renders exactly as before.

### Startup sequence after the fix

1. The init containers resolve the startup Service and reach `/v1/live` while the gateway Pod is still unready.
2. The realtime and batch worker containers start and pass their own `/v1/health` readiness probe, so their Services publish endpoints.
3. The gateway's deep `/v1/health` check then finds both backends healthy, the gateway Pod becomes Ready, and the client-facing gateway Service publishes its endpoint.

### Validation

- `helm lint` passes for both `topology.mode=split` and standalone.
- Rendered split topology confirms `publishNotReadyAddresses: true` only on the startup Service, both init containers pointing at it, and `networkService.port` overrides flowing through to both the Service port and the init container.
- New `nemo_retriever/tests/test_helm_split_gateway_startup.py` covers the startup Service spec, the init container target, port overrides, `ServiceMonitor` non-selection, long-release-name truncation, and that standalone renders neither the Service nor the init container.
- The existing `test_helm_*.py` template suites still pass, including `test_chart_service_urls_use_network_service_port` and the split-mode work-queue tests.
- Docs: `python -m mkdocs build --strict --config-file mkdocs.yml` succeeds from `docs/`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01abc-2c15-70bf-8490-dd687a6713dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01abc-2c15-70bf-8490-dd687a6713dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

