### PR TITLE
Revert 26.08 docs.nvidia.com publish; restore manual 26.05 publishing (revert #2554)

### DIFF
--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -11,35 +11,22 @@
 #   Variables (optional): DOCS_AWS_REGION, NRL_DOCS_PUBLISH_VERSION, DOCS_RELEASE_EMAILS
 #
 # S3 layout written under developer/docs/nemo/retriever/:
-#   index.html, versions.json, latest/, <version>/ (e.g. 26.8.0/)
+#   index.html, versions.json, latest/, <version>/ (e.g. 26.5.0/)
 #
-# 26.08 current-docs model:
-#   - Build content from main (docs + library used by mkdocstrings).
-#   - Publish folder label is 26.8.0; versions.json on main owns the "latest" alias.
-#   - Auto-publish on main pushes is limited to docs/** and this workflow file so
-#     unrelated nemo_retriever code merges do not republish production docs.
+# Manual publish only (workflow_dispatch). Do not re-enable push/tag auto-publish
+# while docs.nvidia.com 26.5.0 / latest are frozen to the 26.05 release docs.
 #
-# Operator steps (first 26.08 go-live):
-#   1. Confirm this workflow is Enabled in Actions (it may still be Disabled manually).
-#   2. Keep docs/publish/versions.json on main with 26.8.0 aliases: ["latest"].
-#   3. Optional: set repo variable NRL_DOCS_PUBLISH_VERSION=26.8.0.
-#   4. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
-#        dry-run: true   (verify build)
-#        then dry-run: false
-#        docs-version-override: 26.8.0
-#        publish-as-latest: true
-#   5. Verify /26.8.0/ and /latest/, and that 26.5.0 remains in the picker without latest.
-# Backports to older trains: workflow_dispatch with publish-as-latest: false
-# (or /not-latest in the commit message); do not move the "latest" alias.
+# Operator steps when ready to publish:
+#   1. Merge doc changes to the 26.05 branch (content source for the build).
+#   2. Keep docs/publish/versions.json on main accurate (version picker + latest alias).
+#   3. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
+#        dry-run: false
+#        docs-version-override: 26.5.0 (or leave empty to use NRL_DOCS_PUBLISH_VERSION / default)
+#        publish-as-latest: true only when intentionally refreshing latest/
+# Backports: publish-as-latest: false; do not move the "latest" alias in versions.json.
 name: NRL documentation — docs.nvidia.com publish
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/**"
-      - ".github/workflows/nrl-docs-nvidia-publish.yml"
   workflow_dispatch:
     inputs:
       dry-run:
@@ -48,7 +35,7 @@ on:
         type: boolean
         default: true
       docs-version-override:
-        description: Version folder to publish (e.g. 26.8.0). Empty uses NRL_DOCS_PUBLISH_VERSION, or 26.8.0.
+        description: Version folder to publish (e.g. 26.5.0). Empty uses NRL_DOCS_PUBLISH_VERSION, or 26.5.0.
         required: false
         type: string
         default: ""
@@ -91,38 +78,25 @@ jobs:
       - name: Resolve publish inputs
         id: publish
         env:
-          DISPATCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
-          VERSION_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.docs-version-override || '' }}
-          PUBLISH_LATEST_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.publish-as-latest }}
-          NOTIFY_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.notify-emails || '' }}
+          DISPATCH_DRY_RUN: ${{ inputs.dry-run }}
+          VERSION_INPUT: ${{ inputs.docs-version-override }}
+          PUBLISH_LATEST_INPUT: ${{ inputs.publish-as-latest }}
+          NOTIFY_INPUT: ${{ inputs.notify-emails }}
           NRL_DOCS_PUBLISH_VERSION_VAR: ${{ vars.NRL_DOCS_PUBLISH_VERSION }}
           DOCS_RELEASE_EMAILS_VAR: ${{ vars.DOCS_RELEASE_EMAILS }}
-          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message || '' }}
-          GITHUB_REF_NAME: ${{ github.ref }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "dry_run=${DISPATCH_DRY_RUN}" >> "$GITHUB_OUTPUT"
-            echo "publish_latest=${PUBLISH_LATEST_INPUT}" >> "$GITHUB_OUTPUT"
-          else
-            echo "dry_run=false" >> "$GITHUB_OUTPUT"
-            echo "publish_latest=true" >> "$GITHUB_OUTPUT"
-          fi
+          echo "dry_run=${DISPATCH_DRY_RUN}" >> "$GITHUB_OUTPUT"
+          echo "publish_latest=${PUBLISH_LATEST_INPUT}" >> "$GITHUB_OUTPUT"
 
           VERSION="${VERSION_INPUT}"
           if [[ -z "${VERSION}" ]]; then
             VERSION="${NRL_DOCS_PUBLISH_VERSION_VAR}"
           fi
           if [[ -z "${VERSION}" ]]; then
-            VERSION="26.8.0"
+            VERSION="26.5.0"
           fi
           echo "docs_version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "site_url=${{ env.DOCS_SITE_URL_BASE }}/${VERSION}/" >> "$GITHUB_OUTPUT"
-
-          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
-            if [[ "${HEAD_COMMIT_MSG}" =~ /not-latest ]] || [[ "${GITHUB_REF_NAME}" =~ not-latest ]]; then
-              echo "publish_latest=false" >> "$GITHUB_OUTPUT"
-            fi
-          fi
 
           EMAILS="${DOCS_RELEASE_EMAILS_VAR}"
           if [[ -n "${NOTIFY_INPUT}" ]]; then
@@ -142,13 +116,23 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the current 26.08 docs from the triggering main commit under the
-      # 26.8.0 label. Use github.sha (not the floating main tip) so a delayed run
-      # cannot publish a newer tip under flags resolved for an earlier commit.
-      - name: Checkout main docs content
+      # Publish the doc pages from the 26.05 release branch, not main. main keeps
+      # moving toward the next release, so its docs must not be published under the
+      # 26.5.0 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.05.
+      - name: Checkout 26.05 docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.sha }}
+          ref: "26.05"
+
+      # versions.json (the version picker + "latest" alias) is canonical on main and
+      # does not exist on 26.05, so fetch just that file from main into a side path.
+      - name: Checkout version-picker metadata from main
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          path: .docs-main-meta
+          sparse-checkout: docs/publish/versions.json
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -172,9 +156,9 @@ jobs:
 
       # MkDocs does not emit versions.json. publish-docs uploads the artifact copy to S3
       # (it does not merge with the live S3 file). versions.json is canonical on main.
-      - name: Copy versions.json into site artifact
+      - name: Stage version picker metadata for publish-docs
         run: |
-          cp docs/publish/versions.json docs/site/versions.json
+          cp .docs-main-meta/docs/publish/versions.json docs/site/versions.json
 
       - name: Upload docs.nvidia.com site artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/docs/publish/versions.json
+++ b/docs/publish/versions.json
@@ -1,13 +1,8 @@
 [
   {
-    "version": "26.8.0",
-    "title": "26.8.0",
-    "aliases": ["latest"]
-  },
-  {
     "version": "26.5.0",
     "title": "26.5.0",
-    "aliases": []
+    "aliases": ["latest"]
   },
   {
     "version": "26.3.0",


### PR DESCRIPTION
## Summary

Reverts #2554. The 26.08 cutover published to `docs.nvidia.com` before 26.08 was public, so `/nemo/retriever/latest/` is currently serving 26.08 content and `/nemo/retriever/26.8.0/` is live. This restores the pre-cutover configuration:

- Publishing is manual only (`workflow_dispatch`); the `push` trigger on `main` is removed.
- Content source returns to the `26.05` branch, so `main` docs cannot reach production under a release label.
- `docs/publish/versions.json` returns `26.5.0` to `aliases: ["latest"]` and drops the `26.8.0` entry.

The workflow **NRL documentation — docs.nvidia.com publish** is disabled in Actions and must stay disabled until this merges.

## Why the unintended publish happened

Two runs published today, and both wrote to `latest/`:

| Run | Trigger | Result |
|---|---|---|
| [32285192127](https://github.com/NVIDIA/NeMo-Retriever/actions/runs/32285192127) | `workflow_dispatch` | `dry-run=false`, `publish-as-latest=true` → published `26.8.0/` and `latest/` |
| [32285635733](https://github.com/NVIDIA/NeMo-Retriever/actions/runs/32285635733) | `push` (#2558) | `push` events force `publish_latest=true` regardless of the form → republished `latest/` |

The second run is the important failure. Under #2554, any merge to `main` touching `docs/**` published to production and moved the `latest` alias, with no operator confirmation and no dry-run gate.

## Production rollback runbook

Do this in S3 and Akamai. Do **not** use **Run workflow** to roll back; a rebuild can drift from the content that was live.

All paths are under `developer/docs/nemo/retriever/` in the docs S3 bucket.

1. **Restore `latest/` from the intact 26.05 tree.** `26.5.0/` was not touched by either run and still holds the July 28 build.

```bash
aws s3 sync s3://<docs-bucket>/developer/docs/nemo/retriever/26.5.0/ \
            s3://<docs-bucket>/developer/docs/nemo/retriever/latest/ --delete
```

2. **Remove the 26.08 tree.**

```bash
aws s3 rm s3://<docs-bucket>/developer/docs/nemo/retriever/26.8.0/ --recursive
```

3. **Restore the root version picker.** Upload `docs/publish/versions.json` from this branch to `developer/docs/nemo/retriever/versions.json`. It must list `26.5.0` with `aliases: ["latest"]` and no `26.8.0` entry. Step 1 already restores `latest/versions.json`.

4. **Purge Akamai** for `/nemo/retriever/`, `/nemo/retriever/versions.json`, `/nemo/retriever/latest/*`, and `/nemo/retriever/26.8.0/*`.

Akamai is still serving July-cached HTML for some `latest/` pages, so the public site currently looks partly correct. That is cache, not origin. Without steps 1 and 2 the 26.08 content surfaces as the cache expires.

5. **Verify** after the purge:

```bash
curl -s https://docs.nvidia.com/nemo/retriever/versions.json
curl -s https://docs.nvidia.com/nemo/retriever/latest/versions.json
curl -s -o /dev/null -w '%{http_code}\n' https://docs.nvidia.com/nemo/retriever/26.8.0/extraction/overview/
```

Expect `26.5.0` aliased to `latest` in both version files, and `404` for the `26.8.0` path.

## Re-enabling the workflow

Leave the workflow disabled until this PR merges. After it merges, re-enabling is safe because only `workflow_dispatch` remains and `dry-run` defaults to `true`.

## When 26.08 is cleared to publish

Re-apply this revert rather than hand-editing the workflow, then treat the auto-publish trigger as a separate decision. Two things should change before `push` publishing is reconsidered:

- A `push` run currently ignores `publish-as-latest` and always moves the `latest` alias. It should not.
- A `push` run sets `dry_run=false` unconditionally, so there is no gate between a docs merge and production.

## Test plan

- [ ] Workflow shows `workflow_dispatch` only, with no `push` trigger.
- [ ] `docs/publish/versions.json` lists `26.5.0` as `latest` and omits `26.8.0`.
- [ ] S3 rollback steps 1 through 4 complete.
- [ ] Verification in step 5 returns the expected values.
- [ ] Workflow re-enabled in Actions after merge.
