### PR TITLE
fix(models): bump Nemotron Parse v1.2 revision

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
+++ b/nemo_retriever/src/nemo_retriever/models/hf_model_registry.py
@@ -27,7 +27,7 @@ HF_MODEL_REVISIONS: dict[str, str] = {
     "nvidia/llama-3.2-nv-embedqa-1b-v2": "cefc2394cc541737b7867df197984cf23f05367f",
     "nvidia/llama-nemotron-embed-1b-v2": "113abe4acafa848e77ead9c0623205e511932348",
     "nvidia/parakeet-ctc-1.1b": "20e63a0fed6aedba145b74b826dbd41df0941730",
-    "nvidia/NVIDIA-Nemotron-Parse-v1.2": "f42c8040b12ee64370922d108778ab655b722c5d",
+    "nvidia/NVIDIA-Nemotron-Parse-v1.2": "2bd0189bffd6cdded6280d9f22a4077b25a504e3",
     "nvidia/NVIDIA-Nemotron-Parse-2.0": "635b84d9b09bb9526b9a684d0b2c953d3cc3df05",
     "nvidia/llama-nemotron-embed-vl-1b-v2": "582e3bf72aee355e3c59ed89de53543c5b0657ee",
     "meta-llama/Llama-3.2-1B": "4e20de362430cd3b72f300e6b0f18e50e7166e08",

--- a/nemo_retriever/tests/test_hf_model_registry.py
+++ b/nemo_retriever/tests/test_hf_model_registry.py
@@ -15,6 +15,9 @@ def test_extraction_hf_repos_have_pinned_revisions():
     assert registry.HF_MODEL_REVISIONS["nvidia/nemotron-ocr-v1"] == "8657d08d3279f4864002d5fd3fdcd47ad8c96bcb"
     assert registry.HF_MODEL_REVISIONS["nvidia/nemotron-ocr-v2"] == "0e83e83f17943524b90afa6c0fd82ac2bc1a40ca"
     assert registry.HF_MODEL_REVISIONS["nvidia/nemotron-page-elements-v3"] == "df62dbb631502575ac4d43b44d700b1674ab1d56"
+    assert (
+        registry.HF_MODEL_REVISIONS["nvidia/NVIDIA-Nemotron-Parse-v1.2"] == "2bd0189bffd6cdded6280d9f22a4077b25a504e3"
+    )
     assert registry.HF_MODEL_REVISIONS["nvidia/NVIDIA-Nemotron-Parse-2.0"] == "635b84d9b09bb9526b9a684d0b2c953d3cc3df05"
     assert (
         registry.HF_MODEL_REVISIONS["nvidia/nemotron-table-structure-v1"] == "9350162faa1110320af62699105780b0c87b73ad"


### PR DESCRIPTION
## Description
updates parse v1.2 pin to 2bd0189bffd6cdded6280d9f22a4077b25a504e3 (may 5th hash)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
