### PR TITLE
fix concurrent writes for vectordb

### DIFF
--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -374,6 +374,36 @@ ERROR 2025-04-24 22:49:44.434 nimutils.py:68] }
 
 
 
+## LanceDB index creation fails during concurrent Helm ingestion { #lancedb-concurrent-index-creation }
+
+Concurrent ingest workers can finish extraction at nearly the same time and
+send overlapping writes to the VectorDB service. In affected releases, those
+writes can rebuild the LanceDB vector or full-text-search index concurrently.
+LanceDB rejects one of the competing commits with an error similar to the
+following:
+
+```text
+Retryable commit conflict for version <version>:
+This CreateIndex transaction was preempted by concurrent transaction CreateIndex.
+Please retry.
+```
+
+Upgrade to a NeMo Retriever Library release that serializes the complete
+legacy LanceDB write transaction. The VectorDB service queues concurrent
+`/internal/vectordb/write` requests that reach the same pod, including the
+append and index rebuild, so the conflicting index commits do not overlap.
+There is no Helm value to configure for this behavior.
+
+Keep the VectorDB deployment at one replica. The serialization is local to a
+single VectorDB process and does not coordinate writes across multiple pods or
+independently deployed processes that share a LanceDB directory.
+
+If a request failed before the upgrade, inspect the table and the ingest job
+before resubmitting it. A write can append rows before a later index rebuild
+fails. The legacy append path does not deduplicate rows, so blindly rerunning
+the same input can create duplicates.
+
+
 ## Helm install succeeds but PersistentVolumeClaims stay Pending { #helm-pending-pvcs }
 
 `helm install` can report `STATUS: deployed` while every default PersistentVolumeClaim stays `Pending`. That status means Helm rendered the release. It does not mean the retriever service, VectorDB, or core NIM workloads can schedule.

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py
@@ -606,6 +606,10 @@ class LanceDB(VDB):
         self._collection_store: Any | None = None
         self._collection_store_init_failed = False
         self._collection_store_lock = threading.Lock()
+        # A write includes both the table mutation and an optional index rebuild.
+        # LanceDB treats competing index commits as a conflict, so these must be
+        # one transaction from the perspective of callers sharing this backend.
+        self._write_lock = threading.Lock()
         super().__init__(**kwargs)
 
     def _get_collection_store(self) -> Any:
@@ -1056,24 +1060,28 @@ class LanceDB(VDB):
 
     def run(self, records):
         """Orchestrate index creation and data ingestion."""
-        table = self.create_index(records=records, table_name=self.table_name)
-        if self.build_index:
-            self.write_to_index(
-                records,
-                table=table,
-                index_type=self.index_type,
-                metric=self.metric,
-                num_partitions=self.num_partitions,
-                num_sub_vectors=self.num_sub_vectors,
-                hybrid=self.hybrid,
-                sparse=self.sparse,
-                fts_language=self.fts_language,
-            )
-        else:
-            logger.info(
-                "Skipping LanceDB index creation for table %r because build_index=False.",
-                self.table_name,
-            )
+        # The VectorDB service can dispatch multiple ingestion callbacks at
+        # once. Serialize append/create and index replacement as one critical
+        # section so a later CreateIndex cannot preempt an in-flight one.
+        with self._write_lock:
+            table = self.create_index(records=records, table_name=self.table_name)
+            if self.build_index:
+                self.write_to_index(
+                    records,
+                    table=table,
+                    index_type=self.index_type,
+                    metric=self.metric,
+                    num_partitions=self.num_partitions,
+                    num_sub_vectors=self.num_sub_vectors,
+                    hybrid=self.hybrid,
+                    sparse=self.sparse,
+                    fts_language=self.fts_language,
+                )
+            else:
+                logger.info(
+                    "Skipping LanceDB index creation for table %r because build_index=False.",
+                    self.table_name,
+                )
         return records
 
     def put(

--- a/nemo_retriever/tests/test_lancedb_ivf_partitions.py
+++ b/nemo_retriever/tests/test_lancedb_ivf_partitions.py
@@ -7,13 +7,15 @@
 from __future__ import annotations
 
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pyarrow as pa
 import pytest
 
 lancedb = pytest.importorskip("lancedb")
 
-from nemo_retriever.common.vdb.lancedb import (
+from nemo_retriever.common.vdb.lancedb import (  # noqa: E402
     LanceDB,
     _effective_ivf_num_partitions,
     _is_ivf_vector_index,
@@ -94,3 +96,37 @@ def test_write_to_index_skips_vector_index_single_row() -> None:
     )
     op.write_to_index([], table=table, num_partitions=16, hybrid=False)
     assert not table.list_indices()
+
+
+def test_run_serializes_write_and_index_transactions(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Concurrent service callbacks must not submit competing CreateIndex commits."""
+    op = LanceDB(uri=str(tmp_path), table_name="concurrent", vector_dim=2)
+    first_write_started = threading.Event()
+    allow_first_write_to_finish = threading.Event()
+    create_calls: list[int] = []
+    calls_lock = threading.Lock()
+
+    def create_index(*, records, table_name):
+        with calls_lock:
+            create_calls.append(1)
+            call_number = len(create_calls)
+        if call_number == 1:
+            first_write_started.set()
+            assert allow_first_write_to_finish.wait(timeout=5)
+        return object()
+
+    monkeypatch.setattr(op, "create_index", create_index)
+    monkeypatch.setattr(op, "write_to_index", lambda *args, **kwargs: None)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(op.run, [])
+        assert first_write_started.wait(timeout=5)
+        second = executor.submit(op.run, [])
+        # The second run cannot call create_index until the first transaction
+        # releases the backend write lock.
+        assert create_calls == [1]
+        allow_first_write_to_finish.set()
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+    assert create_calls == [1, 1]

--- a/nemo_retriever/tests/test_lancedb_ivf_partitions.py
+++ b/nemo_retriever/tests/test_lancedb_ivf_partitions.py
@@ -100,11 +100,31 @@ def test_write_to_index_skips_vector_index_single_row() -> None:
 
 def test_run_serializes_write_and_index_transactions(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """Concurrent service callbacks must not submit competing CreateIndex commits."""
+
+    class TrackingLock:
+        def __init__(self) -> None:
+            self._lock = threading.Lock()
+            self._attempts = 0
+            self._attempts_lock = threading.Lock()
+            self.second_acquisition_attempted = threading.Event()
+
+        def __enter__(self):
+            with self._attempts_lock:
+                self._attempts += 1
+                if self._attempts == 2:
+                    self.second_acquisition_attempted.set()
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback) -> None:
+            self._lock.release()
+
     op = LanceDB(uri=str(tmp_path), table_name="concurrent", vector_dim=2)
     first_write_started = threading.Event()
     allow_first_write_to_finish = threading.Event()
     create_calls: list[int] = []
     calls_lock = threading.Lock()
+    write_lock = TrackingLock()
 
     def create_index(*, records, table_name):
         with calls_lock:
@@ -115,6 +135,7 @@ def test_run_serializes_write_and_index_transactions(monkeypatch: pytest.MonkeyP
             assert allow_first_write_to_finish.wait(timeout=5)
         return object()
 
+    monkeypatch.setattr(op, "_write_lock", write_lock)
     monkeypatch.setattr(op, "create_index", create_index)
     monkeypatch.setattr(op, "write_to_index", lambda *args, **kwargs: None)
 
@@ -122,8 +143,9 @@ def test_run_serializes_write_and_index_transactions(monkeypatch: pytest.MonkeyP
         first = executor.submit(op.run, [])
         assert first_write_started.wait(timeout=5)
         second = executor.submit(op.run, [])
-        # The second run cannot call create_index until the first transaction
-        # releases the backend write lock.
+        # Confirm the second worker reaches the lock while the first write is
+        # still in progress. It must not reach create_index yet.
+        assert write_lock.second_acquisition_attempted.wait(timeout=5)
         assert create_calls == [1]
         allow_first_write_to_finish.set()
         first.result(timeout=5)


### PR DESCRIPTION
## Description
Root cause: concurrent /internal/vectordb/write requests append rows and rebuild the same LanceDB index simultaneously. One CreateIndex commit then preempts the other, producing the 500. The IVF partition messages are normal safeguards, not the failure.

  Implemented a fix:

  - Serializes the complete LanceDB append/create + index rebuild transaction per VectorDB process in nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py:606.
  - Added a concurrent-write regression test in nemo_retriever/tests/test_lancedb_ivf_partitions.py:98.
  - Added Helm recovery guidance in docs/docs/extraction/troubleshoot.md:377.

  Validated:

  - 34 passed across VectorDB service and LanceDB tests
  - Focused Ruff check passed
  - git diff --check passed

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
