### PR TITLE
docs(extraction): add optional Nemotron-3-Embed-1B to 26.08 release notes (NVBug 6628502)

### DIFF
--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -51,10 +51,14 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
     - VL reranking (optional): `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0`
     - Optional Omni caption and configurable answer VLM: `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant`
     - Optional answer-generation LLM: `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5`
+- Optional Nemotron-3-Embed-1B is a released 26.08 embedding artifact. It is not enabled by default and is not a Helm NIM.
+    - Optional NIM: `nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.2`
+    - Optional Hugging Face checkpoint: `nvidia/Nemotron-3-Embed-1B-BF16` (revision `9e0b24858b1195815ecb1188ffa1b73bcea7b30a`)
+- The CLI lists `nvidia/Nemotron-3-Embed-1B-BF16` among tested official local checkpoints. For local Hugging Face inference, pass `--embed-model-name nvidia/Nemotron-3-Embed-1B-BF16`. For a self-hosted or hosted embedding NIM, pass `--embed-invoke-url` with `--embed-model-name`. Refer to [Dense Nemotron embedding checkpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#dense-nemotron-embedding-checkpoints) for local checkpoint usage. Refer to [Route ingest to hosted or self-hosted NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#route-ingest-to-hosted-or-self-hosted-nim-endpoints) and the text-only embedding NIM note in [Multimodal embeddings](embedding.md) for external endpoints.
 - The `page_elements` and `table_structure` services share the combined object-detection image and select distinct models. Pull that image once for air-gapped or allowlisted deployments.
 - Nemotron 3 Nano Omni is the canonical caption model. It is opt-in on Helm and has a larger GPU footprint than Nano caption profiles.
 - Nemotron Parse endpoint wiring is available in service extraction workers, with documented hosted versus self-hosted contract selection.
-- An embedder model router supports additional Llama Nemotron embedding checkpoints, including 1B, 3B, 8B, local, fine-tuned, and ModelOpt.
+- An embedder model router supports additional Llama Nemotron and Nemotron-3 embedding checkpoints, including 1B, 3B, 8B, local, fine-tuned, and ModelOpt.
 
 ### Pipeline and ingestion { #pipeline-and-ingestion }
 
@@ -105,7 +109,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 
 ### Helm chart { #helm-chart }
 
-- The Helm chart under `nemo_retriever/helm/` defaults to OCR v2, the combined object-detection NIM, and VL embedder 2.3.0. Optional NIMs include VL rerank 2.3.0, Omni `2.0.4-variant`, Nemotron Parse, and the Super-49B `answer_llm` slot. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims).
+- The Helm chart under `nemo_retriever/helm/` defaults to OCR v2, the combined object-detection NIM, and VL embedder 2.3.0. Optional NIMs include VL rerank 2.3.0, Omni `2.0.4-variant`, Nemotron Parse, and the Super-49B `answer_llm` slot. Nemotron-3-Embed-1B is optional and is not a chart NIM. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [Models, OCR, and NIM artifacts](#models-ocr-and-captioning).
 
 ### Documentation { #documentation }
 


### PR DESCRIPTION
## Summary
- Add optional Nemotron-3-Embed-1B to the 26.08 Release Notes artifact list: NIM `nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.2` and Hugging Face `nvidia/Nemotron-3-Embed-1B-BF16` (revision `9e0b24858b1195815ecb1188ffa1b73bcea7b30a`).
- Identify it as optional and not a default Helm NIM. Super-49B `2.0.5` is unchanged (confirmed for RC7).
- Link local Hugging Face `--embed-model-name` and external `--embed-invoke-url` configuration in the CLI README and the text-only embedding NIM note.

Follow-up to #2548 for NVBug 6628502 RC7 QA.

## Test plan
- [ ] Confirm Super-49B remains `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5`.
- [ ] Confirm Nemotron-3-Embed-1B is listed as optional and is not described as a chart or default Helm NIM.
- [ ] Confirm the CLI dense-checkpoint and hosted/self-hosted NIM links, plus the multimodal embeddings note, resolve.
- [ ] Confirm the PR diff is only `docs/docs/extraction/releasenotes.md`.

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** docs/docs/extraction/releasenotes.md

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — `releasenotes.md` has no `see [` CTAs; conceptual page-role files are not in this diff. Stock `check-nrl-doc-leakage.ps1 -Base main` scanned `origin/main` (31 files) and failed on untracked leftover `custom-metadata.md`, which is not in this PR. |
| Allowed paths | PASS — 1 documentation file |
| mkdocs --strict | FAIL exit 1 — 4 warnings on untracked leftover `custom-metadata.md` and `user-defined-stages.md`; not in this diff. `releasenotes.md` produced no warnings. |
| ::a audit | PASS — not-a-Helm-NIM and CLI checkpoint claims triangulated (95%). NIM `2.2.2` and HF revision SHA are QA-supplied, not pinned in Helm or `HF_MODEL_REVISIONS`. `validate_code_blocks` pass (0 blocks); `verify_docs` pass (no link issues). |
| ::p polish | none needed — added bullets already name the artifact, optional/Helm boundary, and config links |
| ::r style | 95% — no blocking issues on the added text (`refer to`, no contractions, Optional labeled with a colon) |

**Code drift (not in this docs PR):** `hf_model_registry.py` does not pin `nvidia/Nemotron-3-Embed-1B-BF16` to `9e0b24858b1195815ecb1188ffa1b73bcea7b30a`. Helm has no `nemotron-3-embed-1b` image (intentional; documented as not a chart NIM).

**PR:** https://github.com/NVIDIA/NeMo-Retriever/pull/2559