### PR TITLE
fix(vdb): stop concurrent VectorDB writes from reporting success before they are durable

### DIFF
--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -21,6 +21,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - Legacy `nv-ingest` and compatibility pipeline CLI code paths are removed. Use `retriever ingest` and the graph stage registry.
 - Self-hosted Parakeet on Helm requires both `nimOperator.audio.enabled=true` and `serviceConfig.nimEndpoints.audioGrpcEndpoint=audio:50051`. Enabling the audio NIM alone does not wire the service ASR endpoint.
 - Changing a Helm NIM image repository or tag on an existing release cannot patch `NIMCache` `spec.source.ngc.modelPuller`. Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+- A document whose VectorDB write is not acknowledged now fails instead of reporting `completed` with a positive row count. Earlier builds failed only collection-managed writes and logged a legacy fixed-table failure as a warning. The worker acknowledgement timeout is configurable through `serviceConfig.vectordb.writeTimeoutSeconds` (rendered as `vectordb.write_timeout_s`) and defaults to 300 seconds. Refer to [Ingest fails with a VectorDB write error](troubleshoot.md#vectordb-write-not-acknowledged).
 - Retriever Service OpenAPI `info.version` no longer reports a stale `26.5.0` value. The service reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.
 
 ### Text generation and LLM configuration { #text-generation-and-llm-configuration }
@@ -103,6 +104,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - LanceDB retrieval-mode autodetection and persisted embedding identity for automatic local queries.
 - Dense image-only VDB records are retained where applicable.
 - Scope-isolated collection and document lifecycle APIs (`/v1/collections`) support create, ingest, replace, query, and cleanup without exposing LanceDB table names.
+- Fixed an issue where concurrent ingests into one VectorDB pod could report success minutes before the rows were durable or queryable. Each write now commits its rows independently, and index maintenance runs in a separate serialized phase where concurrent writers share one coalesced rebuild. An index-readiness wait that expires logs a warning and leaves the committed rows queryable instead of failing the write. Refer to [LanceDB index creation fails during concurrent Helm ingestion](troubleshoot.md#lancedb-concurrent-index-creation).
 
 ### Packaging and platform { #packaging-and-platform }
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -407,7 +407,7 @@ queryable until the next rebuild covers them:
 
 ```text
 LanceDB index on column 'vector' did not report coverage of 512 row(s) within
-0:10:00. Queries still scan unindexed rows and the next rebuild will cover them.
+0:01:00. Queries still scan unindexed rows and the next rebuild will cover them.
 ```
 
 Keep the VectorDB deployment at one replica. Row and index serialization is

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -388,20 +388,80 @@ This CreateIndex transaction was preempted by concurrent transaction CreateIndex
 Please retry.
 ```
 
-Upgrade to a NeMo Retriever Library release that serializes the complete
-legacy LanceDB write transaction. The VectorDB service queues concurrent
-`/internal/vectordb/write` requests that reach the same pod, including the
-append and index rebuild, so the conflicting index commits do not overlap.
-There is no Helm value to configure for this behavior.
+Upgrade to a NeMo Retriever Library release that separates row commits from
+index maintenance. The VectorDB service admits concurrent
+`/internal/vectordb/write` requests that reach the same pod. Each request
+commits its rows under a short-lived lock, so those rows are durable as soon
+as the commit lands. LanceDB search also scans rows that no index covers yet,
+so a committed row is queryable before the next rebuild includes it.
 
-Keep the VectorDB deployment at one replica. The serialization is local to a
-single VectorDB process and does not coordinate writes across multiple pods or
-independently deployed processes that share a LanceDB directory.
+Only index maintenance is serialized, because LanceDB rejects competing index
+commits. Concurrent writers share one coalesced rebuild: a rebuild that starts
+after a batch was committed also indexes that batch. A write therefore never
+waits behind another writer's index build. There is no Helm value to configure
+this behavior.
+
+An index-readiness wait that expires no longer fails the write. The VectorDB
+pod logs a warning similar to the following, and the committed rows stay
+queryable until the next rebuild covers them:
+
+```text
+LanceDB index on column 'vector' did not report coverage of 512 row(s) within
+0:10:00. Queries still scan unindexed rows and the next rebuild will cover them.
+```
+
+Keep the VectorDB deployment at one replica. Row and index serialization is
+local to a single VectorDB process. It does not coordinate writes across
+multiple pods or independently deployed processes that share a LanceDB
+directory.
 
 If a request failed before the upgrade, inspect the table and the ingest job
-before resubmitting it. A write can append rows before a later index rebuild
-fails. The legacy append path does not deduplicate rows, so blindly rerunning
-the same input can create duplicates.
+before you resubmit it. A write can append rows before a later index rebuild
+fails. The legacy append path does not deduplicate rows, so rerunning the same
+input can create duplicate rows.
+
+## Ingest fails with a VectorDB write error { #vectordb-write-not-acknowledged }
+
+A worker posts extracted records to the VectorDB service before it reports a
+document as complete. When the VectorDB service rejects that write or does not
+acknowledge it within the configured timeout, the document fails with an error
+similar to the following:
+
+```text
+RuntimeError: VectorDB write failed for report.pdf: <error>. The extracted rows
+are not confirmed durable, so the document is not queryable.
+```
+
+A write into a managed collection reports
+`Collection write failed for report.pdf: <error>` instead.
+
+The worker pod logs the underlying failure at error level:
+
+```text
+Failed to POST 128 records to vectordb for report.pdf: <error>
+```
+
+Earlier releases logged this failure as a warning for writes to the legacy
+fixed table and still reported the document as `completed` with a positive row
+count. Queries then returned no rows for a document that the ingest job called
+successful. A failed document now means the rows are not confirmed durable.
+
+Complete the following checks:
+
+1. Run `kubectl get pods --namespace <namespace>` and confirm the VectorDB pod is `Running` and ready. A pod that is restarting or unschedulable does not accept writes.
+2. Read the VectorDB pod logs for the same records. A rejected write reports a request or backend error. A write that the worker abandoned on timeout can still be in progress on the VectorDB pod.
+3. If writes time out under load or on slow storage, raise the acknowledgement timeout. `serviceConfig.vectordb.writeTimeoutSeconds` defaults to `300` seconds and covers the row commit plus the index maintenance that follows it.
+4. Resubmit the failed documents after the write path is healthy. A write that timed out on the worker can still have committed its rows, and the legacy append path does not deduplicate rows, so check the table row count first.
+
+To raise the timeout on an existing release, run the following command:
+
+```bash
+helm upgrade retriever ./nemo_retriever/helm \
+  --reuse-values \
+  --set serviceConfig.vectordb.writeTimeoutSeconds=900
+```
+
+For the rendered service key and sibling VectorDB values, refer to [Service configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#service-configuration-rendered-into-retriever-serviceyaml).
 
 
 ## Helm install succeeds but PersistentVolumeClaims stay Pending { #helm-pending-pvcs }

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -694,6 +694,7 @@ client entrypoint. Refer to [Health probes](#health-probes).
 | `serviceConfig.vectordb.embedModel`               | `nvidia/llama-nemotron-embed-vl-1b-v2` | Passed to vectordb + worker `embed_model_name`. |
 | `serviceConfig.vectordb.indexMode`                | `hybrid` | Create LanceDB dense-vector and full-text-search indexes. Set to `dense` to create only the dense-vector index. |
 | `serviceConfig.vectordb.embedModelProviderPrefix` | `""` | Optional LiteLLM provider prefix prepended to the remote embed model name. |
+| `serviceConfig.vectordb.writeTimeoutSeconds`      | `300` | Rendered as `vectordb.write_timeout_s`. How long a worker waits for the vectordb Pod to acknowledge a record write. A write that is not acknowledged fails the document, so raise this value on slow storage. Refer to [Timeouts and alleviating ingest failures](#timeouts-and-alleviating-ingest-failures). |
 
 ### Sidecar metadata in split topology
 
@@ -1543,6 +1544,7 @@ document callbacks even though only one root cause occurred.
 |-------|---------|-----------------|
 | Remote embed HTTP calls | **600 s** (10 min) | Service image (`EmbedParams.request_timeout_s`); not a Helm value today. |
 | Gateway → realtime/batch proxy | **300 s** | Rendered `gateway.timeout_s` in `retriever-service.yaml` (split topology). |
+| Worker → vectordb record write | **300 s** | `serviceConfig.vectordb.writeTimeoutSeconds`, rendered as `vectordb.write_timeout_s` in `retriever-service.yaml`. |
 | VLM embed model name | `serviceConfig.vectordb.embedModel` | Also copied into worker `nim_endpoints.embed_model_name` in the ConfigMap. |
 
 Symptoms to look for in pod logs:
@@ -1552,6 +1554,9 @@ Symptoms to look for in pod logs:
   `BrokenProcessPool` failures on other in-flight documents.
 - Embed NIM pod messages such as `failed to allocate pinned system memory`
   (GPU pressure from too many concurrent `/v1/embeddings` requests).
+- `Failed to POST <n> records to vectordb for <file>` on the **batch** or
+  **realtime** pod, followed by a `failed` document. The vectordb Pod did not
+  acknowledge the record write in time.
 
 The **gateway** pod usually only logs `status=failed` callbacks; diagnose on
 **batch** (and **realtime** for page-sized uploads), plus the embed NIM pod.
@@ -1603,6 +1608,31 @@ Long batch jobs may exceed the gateway proxy timeout (300 s) or an Ingress
 `proxy-read-timeout`. Increase ingress annotations if clients disconnect
 while workers are still processing; see the commented example on
 `ingress.annotations` in `values.yaml`.
+
+**6. Raise the vectordb write timeout on slow storage.**
+
+A worker fails the document when the vectordb Pod does not acknowledge its
+record write:
+
+```text
+VectorDB write failed for report.pdf: <error>. The extracted rows are not
+confirmed durable, so the document is not queryable.
+```
+
+That acknowledgement covers the row commit plus the index maintenance that
+follows it, so a large batch on slow storage can exceed the default 300 s.
+Raise the timeout and redeploy:
+
+```bash
+helm upgrade retriever ./nemo_retriever/helm \
+  --reuse-values \
+  --set serviceConfig.vectordb.writeTimeoutSeconds=900
+```
+
+Concurrent writes to one vectordb Pod do not block each other, so a write
+timeout points at storage throughput or table size rather than write
+serialization. Refer to
+[LanceDB index creation fails during concurrent Helm ingestion](https://docs.nvidia.com/nemo/retriever/latest/extraction/troubleshoot/#lancedb-concurrent-index-creation).
 
 ---
 

--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -255,6 +255,7 @@ vectordb:
   embed_model_provider_prefix: null
 {{- end }}
   vectordb_url: "http://{{ .vectordbSvc }}:{{ .vectordbPort }}"
+  write_timeout_s: {{ .Values.serviceConfig.vectordb.writeTimeoutSeconds | default 300 }}
 {{- else }}
 vectordb:
   enabled: false

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -714,6 +714,10 @@ serviceConfig:
     indexMode: "hybrid"
     embedModel: "nvidia/llama-nemotron-embed-vl-1b-v2"
     embedModelProviderPrefix: ""
+    # How long a worker waits for the VectorDB pod to acknowledge a record
+    # write. A write that is not acknowledged fails the document, so raise
+    # this on slow storage rather than accepting unacknowledged writes.
+    writeTimeoutSeconds: 300
     # Optional service-internal authentication. When enabled, Retriever and
     # VectorDB pods read the same existing Secret key. In split topology, the
     # gateway also uses this credential for restricted gateway-to-worker

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py
@@ -9,7 +9,6 @@ import threading
 import time
 
 from collections.abc import Iterable, Sequence
-from datetime import timedelta
 from types import SimpleNamespace
 from typing import Any, Final, FrozenSet
 
@@ -32,7 +31,10 @@ from nemo_retriever.common.vdb.adt_vdb import (
     CollectionWriteResult,
     VDB,
 )
-from nemo_retriever.common.vdb.lancedb_capabilities import inspect_lancedb_table_object
+from nemo_retriever.common.vdb.lancedb_capabilities import (
+    inspect_lancedb_table_object,
+    wait_for_column_index,
+)
 from nemo_retriever.common.vdb.lancedb_schema import (
     build_lancedb_row,
     infer_vector_dim,
@@ -606,10 +608,16 @@ class LanceDB(VDB):
         self._collection_store: Any | None = None
         self._collection_store_init_failed = False
         self._collection_store_lock = threading.Lock()
-        # A write includes both the table mutation and an optional index rebuild.
-        # LanceDB treats competing index commits as a conflict, so these must be
-        # one transaction from the perspective of callers sharing this backend.
+        # Row admission is serialized on its own short-lived lock so a caller
+        # never waits on index maintenance to get its rows committed.
         self._write_lock = threading.Lock()
+        # LanceDB treats competing index commits as a conflict, so only one
+        # rebuild may run at a time. Rebuilds are coalesced by generation:
+        # a rebuild that starts after a batch was committed also covers it.
+        self._index_lock = threading.Lock()
+        self._index_generation_lock = threading.Lock()
+        self._index_requested_generation = 0
+        self._index_completed_generation = 0
         super().__init__(**kwargs)
 
     def _get_collection_store(self) -> Any:
@@ -998,10 +1006,9 @@ class LanceDB(VDB):
 
         if sparse:
             fts_index_start = time.perf_counter()
+            sparse_rows = int(table.count_rows())
             table.create_fts_index("text", language=fts_language, replace=True)
-            for index_stub in table.list_indices():
-                if "text" in index_stub.name.lower() or "fts" in index_stub.name.lower():
-                    table.wait_for_index([index_stub.name], timeout=timedelta(seconds=600))
+            wait_for_column_index(table, "text", covered_rows=sparse_rows)
             _record_timing("lancedb.fts_index_ready", time.perf_counter() - fts_index_start)
             return
 
@@ -1046,26 +1053,69 @@ class LanceDB(VDB):
                 vector_column_name="vector",
                 replace=True,
             )
-            for index_stub in table.list_indices():
-                table.wait_for_index([index_stub.name], timeout=timedelta(seconds=600))
+            wait_for_column_index(table, "vector", covered_rows=num_rows)
             _record_timing("lancedb.vector_index_ready", time.perf_counter() - vector_index_start)
 
         if hybrid:
             fts_index_start = time.perf_counter()
             table.create_fts_index("text", language=fts_language, replace=True)
-            for index_stub in table.list_indices():
-                if "text" in index_stub.name.lower() or "fts" in index_stub.name.lower():
-                    table.wait_for_index([index_stub.name], timeout=timedelta(seconds=600))
+            wait_for_column_index(table, "text", covered_rows=num_rows)
             _record_timing("lancedb.fts_index_ready", time.perf_counter() - fts_index_start)
 
     def run(self, records):
-        """Orchestrate index creation and data ingestion."""
-        # The VectorDB service can dispatch multiple ingestion callbacks at
-        # once. Serialize append/create and index replacement as one critical
-        # section so a later CreateIndex cannot preempt an in-flight one.
+        """Commit rows, then bring the table indexes up to date.
+
+        The VectorDB service can dispatch multiple ingestion callbacks at once.
+        Row admission and index maintenance are two separate critical sections:
+
+        * ``_write_lock`` serializes only the table create/append, so a
+          concurrent write is never held behind another writer's index build.
+          Rows are durable and queryable (Lance scans unindexed fragments)
+          as soon as this section commits.
+        * ``_index_lock`` serializes index commits, which LanceDB rejects when
+          they conflict. Rebuilds are coalesced: a rebuild that starts after
+          this batch was committed also indexes this batch, so concurrent
+          writers share one rebuild instead of queueing one each.
+        """
         with self._write_lock:
             table = self.create_index(records=records, table_name=self.table_name)
-            if self.build_index:
+
+        if not self.build_index:
+            logger.info(
+                "Skipping LanceDB index creation for table %r because build_index=False.",
+                self.table_name,
+            )
+            return records
+
+        self._maintain_indexes(records, table)
+        return records
+
+    def _maintain_indexes(self, records, table) -> None:
+        """Rebuild table indexes so they cover the rows committed by this call.
+
+        Returns once an index build that started after this caller's rows were
+        committed has finished. Callers that arrive while such a build is
+        already running wait for it rather than queueing another one.
+        """
+        with self._index_generation_lock:
+            self._index_requested_generation += 1
+            required_generation = self._index_requested_generation
+
+        while True:
+            with self._index_generation_lock:
+                if self._index_completed_generation >= required_generation:
+                    return
+
+            with self._index_lock:
+                with self._index_generation_lock:
+                    if self._index_completed_generation >= required_generation:
+                        return
+                    building_generation = self._index_requested_generation
+
+                # Index the newest committed version, not the snapshot this
+                # caller happened to open, so one rebuild can cover the rows
+                # of every writer it has coalesced.
+                self._checkout_latest(table)
                 self.write_to_index(
                     records,
                     table=table,
@@ -1077,12 +1127,23 @@ class LanceDB(VDB):
                     sparse=self.sparse,
                     fts_language=self.fts_language,
                 )
-            else:
-                logger.info(
-                    "Skipping LanceDB index creation for table %r because build_index=False.",
-                    self.table_name,
-                )
-        return records
+
+                with self._index_generation_lock:
+                    self._index_completed_generation = max(
+                        self._index_completed_generation,
+                        building_generation,
+                    )
+
+    @staticmethod
+    def _checkout_latest(table) -> None:
+        """Advance ``table`` to the latest committed version when supported."""
+        checkout_latest = getattr(table, "checkout_latest", None)
+        if not callable(checkout_latest):
+            return
+        try:
+            checkout_latest()
+        except Exception as exc:  # noqa: BLE001 - version refresh is advisory.
+            logger.debug("Could not advance LanceDB table handle to the latest version: %s", exc)
 
     def put(
         self,

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_bulk.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_bulk.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import Any, Dict, List, Sequence
 
 import lancedb
+from nemo_retriever.common.vdb.lancedb_capabilities import wait_for_column_index
 from nemo_retriever.common.vdb.lancedb_schema import build_lancedb_row, infer_vector_dim, lancedb_schema
 
 logger = logging.getLogger(__name__)
@@ -65,6 +65,7 @@ def _build_lancedb_rows_from_df(rows: List[Dict[str, Any]]) -> List[Dict[str, An
 
 def create_lancedb_index(table: Any, *, cfg: LanceDBConfig, text_column: str = "text") -> None:
     """Create vector (IVF_HNSW_SQ) and optionally FTS indices on a LanceDB table."""
+    covered_rows = int(table.count_rows())
     try:
         table.create_index(
             index_type=cfg.index_type,
@@ -86,8 +87,9 @@ def create_lancedb_index(table: Any, *, cfg: LanceDBConfig, text_column: str = "
                 exc_info=True,
             )
 
-    for index_stub in table.list_indices():
-        table.wait_for_index([index_stub.name], timeout=timedelta(seconds=600))
+    wait_for_column_index(table, "vector", covered_rows=covered_rows)
+    if cfg.hybrid:
+        wait_for_column_index(table, text_column, covered_rows=covered_rows)
 
 
 def _write_rows_to_lancedb(rows: Sequence[Dict[str, Any]], *, cfg: LanceDBConfig) -> None:

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
@@ -6,12 +6,20 @@
 
 from __future__ import annotations
 
+import logging
+import time
 from dataclasses import dataclass
-from typing import Any, Literal
+from datetime import timedelta
+from typing import Any, Final, Literal
 
 import pyarrow as pa
 
+logger = logging.getLogger(__name__)
+
 LanceRetrievalMode = Literal["dense", "hybrid", "sparse", "unknown"]
+
+INDEX_READY_TIMEOUT: Final[timedelta] = timedelta(seconds=600)
+_INDEX_READY_POLL_INTERVAL_S: Final[float] = 0.25
 
 _RETRIEVAL_MODE_METADATA_KEYS = (
     "retrieval_mode",
@@ -106,6 +114,82 @@ def _detect_fts_columns(table: Any) -> list[str]:
         if index_type == "fts" or "index(fts" in index_repr or " fts" in index_repr:
             fts_columns.extend(_index_columns(index))
     return list(dict.fromkeys(column for column in fts_columns if column))
+
+
+def column_index_stubs(table: Any, column: str) -> list[Any]:
+    """Return the index descriptors LanceDB reports for ``column``."""
+    list_indices = getattr(table, "list_indices", None)
+    if not callable(list_indices):
+        return []
+
+    stubs: list[Any] = []
+    for index in list_indices():
+        name = getattr(index, "name", None)
+        if not name:
+            continue
+        columns = _index_columns(index)
+        if columns:
+            if column in columns:
+                stubs.append(index)
+        elif column in str(name).lower():
+            # Older LanceDB builds do not report columns on the index stub.
+            stubs.append(index)
+    return stubs
+
+
+def wait_for_column_index(
+    table: Any,
+    column: str,
+    *,
+    covered_rows: int,
+    timeout: timedelta | None = None,
+) -> None:
+    """Wait until the index on ``column`` covers ``covered_rows`` rows.
+
+    Two things this deliberately does not do:
+
+    * It does not wait on indexes of other columns. A vector-index phase that
+      blocks on an FTS index stalls every writer sharing the table for the
+      whole timeout, even though the FTS index is none of its business.
+    * It does not wait for the index to have zero unindexed rows, which is what
+      ``Table.wait_for_index`` requires. Concurrent writers keep committing
+      rows, so that condition can stay false until the timeout expires even
+      though the index this phase built is complete. Rows outside the index are
+      still returned by search because Lance scans them, so an unindexed tail
+      is a performance property rather than a correctness one, and the next
+      rebuild folds it in.
+    """
+    timeout = timeout or INDEX_READY_TIMEOUT
+    deadline = time.monotonic() + timeout.total_seconds()
+    while True:
+        stubs = column_index_stubs(table, column)
+        if stubs and all(_indexed_rows(stub) >= covered_rows for stub in stubs):
+            return
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "LanceDB index on column %r did not report coverage of %d row(s) within %s. "
+                "Queries still scan unindexed rows and the next rebuild will cover them.",
+                column,
+                covered_rows,
+                timeout,
+            )
+            return
+        time.sleep(_INDEX_READY_POLL_INTERVAL_S)
+
+
+def _indexed_rows(index: Any) -> float:
+    """Return how many rows ``index`` reports as indexed.
+
+    Builds that do not report the counter are treated as fully covered: the
+    local LanceDB path indexes synchronously, so there is nothing to poll for.
+    """
+    indexed = getattr(index, "num_indexed_rows", None)
+    if indexed is None:
+        return float("inf")
+    try:
+        return float(indexed)
+    except (TypeError, ValueError):
+        return float("inf")
 
 
 def _mode_from_capabilities(has_vector: bool, has_fts: bool) -> LanceRetrievalMode:

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
@@ -18,7 +18,13 @@ logger = logging.getLogger(__name__)
 
 LanceRetrievalMode = Literal["dense", "hybrid", "sparse", "unknown"]
 
-INDEX_READY_TIMEOUT: Final[timedelta] = timedelta(seconds=600)
+# Index readiness is advisory: rows are queryable before an index covers them,
+# so expiry only costs query speed until the next rebuild. A write is
+# acknowledged to its caller only after index maintenance, and hybrid tables
+# wait once per index, so keep MAX_INDEX_READY_WAITS_PER_WRITE times this value
+# below the caller's write timeout or a durable write fails on the wait alone.
+INDEX_READY_TIMEOUT: Final[timedelta] = timedelta(seconds=60)
+MAX_INDEX_READY_WAITS_PER_WRITE: Final[int] = 2
 _INDEX_READY_POLL_INTERVAL_S: Final[float] = 0.25
 
 _RETRIEVAL_MODE_METADATA_KEYS = (

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -450,6 +450,14 @@ class VectorDbConfig(RichModel):
         default=None,
         description="Dedicated gateway/worker credential for the VectorDB service.",
     )
+    write_timeout_s: float = Field(
+        default=300.0,
+        gt=0,
+        description=(
+            "How long a worker waits for the VectorDB service to acknowledge a "
+            "record write before failing the document."
+        ),
+    )
     reconciliation_interval_seconds: int = Field(
         default=60,
         ge=0,

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 _MP_CONTEXT = mp.get_context("forkserver")
 _MAX_TASKS_PER_CHILD = 100
 _DEFAULT_WARM_MAX_TASKS_PER_CHILD = 10_000
+# Storage acknowledgement is part of the ingest contract, so the worker waits
+# long enough for a busy VectorDB to commit rather than reporting a success
+# the storage tier never confirmed.
+_DEFAULT_VECTORDB_WRITE_TIMEOUT_S = 300.0
 
 _SENSITIVE_PATTERNS = frozenset(
     {
@@ -289,12 +293,14 @@ def _post_records_to_vectordb(
     context: DocumentWriteContext,
     job_id: str | None = None,
     internal_api_token: str | None = None,
+    timeout_s: float = _DEFAULT_VECTORDB_WRITE_TIMEOUT_S,
 ) -> None:
-    """Post canonical NRL record batches to VectorDB, preserving legacy best-effort behavior.
+    """Post canonical NRL record batches to VectorDB and fail the job on rejection.
 
-    Collection-managed writes are lifecycle-authoritative and therefore fail
-    the job when storage rejects the write. Legacy fixed-table writes retain
-    their historical best-effort behavior.
+    A write the storage tier never acknowledged cannot be reported as a
+    completed ingest: the caller would see a row count for records that are
+    not queryable. Both collection-managed and legacy fixed-table writes
+    therefore surface the storage failure to the document.
     """
     import json
     import urllib.request
@@ -331,7 +337,7 @@ def _post_records_to_vectordb(
     )
     record_count = sum(len(batch) for batch in records)
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
             logging.getLogger(__name__).info(
                 "Posted %d records to vectordb for %s — HTTP %d",
                 record_count,
@@ -339,7 +345,7 @@ def _post_records_to_vectordb(
                 resp.status,
             )
     except Exception as exc:
-        logging.getLogger(__name__).warning(
+        logging.getLogger(__name__).error(
             "Failed to POST %d records to vectordb for %s: %s",
             record_count,
             filename,
@@ -347,6 +353,10 @@ def _post_records_to_vectordb(
         )
         if context.collection_name:
             raise RuntimeError(f"Collection write failed for {filename}: {exc}") from exc
+        raise RuntimeError(
+            f"VectorDB write failed for {filename}: {exc}. "
+            "The extracted rows are not confirmed durable, so the document is not queryable."
+        ) from exc
 
 
 _TRUST_OWNED_EXTRACT_KEYS: tuple[str, ...] = (
@@ -735,6 +745,7 @@ def _run_pipeline_in_process(
     write_context: DocumentWriteContext | None = None,
     job_id: str | None = None,
     internal_api_token: str | None = None,
+    vectordb_write_timeout_s: float = _DEFAULT_VECTORDB_WRITE_TIMEOUT_S,
 ) -> tuple[int, list[dict[str, Any]], float]:
     """Execute one pipeline run inside a child process.
 
@@ -813,6 +824,7 @@ def _run_pipeline_in_process(
             context=write_context or DocumentWriteContext(),
             job_id=job_id,
             internal_api_token=internal_api_token,
+            timeout_s=vectordb_write_timeout_s,
         )
 
     result_options = pipeline_spec or {}
@@ -1134,6 +1146,7 @@ def _make_work_fn(
                 write_context,
                 item.job_id,
                 config.vectordb.internal_api_token,
+                config.vectordb.write_timeout_s,
             )
         except BrokenProcessPool:
             logger.error(

--- a/nemo_retriever/tests/test_helm_vectordb_write_timeout.py
+++ b/nemo_retriever/tests/test_helm_vectordb_write_timeout.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helm wiring for the worker-to-VectorDB write acknowledgement timeout."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from unittest import SkipTest
+
+import yaml
+
+
+CHART = Path(__file__).resolve().parents[1] / "helm"
+
+
+def _render(*extra_args: str) -> dict:
+    helm = shutil.which("helm")
+    if helm is None:
+        raise SkipTest("`helm` binary not available in this environment.")
+
+    completed = subprocess.run(
+        [
+            helm,
+            "template",
+            "vectordb-write-timeout-test",
+            str(CHART),
+            "--set",
+            "nims.enabled=false",
+            *extra_args,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    completed.check_returncode()
+    documents = [document for document in yaml.safe_load_all(completed.stdout) if document]
+    configmap = next(
+        document
+        for document in documents
+        if document.get("kind") == "ConfigMap" and "retriever-service.yaml" in document.get("data", {})
+    )
+    return yaml.safe_load(configmap["data"]["retriever-service.yaml"])
+
+
+def test_default_write_timeout_is_rendered() -> None:
+    config = _render()
+
+    assert config["vectordb"]["write_timeout_s"] == 300
+
+
+def test_write_timeout_override_is_rendered() -> None:
+    config = _render("--set", "serviceConfig.vectordb.writeTimeoutSeconds=900")
+
+    assert config["vectordb"]["write_timeout_s"] == 900

--- a/nemo_retriever/tests/test_helm_vectordb_write_timeout.py
+++ b/nemo_retriever/tests/test_helm_vectordb_write_timeout.py
@@ -30,6 +30,11 @@ def _render(*extra_args: str) -> dict:
             str(CHART),
             "--set",
             "nims.enabled=false",
+            # The value under test only renders with the vectordb sub-stack
+            # enabled, and that stack refuses to render without a query
+            # embedding backend.
+            "--set",
+            "serviceConfig.nimEndpoints.embedInvokeUrl=http://embed:8000/v1/embeddings",
             *extra_args,
         ],
         check=False,

--- a/nemo_retriever/tests/test_internal_auth.py
+++ b/nemo_retriever/tests/test_internal_auth.py
@@ -14,7 +14,10 @@ import pytest
 
 from nemo_retriever.service.auth import _is_gateway_proxy_path, internal_auth_headers
 from nemo_retriever.service.config import load_config
-from nemo_retriever.service.services.pipeline_executor import _post_records_to_vectordb
+from nemo_retriever.service.services.pipeline_executor import (
+    _DEFAULT_VECTORDB_WRITE_TIMEOUT_S,
+    _post_records_to_vectordb,
+)
 from nemo_retriever.service.services.pipeline_pool import DocumentWriteContext
 
 
@@ -66,5 +69,5 @@ def test_pipeline_vectordb_request_uses_normalized_internal_header() -> None:
             context=DocumentWriteContext(),
         )
 
-    assert captured["timeout"] == 30
+    assert captured["timeout"] == _DEFAULT_VECTORDB_WRITE_TIMEOUT_S
     assert captured["request"].get_header("X-nrl-internal-token") == "internal-secret"

--- a/nemo_retriever/tests/test_lancedb_concurrent_writes.py
+++ b/nemo_retriever/tests/test_lancedb_concurrent_writes.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Concurrent VectorDB writes against a real LanceDB table.
+
+These tests exercise the ingest path the VectorDB service uses (``hybrid``
+index mode, so both a vector and an FTS index exist) with real index builds.
+``write_to_index`` is never replaced with a no-op: a mocked index phase cannot
+observe a writer blocked behind another writer's index-readiness wait, which is
+exactly what regressed durability and queryability for concurrent ingests.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+
+import pytest
+
+lancedb = pytest.importorskip("lancedb")
+
+from lancedb.table import LanceTable  # noqa: E402
+
+from nemo_retriever.common.vdb import lancedb_capabilities  # noqa: E402
+from nemo_retriever.common.vdb.lancedb import LanceDB  # noqa: E402
+
+_DIM = 4
+_TABLE = "nemo_retriever"
+_WAIT_TIMEOUT_S = 30.0
+_INDEX_READY_TIMEOUT_S = 3.0
+
+
+@pytest.fixture(autouse=True)
+def _bounded_index_ready_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cap index-readiness waits so a regression fails fast instead of stalling."""
+    monkeypatch.setattr(
+        lancedb_capabilities,
+        "INDEX_READY_TIMEOUT",
+        timedelta(seconds=_INDEX_READY_TIMEOUT_S),
+    )
+
+
+def _record(text: str, vector: list[float]) -> dict:
+    return {
+        "document_type": "text",
+        "metadata": {
+            "embedding": vector,
+            "content": text,
+            "content_metadata": {"page_number": 1, "type": "text"},
+            "source_metadata": {"source_id": f"/data/{text}.txt", "source_name": f"{text}.txt"},
+        },
+    }
+
+
+def _backend(tmp_path) -> LanceDB:
+    """Build the backend the VectorDB service uses for ``index_mode='hybrid'``."""
+    return LanceDB(
+        uri=str(tmp_path),
+        table_name=_TABLE,
+        vector_dim=_DIM,
+        overwrite=False,
+        hybrid=True,
+        build_index=True,
+        num_partitions=2,
+        num_sub_vectors=2,
+    )
+
+
+def _seed(backend: LanceDB) -> None:
+    backend.run(
+        [
+            [
+                _record("seed_alpha", [1.0, 0.0, 0.0, 0.0]),
+                _record("seed_beta", [0.0, 1.0, 0.0, 0.0]),
+            ]
+        ]
+    )
+
+
+def _open_table(backend: LanceDB) -> LanceTable:
+    return lancedb.connect(backend.uri).open_table(backend.table_name)
+
+
+def _row_count(backend: LanceDB) -> int:
+    return int(_open_table(backend).count_rows())
+
+
+def _unindexed_rows(backend: LanceDB, column: str) -> int:
+    stubs = [
+        stub
+        for stub in _open_table(backend).list_indices()
+        if column in [str(entry) for entry in (stub.columns or [])]
+    ]
+    assert stubs, f"no LanceDB index on column {column!r}"
+    return sum(int(stub.num_unindexed_rows) for stub in stubs)
+
+
+def _append_unindexed_row(backend: LanceDB, text: str, vector: list[float]) -> None:
+    """Commit a row without rebuilding indexes, leaving every index a tail."""
+    backend.create_index(records=[[_record(text, vector)]], table_name=backend.table_name)
+
+
+def _await(event: threading.Event) -> None:
+    assert event.wait(timeout=_WAIT_TIMEOUT_S), "timed out waiting for the write under test"
+
+
+def _await_committed(backend: LanceDB, expected: int) -> None:
+    """Block until ``expected`` rows are committed to the table."""
+    waiter = threading.Event()
+    for _ in range(int(_WAIT_TIMEOUT_S / 0.05)):
+        if _row_count(backend) >= expected:
+            return
+        waiter.wait(timeout=0.05)
+    raise AssertionError(f"table never reached {expected} committed rows")
+
+
+def _gate_first_index_build(monkeypatch: pytest.MonkeyPatch) -> tuple[threading.Event, threading.Event]:
+    """Make the first vector-index build block, emulating a slow index build.
+
+    Returns ``(entered, release)``: ``entered`` is set once a writer is parked
+    in its index phase, and setting ``release`` lets that build proceed.
+    """
+    original = LanceTable.create_index
+    entered = threading.Event()
+    release = threading.Event()
+    gated = threading.Event()
+
+    def create_index(self, *args, **kwargs):
+        if not gated.is_set():
+            gated.set()
+            entered.set()
+            assert release.wait(timeout=_WAIT_TIMEOUT_S), "gated index build was never released"
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(LanceTable, "create_index", create_index)
+    return entered, release
+
+
+def test_vector_index_phase_does_not_wait_on_an_fts_tail(tmp_path) -> None:
+    """The vector phase must not block on rows another writer left unindexed."""
+    backend = _backend(tmp_path)
+    _seed(backend)
+    _append_unindexed_row(backend, "gamma_comet", [0.0, 0.0, 1.0, 0.0])
+    assert _unindexed_rows(backend, "text") == 1
+
+    started = time.monotonic()
+    backend.write_to_index([], table=_open_table(backend), num_partitions=2, hybrid=False)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < _INDEX_READY_TIMEOUT_S
+    # The FTS tail is untouched: the vector phase neither waited for it nor
+    # rebuilt it.
+    assert _unindexed_rows(backend, "text") == 1
+    assert _unindexed_rows(backend, "vector") == 0
+
+
+def test_fts_index_phase_does_not_wait_on_a_vector_tail(tmp_path) -> None:
+    backend = _backend(tmp_path)
+    _seed(backend)
+    _append_unindexed_row(backend, "gamma_comet", [0.0, 0.0, 1.0, 0.0])
+
+    started = time.monotonic()
+    backend.write_to_index([], table=_open_table(backend), sparse=True)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < _INDEX_READY_TIMEOUT_S
+    assert _unindexed_rows(backend, "text") == 0
+    assert _unindexed_rows(backend, "vector") == 1
+
+
+def test_concurrent_writes_are_durable_and_queryable(tmp_path) -> None:
+    """Two concurrent service writes must both land and both be retrievable."""
+    backend = _backend(tmp_path)
+    _seed(backend)
+    assert _row_count(backend) == 2
+
+    batches = [
+        [_record("gamma_comet", [0.0, 0.0, 1.0, 0.0])],
+        [_record("delta_pulsar", [0.0, 0.0, 0.0, 1.0])],
+    ]
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        for future in [pool.submit(backend.run, [batch]) for batch in batches]:
+            future.result(timeout=_WAIT_TIMEOUT_S)
+
+    assert _row_count(backend) == 4
+    table = _open_table(backend)
+    stored = {row["text"] for row in table.to_arrow().to_pylist()}
+    assert {"gamma_comet", "delta_pulsar"} <= stored
+    for sentinel in ("gamma_comet", "delta_pulsar"):
+        hits = table.search(sentinel, query_type="fts").limit(10).to_list()
+        assert sentinel in {hit["text"] for hit in hits}
+
+
+def test_rows_are_committed_while_another_writer_waits_on_its_index(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later write must not be held behind an in-flight index build."""
+    backend = _backend(tmp_path)
+    _seed(backend)
+    entered, release = _gate_first_index_build(monkeypatch)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        blocked = pool.submit(backend.run, [[_record("gamma_comet", [0.0, 0.0, 1.0, 0.0])]])
+        _await(entered)
+
+        later = pool.submit(backend.run, [[_record("delta_pulsar", [0.0, 0.0, 0.0, 1.0])]])
+        _await_committed(backend, 4)
+        # The gated writer is still parked in its index wait, yet every row is durable.
+        assert not blocked.done()
+
+        release.set()
+        blocked.result(timeout=_WAIT_TIMEOUT_S)
+        later.result(timeout=_WAIT_TIMEOUT_S)
+
+    stored = {row["text"] for row in _open_table(backend).to_arrow().to_pylist()}
+    assert {"gamma_comet", "delta_pulsar"} <= stored
+
+
+def test_index_rebuilds_stay_serialized_and_coalesce(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Writers queued behind one index build share a single follow-up rebuild."""
+    backend = _backend(tmp_path)
+    _seed(backend)
+
+    builds: list[str] = []
+    active = 0
+    overlapped = False
+    state_lock = threading.Lock()
+    real_write_to_index = backend.write_to_index
+
+    def write_to_index(*args, **kwargs):
+        nonlocal active, overlapped
+        with state_lock:
+            active += 1
+            overlapped = overlapped or active > 1
+            builds.append(threading.current_thread().name)
+        try:
+            return real_write_to_index(*args, **kwargs)
+        finally:
+            with state_lock:
+                active -= 1
+
+    monkeypatch.setattr(backend, "write_to_index", write_to_index)
+    entered, release = _gate_first_index_build(monkeypatch)
+
+    followers = ["delta_pulsar", "epsilon_quasar", "zeta_nebula"]
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        first = pool.submit(backend.run, [[_record("gamma_comet", [0.0, 0.0, 1.0, 0.0])]])
+        _await(entered)
+
+        rest = [pool.submit(backend.run, [[_record(name, [1.0, 1.0, 0.0, 0.0])]]) for name in followers]
+        _await_committed(backend, 2 + 1 + len(followers))
+
+        release.set()
+        first.result(timeout=_WAIT_TIMEOUT_S)
+        for future in rest:
+            future.result(timeout=_WAIT_TIMEOUT_S)
+
+    assert not overlapped, "index builds must never run concurrently"
+    # One build for the gated writer, one coalesced build covering the writers
+    # that committed rows while it was parked.
+    assert len(builds) == 2
+    stored = {row["text"] for row in _open_table(backend).to_arrow().to_pylist()}
+    assert {"gamma_comet", *followers} <= stored

--- a/nemo_retriever/tests/test_lancedb_concurrent_writes.py
+++ b/nemo_retriever/tests/test_lancedb_concurrent_writes.py
@@ -7,8 +7,8 @@
 These tests exercise the ingest path the VectorDB service uses (``hybrid``
 index mode, so both a vector and an FTS index exist) with real index builds.
 ``write_to_index`` is never replaced with a no-op: a mocked index phase cannot
-observe a writer blocked behind another writer's index-readiness wait, which is
-exactly what regressed durability and queryability for concurrent ingests.
+observe a writer blocked behind another writer's index build, which is exactly
+what regressed durability and queryability for concurrent ingests.
 """
 
 from __future__ import annotations
@@ -90,9 +90,7 @@ def _row_count(backend: LanceDB) -> int:
 
 def _unindexed_rows(backend: LanceDB, column: str) -> int:
     stubs = [
-        stub
-        for stub in _open_table(backend).list_indices()
-        if column in [str(entry) for entry in (stub.columns or [])]
+        stub for stub in _open_table(backend).list_indices() if column in [str(entry) for entry in (stub.columns or [])]
     ]
     assert stubs, f"no LanceDB index on column {column!r}"
     return sum(int(stub.num_unindexed_rows) for stub in stubs)
@@ -109,11 +107,11 @@ def _await(event: threading.Event) -> None:
 
 def _await_committed(backend: LanceDB, expected: int) -> None:
     """Block until ``expected`` rows are committed to the table."""
-    waiter = threading.Event()
-    for _ in range(int(_WAIT_TIMEOUT_S / 0.05)):
+    deadline = time.monotonic() + _WAIT_TIMEOUT_S
+    while time.monotonic() < deadline:
         if _row_count(backend) >= expected:
             return
-        waiter.wait(timeout=0.05)
+        time.sleep(0.05)
     raise AssertionError(f"table never reached {expected} committed rows")
 
 
@@ -194,7 +192,7 @@ def test_concurrent_writes_are_durable_and_queryable(tmp_path) -> None:
         assert sentinel in {hit["text"] for hit in hits}
 
 
-def test_rows_are_committed_while_another_writer_waits_on_its_index(
+def test_rows_are_committed_while_another_writer_builds_its_index(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -209,7 +207,7 @@ def test_rows_are_committed_while_another_writer_waits_on_its_index(
 
         later = pool.submit(backend.run, [[_record("delta_pulsar", [0.0, 0.0, 0.0, 1.0])]])
         _await_committed(backend, 4)
-        # The gated writer is still parked in its index wait, yet every row is durable.
+        # The gated writer is still parked in its index build, yet every row is durable.
         assert not blocked.done()
 
         release.set()
@@ -263,8 +261,8 @@ def test_index_rebuilds_stay_serialized_and_coalesce(
             future.result(timeout=_WAIT_TIMEOUT_S)
 
     assert not overlapped, "index builds must never run concurrently"
-    # One build for the gated writer, one coalesced build covering the writers
-    # that committed rows while it was parked.
-    assert len(builds) == 2
+    # Without coalescing each of the four writers rebuilds: the gated build plus
+    # one per follower. Coalescing collapses the followers into one rebuild.
+    assert len(builds) <= 2
     stored = {row["text"] for row in _open_table(backend).to_arrow().to_pylist()}
     assert {"gamma_comet", *followers} <= stored

--- a/nemo_retriever/tests/test_lancedb_concurrent_writes.py
+++ b/nemo_retriever/tests/test_lancedb_concurrent_writes.py
@@ -24,6 +24,7 @@ lancedb = pytest.importorskip("lancedb")
 
 from lancedb.table import LanceTable  # noqa: E402
 
+from nemo_retriever.common.vdb import lancedb as lancedb_module  # noqa: E402
 from nemo_retriever.common.vdb import lancedb_capabilities  # noqa: E402
 from nemo_retriever.common.vdb.lancedb import LanceDB  # noqa: E402
 
@@ -105,6 +106,39 @@ def _await(event: threading.Event) -> None:
     assert event.wait(timeout=_WAIT_TIMEOUT_S), "timed out waiting for the write under test"
 
 
+def _record_index_waits(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record which column each index-readiness wait was scoped to.
+
+    Asserting on the columns rather than on elapsed time states the actual
+    requirement, and does not turn a slow machine into a failure.
+    """
+    waited: list[str] = []
+    original = lancedb_module.wait_for_column_index
+
+    def wait_for_column_index(table, column, **kwargs):
+        waited.append(column)
+        return original(table, column, **kwargs)
+
+    monkeypatch.setattr(lancedb_module, "wait_for_column_index", wait_for_column_index)
+    return waited
+
+
+def _await_index_requests(backend: LanceDB, expected: int) -> None:
+    """Block until ``expected`` writers have asked for index maintenance.
+
+    Rows are committed just before a writer registers its index generation.
+    Waiting for the registration instead of the rows makes coalescing
+    deterministic, because every writer is then known to be queued.
+    """
+    deadline = time.monotonic() + _WAIT_TIMEOUT_S
+    while time.monotonic() < deadline:
+        with backend._index_generation_lock:
+            if backend._index_requested_generation >= expected:
+                return
+        time.sleep(0.01)
+    raise AssertionError(f"only {backend._index_requested_generation} of {expected} writers requested a rebuild")
+
+
 def _await_committed(backend: LanceDB, expected: int) -> None:
     """Block until ``expected`` rows are committed to the table."""
     deadline = time.monotonic() + _WAIT_TIMEOUT_S
@@ -137,34 +171,38 @@ def _gate_first_index_build(monkeypatch: pytest.MonkeyPatch) -> tuple[threading.
     return entered, release
 
 
-def test_vector_index_phase_does_not_wait_on_an_fts_tail(tmp_path) -> None:
+def test_vector_index_phase_does_not_wait_on_an_fts_tail(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The vector phase must not block on rows another writer left unindexed."""
     backend = _backend(tmp_path)
     _seed(backend)
     _append_unindexed_row(backend, "gamma_comet", [0.0, 0.0, 1.0, 0.0])
     assert _unindexed_rows(backend, "text") == 1
+    waited = _record_index_waits(monkeypatch)
 
-    started = time.monotonic()
     backend.write_to_index([], table=_open_table(backend), num_partitions=2, hybrid=False)
-    elapsed = time.monotonic() - started
 
-    assert elapsed < _INDEX_READY_TIMEOUT_S
+    assert waited == ["vector"]
     # The FTS tail is untouched: the vector phase neither waited for it nor
     # rebuilt it.
     assert _unindexed_rows(backend, "text") == 1
     assert _unindexed_rows(backend, "vector") == 0
 
 
-def test_fts_index_phase_does_not_wait_on_a_vector_tail(tmp_path) -> None:
+def test_fts_index_phase_does_not_wait_on_a_vector_tail(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     backend = _backend(tmp_path)
     _seed(backend)
     _append_unindexed_row(backend, "gamma_comet", [0.0, 0.0, 1.0, 0.0])
+    waited = _record_index_waits(monkeypatch)
 
-    started = time.monotonic()
     backend.write_to_index([], table=_open_table(backend), sparse=True)
-    elapsed = time.monotonic() - started
 
-    assert elapsed < _INDEX_READY_TIMEOUT_S
+    assert waited == ["text"]
     assert _unindexed_rows(backend, "text") == 0
     assert _unindexed_rows(backend, "vector") == 1
 
@@ -254,6 +292,7 @@ def test_index_rebuilds_stay_serialized_and_coalesce(
 
         rest = [pool.submit(backend.run, [[_record(name, [1.0, 1.0, 0.0, 0.0])]]) for name in followers]
         _await_committed(backend, 2 + 1 + len(followers))
+        _await_index_requests(backend, 1 + len(followers))
 
         release.set()
         first.result(timeout=_WAIT_TIMEOUT_S)
@@ -263,6 +302,6 @@ def test_index_rebuilds_stay_serialized_and_coalesce(
     assert not overlapped, "index builds must never run concurrently"
     # Without coalescing each of the four writers rebuilds: the gated build plus
     # one per follower. Coalescing collapses the followers into one rebuild.
-    assert len(builds) <= 2
+    assert len(builds) == 2
     stored = {row["text"] for row in _open_table(backend).to_arrow().to_pylist()}
     assert {"gamma_comet", *followers} <= stored

--- a/nemo_retriever/tests/test_lancedb_ivf_partitions.py
+++ b/nemo_retriever/tests/test_lancedb_ivf_partitions.py
@@ -98,8 +98,13 @@ def test_write_to_index_skips_vector_index_single_row() -> None:
     assert not table.list_indices()
 
 
-def test_run_serializes_write_and_index_transactions(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    """Concurrent service callbacks must not submit competing CreateIndex commits."""
+def test_run_serializes_row_admission(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Concurrent service callbacks must not append to the table at the same time.
+
+    Index maintenance is serialized separately; see
+    ``test_lancedb_concurrent_writes.py`` for the real-LanceDB coverage of the
+    write and index critical sections.
+    """
 
     class TrackingLock:
         def __init__(self) -> None:

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -27,6 +27,7 @@ from nemo_retriever.common.schemas.pipeline_spec import PipelineSpec
 from nemo_retriever.common.policy import PolicyError, validate_pipeline_spec
 from nemo_retriever.service.services.pipeline_executor import (
     _build_graph_ingestor_from_spec,
+    _DEFAULT_VECTORDB_WRITE_TIMEOUT_S,
     _merge_server_owned,
     _post_records_to_vectordb,
     _request_needs_asr_params,
@@ -997,7 +998,7 @@ def test_post_records_to_vectordb_uses_canonical_internal_payload(monkeypatch: p
     )
 
     assert posted["url"] == "http://vectordb:7671/internal/vectordb/write"
-    assert posted["timeout"] == 30
+    assert posted["timeout"] == _DEFAULT_VECTORDB_WRITE_TIMEOUT_S
     assert posted["headers"]["X-nrl-internal-token"] == "internal-token"
     assert posted["json"] == {
         "records": records,
@@ -1012,3 +1013,54 @@ def test_post_records_to_vectordb_uses_canonical_internal_payload(monkeypatch: p
     }
     assert "rows" not in posted["json"]
     assert "artifact_prefix" not in posted["json"]
+
+
+def test_post_records_to_vectordb_fails_the_document_when_the_write_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A write the storage tier never acknowledged must not be reported as ingested."""
+
+    def _urlopen(request, timeout):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+    records = [[{"document_type": "text", "metadata": {"embedding": [0.1], "content": "chunk"}}]]
+
+    # A legacy fixed-table write, i.e. no collection context.
+    with pytest.raises(RuntimeError, match="VectorDB write failed for gamma.txt"):
+        _post_records_to_vectordb(
+            records,
+            "http://vectordb:7671",
+            "gamma.txt",
+            context=DocumentWriteContext(),
+        )
+
+
+def test_post_records_to_vectordb_honors_the_configured_write_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def _urlopen(request, timeout):
+        seen["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+    _post_records_to_vectordb(
+        [[{"document_type": "text", "metadata": {"embedding": [0.1], "content": "chunk"}}]],
+        "http://vectordb:7671",
+        "gamma.txt",
+        context=DocumentWriteContext(),
+        timeout_s=45.0,
+    )
+
+    assert seen["timeout"] == 45.0

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -22,6 +22,7 @@ import json
 import pytest
 
 from nemo_retriever.common.params import DedupParams, EmbedParams, ExtractParams
+from nemo_retriever.common.vdb import lancedb_capabilities
 from nemo_retriever.service.config import PipelineOverridesConfig
 from nemo_retriever.common.schemas.pipeline_spec import PipelineSpec
 from nemo_retriever.common.policy import PolicyError, validate_pipeline_spec
@@ -1064,3 +1065,17 @@ def test_post_records_to_vectordb_honors_the_configured_write_timeout(
     )
 
     assert seen["timeout"] == 45.0
+
+
+def test_default_write_timeout_outlasts_the_index_readiness_waits() -> None:
+    """A durable write must not fail because the VectorDB waited on its own indexes.
+
+    The VectorDB acknowledges a write only after index maintenance, and a hybrid
+    table waits once per index. If those advisory waits can outlast the worker's
+    timeout, a document whose rows are already committed fails on the wait alone.
+    """
+    worst_case_index_wait_s = (
+        lancedb_capabilities.MAX_INDEX_READY_WAITS_PER_WRITE * lancedb_capabilities.INDEX_READY_TIMEOUT.total_seconds()
+    )
+
+    assert worst_case_index_wait_s < _DEFAULT_VECTORDB_WRITE_TIMEOUT_S

--- a/nemo_retriever/tests/test_service_pipeline_tracing.py
+++ b/nemo_retriever/tests/test_service_pipeline_tracing.py
@@ -170,6 +170,7 @@ def test_make_work_fn_continues_when_trace_capture_fails(
             enabled=False,
             vectordb_url=None,
             internal_api_token=None,
+            write_timeout_s=300.0,
         ),
         pipeline=SimpleNamespace(
             realtime_workers=1,

--- a/retriever-service.log.1
+++ b/retriever-service.log.1
@@ -1,0 +1,2404 @@
+2026-08-20 18:15:55,170 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=3, label=None)
+2026-08-20 18:15:55,178 | INFO | nemo_retriever.service.services.job_tracker | Job registered: a (expected_documents=1, label=None)
+2026-08-20 18:15:55,185 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b (expected_documents=1, label=None)
+2026-08-20 18:15:55,187 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,189 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,201 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,203 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,205 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 2 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,247 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_service_start_mounts_mcp_0/service.log
+2026-08-20 18:15:55,257 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,259 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,260 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,262 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,267 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,269 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,270 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,272 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,296 | INFO | mcp.server.streamable_http_manager | Created new transport with session ID: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,298 | INFO | mcp.server.streamable_http | Terminating session: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,299 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,300 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,301 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,302 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,303 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,304 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,305 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,306 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,307 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,308 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,316 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,327 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,328 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,329 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,332 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,333 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,334 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,335 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,336 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,337 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,338 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,339 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,340 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,341 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,357 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ac445a69cfc74efc8126f535d699c19d (expected_documents=1, label=None)
+2026-08-20 18:15:55,362 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,363 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,364 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,365 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,366 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,367 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,368 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,369 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,370 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,371 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,373 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,384 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,385 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,386 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,389 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,390 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,391 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,392 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,393 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,394 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,395 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,396 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,397 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,398 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,415 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 58ac7310db284e8487ac4132eff5558f (expected_documents=1, label=None)
+2026-08-20 18:15:55,419 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,421 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,422 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,423 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,424 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,425 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,426 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,427 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,428 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,429 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,431 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,441 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,442 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,444 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,446 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,448 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,449 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,450 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,452 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,453 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,454 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,455 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,456 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,472 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 98348a991fe14684bd72baa3464fa231 (expected_documents=1, label=None)
+2026-08-20 18:15:55,476 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,477 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,478 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,480 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,481 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,482 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,483 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,484 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,485 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,486 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,489 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,500 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,502 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,503 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,506 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,507 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,508 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,509 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,511 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,512 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,513 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,514 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,516 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,517 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,532 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 982ba7b1c898422f9bcfd0d6c15ce711 (expected_documents=1, label=None)
+2026-08-20 18:15:55,537 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,539 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,540 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,541 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,542 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,543 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,544 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,545 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,547 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,548 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,550 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,560 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,562 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,563 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,565 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,567 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,568 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,569 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,570 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,571 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,572 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,573 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,575 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,576 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,591 | INFO | nemo_retriever.service.services.job_tracker | Job registered: fae3557728a941de97f5ffc0e1c8e820 (expected_documents=1, label=None)
+2026-08-20 18:15:55,594 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:55,597 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,599 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,600 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:55,601 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,602 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,603 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,604 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,605 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,606 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,607 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,610 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,623 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,626 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,627 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,628 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,629 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,630 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,631 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,632 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,633 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,635 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,636 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,651 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 678895b4c35942f19b6a2d617d600d62 (expected_documents=1, label=None)
+2026-08-20 18:15:55,656 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,657 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,658 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,660 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,662 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,663 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,664 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,665 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,666 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,669 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,672 | INFO | nemo_retriever.service.app | Media dependencies (ffmpeg, ffprobe) detected — audio/video ingestion enabled (mode=batch)
+2026-08-20 18:15:55,674 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,677 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:55,678 | WARNING | nemo_retriever.service.services.job_tracker | JobTracker.mark_failed: no record of document 'unknown' — callback dropped (likely gateway-pod restart between upload acceptance and worker callback); client may hang waiting for an SSE event that will never arrive
+2026-08-20 18:15:55,680 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,682 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,685 | WARNING | nemo_retriever.service.metrics_otel | OpenTelemetry metrics setup failed: OpenTelemetry metrics SDK/exporter packages are not importable
+2026-08-20 18:15:55,698 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,709 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,710 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,711 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,714 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,715 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,716 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,717 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,744 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,746 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,747 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,748 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,844 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,846 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,847 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:55,848 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,849 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,850 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,851 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,852 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,856 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,866 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,867 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,869 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,872 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,873 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,874 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,875 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,902 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,903 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,904 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,905 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,999 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,001 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,002 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:56,003 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,004 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,005 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,006 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,007 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,116 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for report.pdf — HTTP 200
+2026-08-20 18:15:56,118 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for document.pdf — HTTP 200
+2026-08-20 18:15:56,120 | ERROR | nemo_retriever.service.services.pipeline_executor | Failed to POST 1 records to vectordb for gamma.txt: timed out
+2026-08-20 18:15:56,122 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for gamma.txt — HTTP 200
+2026-08-20 18:15:56,125 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=parent-test
+2026-08-20 18:15:56,128 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context extraction failed for pipeline execution: bad carrier
+2026-08-20 18:15:56,131 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Realtime): extract=_Params, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:56,132 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context capture failed for pipeline execution: inject failed
+2026-08-20 18:15:56,134 | INFO | nemo_retriever.service.services.pipeline_executor | Realtime pipeline completed: id=item-1 file=contract.pdf rows=1 elapsed=0.01s
+2026-08-20 18:15:56,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,137 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' started: workers=3 queue_size=17 work_fn=noop
+2026-08-20 18:15:56,139 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' shut down (processed=0)
+2026-08-20 18:15:56,158 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' started: workers=1 queue_size=4 work_fn=slow_work
+2026-08-20 18:15:56,262 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' shut down (processed=4)
+2026-08-20 18:15:56,264 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' started: workers=2 queue_size=16 work_fn=work
+2026-08-20 18:15:56,320 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' shut down (processed=3)
+2026-08-20 18:15:56,322 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' started: workers=1 queue_size=4 work_fn=boom
+2026-08-20 18:15:56,324 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-0
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,326 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-1
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,346 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' shut down (processed=0)
+2026-08-20 18:15:56,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:56,351 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,402 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' shut down (processed=1)
+2026-08-20 18:15:56,404 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,406 | WARNING | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' trace context extraction failed for item doc-1; continuing without parent context: propagator unavailable
+2026-08-20 18:15:56,407 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' shut down (processed=1)
+2026-08-20 18:15:56,409 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,412 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,415 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,417 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,420 | WARNING | nemo_retriever.service.services.proxy | Gateway forwarding empty body to batch http://batch.test/v1/ingest/sidecar/sidecar-id — the body-cache middleware may not have run
+2026-08-20 18:15:56,444 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_main_0/service.log
+2026-08-20 18:15:56,454 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,456 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,457 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,460 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,461 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,462 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,463 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,464 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,466 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,467 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,468 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,469 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,470 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,488 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,489 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,491 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,492 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,493 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,494 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,495 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,496 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,497 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,498 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,503 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_defaults_r0/service.log
+2026-08-20 18:15:56,513 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,514 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,515 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,518 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,519 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,520 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,521 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,523 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,524 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,525 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,526 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,527 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,528 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,544 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,546 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,547 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,548 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,549 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,550 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,551 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,552 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,553 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,554 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,559 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_requires_m0/service.log
+2026-08-20 18:15:56,570 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,571 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,573 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,575 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,577 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,578 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,579 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,580 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,581 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,582 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,583 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,585 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,586 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,601 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,603 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,604 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,605 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,606 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,607 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,608 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,609 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,611 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,612 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,616 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_lazy_0/service.log
+2026-08-20 18:15:56,626 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,627 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,629 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,632 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,633 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,635 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,636 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,637 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,638 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,639 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,640 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,641 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,643 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,659 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,660 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,663 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,664 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,665 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,666 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,667 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,668 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,669 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,674 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_false_rerank_string_uses_0/service.log
+2026-08-20 18:15:56,685 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,686 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,688 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,691 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,692 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,693 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,694 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,695 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,697 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,698 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,699 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,700 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,701 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,717 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,718 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,720 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,721 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,722 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,723 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,724 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,725 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,727 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,728 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,751 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: persistent result failure
+2026-08-20 18:15:56,753 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: Server error '500 Internal Server Error' for url 'http://example:7670/v1/ingest/status/doc-a'
+For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+2026-08-20 18:15:56,755 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,757 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=Imq1oQh1lHrfqXVv76A5LQ filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,758 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,759 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,760 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,762 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=hs7jZxgJty7jhrB3K5W1JQ filename=meta.csv bytes=15 ttl=3600s
+2026-08-20 18:15:56,764 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=igLu5XyPcBPQqocZ0EIuOg filename=meta.csv bytes=8 ttl=3600s
+2026-08-20 18:15:56,766 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=rUXGfWIAp-j4EL6GwKOn-g filename=m.csv bytes=2 ttl=0s
+2026-08-20 18:15:56,868 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=xSTJT-pRaRTYQuJlV_NMRA filename=m.csv bytes=2 ttl=3600s
+2026-08-20 18:15:56,869 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got='eve')
+2026-08-20 18:15:56,870 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got=None)
+2026-08-20 18:15:56,872 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=zkaAdBIxvlJbKtlylUCxOw filename=a bytes=1 ttl=3600s
+2026-08-20 18:15:56,873 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=DEFQz9VJnxSEo8IPOP9uQw filename=b bytes=1 ttl=3600s
+2026-08-20 18:15:56,882 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,883 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=q9OPldT-uth9LrqNNksAaw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,884 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,886 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,887 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,891 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,901 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,902 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,904 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,906 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,907 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,908 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,911 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,912 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,913 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,914 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,915 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,917 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,934 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bWOIyS5Xmh67fSqJmBv2Aw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,936 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,939 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,940 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,941 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,942 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,944 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,945 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,946 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,947 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,949 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,960 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,961 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,963 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,965 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,967 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,968 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,969 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,970 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,971 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,972 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,974 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,975 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,992 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,994 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,995 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,996 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,998 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,999 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,000 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,001 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,002 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,003 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,006 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,017 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,018 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,020 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,022 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,023 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,025 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,026 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,027 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,028 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,029 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,031 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,032 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,033 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,049 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=0vlA8-E81KijVI3q7m8lLQ filename=m.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,053 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,054 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,056 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,057 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,058 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,059 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,060 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,061 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,063 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,064 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,066 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,077 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,078 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,080 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,082 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,084 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,085 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,086 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,087 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,088 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,089 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,091 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,092 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,093 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,109 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=w8p9knDLq7tZ6fVK9bjESg filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,113 | INFO | nemo_retriever.service.services.job_tracker | Job registered: bd7492d41b31416c9322537144154ed1 (expected_documents=1, label=None)
+2026-08-20 18:15:57,118 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,121 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,122 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,124 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,125 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,126 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,127 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,128 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,129 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,131 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,132 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,135 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,146 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,147 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,149 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:57,152 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,154 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,155 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,156 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,183 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:57,185 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,186 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:57,187 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,202 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bHdpDDCmiTkW8G8l1BgErw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b3ce5cfda3574e0584d9b5860a71ca2a (expected_documents=1, label=None)
+2026-08-20 18:15:57,230 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,232 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,233 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:57,235 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,236 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,237 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,239 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,240 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,243 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,255 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,256 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,258 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,261 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,269 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,270 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,271 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,273 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,289 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 36ffaab76fad4e888bdf9e64f7fcc36a (expected_documents=1, label=None)
+2026-08-20 18:15:57,293 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,295 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,296 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,297 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,299 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,300 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,301 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,302 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,304 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,305 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,307 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,318 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,319 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,321 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,325 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,326 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,327 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,328 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,330 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,331 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,332 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,334 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,335 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,353 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=NZXwpLNpgZqNSNyPD90i9Q filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,356 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,358 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,359 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,360 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,362 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,363 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:57,364 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,365 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,367 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,368 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,388 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,624 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,627 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,629 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,630 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,632 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,633 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,634 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,636 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,637 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,638 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,640 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,655 | INFO | nemo_retriever.service.services.job_tracker | Job registered: cb13321bd9cc4a7690a99333e2ece25a (expected_documents=1, label=None)
+2026-08-20 18:15:57,659 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,664 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,665 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,666 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,667 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,668 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,670 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,671 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,672 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,674 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,677 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,687 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,689 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,691 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,694 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,695 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,696 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,697 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,699 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,700 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,701 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,703 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,704 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,706 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,722 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 12789d144cbb460fa91ab1fefc91ed95 (expected_documents=1, label=None)
+2026-08-20 18:15:57,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,729 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,732 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,734 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,736 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,737 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,739 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,740 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,743 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,753 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,755 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,756 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,759 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,761 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,762 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,763 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,765 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,766 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,767 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,768 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,770 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,771 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,787 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 8e80a281c7b34a84b05ac04a83c08865 (expected_documents=1, label=None)
+2026-08-20 18:15:57,791 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,793 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,794 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,796 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,797 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,798 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,800 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,801 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,802 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,804 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,806 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,818 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,819 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,821 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,825 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,826 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,827 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,828 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,830 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,831 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,833 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,834 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,835 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,837 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,853 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,855 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,856 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,857 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,859 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,860 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,861 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,863 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,864 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,865 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,868 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,879 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,880 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,882 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,885 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,886 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,888 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,889 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,890 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,892 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,893 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,894 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,896 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,897 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,914 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,915 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,917 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,918 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,919 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,921 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,922 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,923 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,925 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,926 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,929 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,940 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,942 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,944 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,947 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,949 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,950 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,951 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,953 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,954 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,955 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,957 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,958 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,960 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,978 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,979 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,981 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,982 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,983 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,985 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,986 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,988 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,989 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,992 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,002 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,004 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,005 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,009 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,014 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,016 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,017 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,019 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,020 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,022 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,039 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,041 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,043 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,044 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,045 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,047 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,048 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,049 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,051 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,052 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,055 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,065 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,067 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,068 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,072 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,073 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,074 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,076 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,077 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,078 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,080 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,081 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,083 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,084 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,175 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,177 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,179 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,180 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,182 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,183 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,184 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,186 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,187 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,188 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,191 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,201 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,203 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,205 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,208 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,210 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,211 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,212 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,214 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,215 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,217 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,218 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,220 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,221 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,311 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,313 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,314 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,316 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,317 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,318 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,320 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,321 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,324 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,335 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: tracer unavailable
+2026-08-20 18:15:58,337 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: span enter failed
+2026-08-20 18:15:58,341 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,346 | WARNING | nemo_retriever.service.tracing | OpenTelemetry tracing setup failed: processor install failed
+2026-08-20 18:15:58,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,352 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,355 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,358 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,369 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:58,371 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,373 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,391 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,393 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,405 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=2
+2026-08-20 18:15:58,407 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,422 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,434 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,447 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,450 | INFO | nemo_retriever.service.vectordb_app | Unsupported VDB operation: Collection retrieval mode is unsupported
+2026-08-20 18:15:58,453 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,457 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,470 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,477 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,492 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,502 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,515 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,528 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,537 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,550 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,554 | ERROR | nemo_retriever.service.vectordb_app | VectorDB retrieval contract violation
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 254, in retrieve_collection
+    raise RetrievalContractError("physical table secret must not be returned")
+nemo_retriever.common.vdb.records.RetrievalContractError: physical table secret must not be returned
+2026-08-20 18:15:58,558 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,571 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,575 | ERROR | nemo_retriever.service.vectordb_app | Unexpected VectorDB service failure
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
+    await self.app(scope, receive, _send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 193, in __call__
+    response = await self.dispatch_func(request, call_next)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 417, in require_internal_credential
+    return await call_next(request)
+           ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 168, in call_next
+    raise app_exc from app_exc.__cause__ or app_exc.__context__
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro
+    await self.app(scope, receive_or_disconnect, send_no_error)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
+    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 670, in __call__
+    await self.middleware_stack(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 2734, in app
+    await route.handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 1281, in handle
+    await super().handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 280, in handle
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 158, in app
+    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 259, in retrieve_collection
+    raise ValueError("backend parsing failed")
+ValueError: backend parsing failed
+2026-08-20 18:15:58,578 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,591 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,595 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,607 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,611 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,626 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=none max_concurrent_queries=4
+2026-08-20 18:15:58,627 | ERROR | nemo_retriever.service.vectordb_app | VectorDB started without an embedding backend; /v1/query will return HTTP 501 until --embed-endpoint or --local-embed is configured.
+2026-08-20 18:15:58,631 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,643 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,647 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,660 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,664 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,677 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,679 | ERROR | nemo_retriever.service.vectordb_app | VectorDB backend health inspection failed
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 243, in _safe_backend_health
+    health = state.vdb.health()
+             ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 264, in health
+    raise RuntimeError("backend unavailable")
+RuntimeError: backend unavailable
+2026-08-20 18:15:58,681 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,686 | INFO | nemo_retriever.service.vectordb_app | Loaded local query embedder model=nvidia/llama-nemotron-embed-1b-v2 backend=hf
+2026-08-20 18:15:58,700 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,710 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'nemo_retriever' because build_index=False.
+2026-08-20 18:15:58,725 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,772 | WARNING | nemo_retriever.service.services.work_queue | Heartbeat request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 598, in heartbeat
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,776 | WARNING | nemo_retriever.service.services.work_queue | Release request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 616, in release
+    await client.post(
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,779 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=2 queue_size=99 work_fn=work
+2026-08-20 18:15:58,781 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,839 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,840 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:58,842 | ERROR | nemo_retriever.service.services.work_queue | Failed to spool payload for work 'work' (job 'job'); rolling back admission
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 255, in enqueue
+    await asyncio.to_thread(self._write_spool, spool_path, payload)
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 855, in fail_write
+    raise OSError("injected payload fsync failure")
+OSError: injected payload fsync failure
+2026-08-20 18:15:58,845 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,849 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_upload_claim_payl0/service.log
+2026-08-20 18:15:58,851 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,853 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,858 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,859 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,861 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,889 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,891 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,893 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:58,908 | INFO | nemo_retriever.service.services.job_tracker | Job registered: aa41f4bceb1b41e0aa6cc1571e7b7303 (expected_documents=1, label=None)
+2026-08-20 18:15:58,933 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=c8b3b455e394483b9187bde445f49903 job_id=aa41f4bceb1b41e0aa6cc1571e7b7303 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:58,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,939 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:58,941 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,942 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,943 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,945 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,946 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,951 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_callback_treats_s0/service.log
+2026-08-20 18:15:58,953 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,955 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,960 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,962 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,963 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,964 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,992 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,993 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,995 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,010 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ae13dee2d4f543b6ade0f7542a4a9ca9 (expected_documents=1, label=None)
+2026-08-20 18:15:59,028 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=643920c51f4841af8f2cf54ac4985e42 job_id=ae13dee2d4f543b6ade0f7542a4a9ca9 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:59,029 | WARNING | nemo_retriever.service.routers.ingest | Work lease for 643920c51f4841af8f2cf54ac4985e42 was already superseded at acknowledge; tracker already updated
+2026-08-20 18:15:59,033 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,035 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,036 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,038 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,039 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,041 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,042 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,047 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_internal_work_endpoints_r0/service.log
+2026-08-20 18:15:59,049 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,050 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,054 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,055 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,057 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,058 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,085 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,087 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,089 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,136 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,138 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,139 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,141 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,142 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,144 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,149 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_dry_run_does_not_0/service.log
+2026-08-20 18:15:59,151 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,152 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,156 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,157 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,159 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,160 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,187 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,189 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,190 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 75e734ec8d3b435e8cae58b72a5c1307 (expected_documents=2, label=None)
+2026-08-20 18:15:59,264 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,266 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,267 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,268 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,270 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,272 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,273 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,277 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,279 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,281 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,287 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,289 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,290 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,292 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,319 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,321 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,322 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,340 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 498e74549207425b90495819b296c02b (expected_documents=1, label=None)
+2026-08-20 18:15:59,355 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,358 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,359 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,361 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,362 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,364 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,365 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,368 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,370 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,372 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,380 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,382 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,383 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,385 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,411 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,413 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,415 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,441 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,443 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,444 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,445 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,448 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,450 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,455 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,469 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,470 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,472 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,476 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,478 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,484 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,486 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,487 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:59,489 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,491 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,505 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,521 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,526 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,528 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,530 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,531 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,532 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,534 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,536 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,553 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'doc-read-error'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 310, in _get_from_filesystem
+    with candidate.open(encoding="utf-8") as stream:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_worker_callback.py", line 153, in fail_generation_read_once
+    raise OSError(errno.EIO, "I/O error")
+OSError: [Errno 5] I/O error
+2026-08-20 18:15:59,558 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'invalid'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 311, in _get_from_filesystem
+    rows = json.load(stream)
+           ^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 293, in load
+    return loads(fp.read(),
+           ^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+    return _default_decoder.decode(s)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 353, in raw_decode
+    obj, end = self.scan_once(s, idx)
+               ^^^^^^^^^^^^^^^^^^^^^^
+json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
+2026-08-20 18:15:59,562 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,567 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,578 | INFO | nemo_retriever.service.services.worker_result_store | Removed 2 expired shared result file(s) from /tmp/pytest-of-ubuntu/pytest-98/test_shared_result_store_remov0/.worker-results-v1
+2026-08-20 18:15:59,594 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,605 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,607 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,609 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,615 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,628 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,630 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,632 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,635 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,636 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,638 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=16, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,640 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=16 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,642 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=8w/2048q, batch=16w/4096q)
+2026-08-20 18:15:59,644 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,645 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,667 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,671 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 1 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,674 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 2 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,677 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 3 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,680 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 4 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,683 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 6 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,686 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 7 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,689 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 5 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,691 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 8 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,694 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 10 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,697 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 9 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,700 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 11 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,703 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 13 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,706 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 14 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,709 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 15 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,712 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 12 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,730 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,734 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,736 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,738 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,766 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,777 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,779 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,781 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,789 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,791 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,793 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,794 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,821 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,823 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,824 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,826 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,828 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job-shared (expected_documents=2, label=None)
+2026-08-20 18:15:59,857 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,859 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,860 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,863 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,865 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 2, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,867 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,868 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,872 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item doc-retry (attempt 1)
+2026-08-20 18:15:59,875 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 410 for item permanently-rejected-doc (attempt 1)
+2026-08-20 18:15:59,876 | ERROR | nemo_retriever.service.services.pipeline_pool | Gateway callback permanently rejected item permanently-rejected-doc with HTTP 410
+2026-08-20 18:15:59,880 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,891 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,893 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,895 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,904 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,906 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,907 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,936 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,938 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,939 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,941 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,943 | INFO | nemo_retriever.service.services.job_tracker | Job registered: handoff-job (expected_documents=1, label=None)
+2026-08-20 18:15:59,962 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=handoff-doc job_id=handoff-job status=completed outcome=transitioned rows=1 subscribers=0
+2026-08-20 18:15:59,967 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,969 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,970 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,972 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,973 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,975 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,976 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,978 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,982 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,995 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,997 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,999 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,008 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,040 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,042 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,044 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,045 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,047 | INFO | nemo_retriever.service.services.job_tracker | Job registered: failed-handoff-job (expected_documents=1, label=None)
+2026-08-20 18:16:00,064 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,066 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,068 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,069 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,071 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,072 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 1, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,074 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,076 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,082 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:16:00,093 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:16:00,094 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:16:00,096 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,105 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,107 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,108 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,110 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,137 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,139 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,141 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,142 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,160 | WARNING | nemo_retriever.service.routers.ingest | Permanently rejecting retained result handoff for unknown document restart-orphaned-doc
+2026-08-20 18:16:00,162 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,164 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,166 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,167 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,169 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,170 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,172 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,173 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,180 | INFO | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback succeeded for item deferred-doc
+2026-08-20 18:16:00,184 | ERROR | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback permanently failed for item restart-orphaned-doc; result remains unacknowledged
+2026-08-20 18:16:00,196 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item retry-after-doc (attempt 1)
+2026-08-20 18:16:01,436 | INFO | nemo_retriever.graph.ingestor_runtime | Selected OCR engine: v2 (OCRActor)
+2026-08-20 18:16:01,694 | WARNING | nemo_retriever.common.api.util.exception_handlers.pdf | PDF Processing:boom error:x
+2026-08-20 18:16:01,960 | WARNING | nemo_retriever.operators.extract.txt.ray_data | Failed to split text source 'bad.txt'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/extract/txt/ray_data.py", line 113, in process
+    chunk_df = txt_bytes_to_chunks_df(bytes(raw), path_str, params=params)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_tokenizer_provider.py", line 165, in split_document
+    raise ValueError("malformed document")
+ValueError: malformed document
+2026-08-20 18:16:02,032 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 3 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,040 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 12 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,048 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 4 frame rows -> 2 (max_dropped_frames=2)
+2026-08-20 18:16:02,056 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 2 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,117 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['missing']
+2026-08-20 18:16:02,121 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['nope']
+2026-08-20 18:16:02,132 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 2 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,136 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 1 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,140 | ERROR | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: failed to POST to https://hook.example.com/ingest
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/graph_ops/webhook_operator.py", line 123, in process
+    response = session.post(url, json=records, timeout=timeout)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1134, in __call__
+    return self._mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
+    raise effect
+ConnectionError: boom

--- a/retriever-service.log.2
+++ b/retriever-service.log.2
@@ -1,0 +1,2404 @@
+2026-08-20 18:15:55,170 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=3, label=None)
+2026-08-20 18:15:55,178 | INFO | nemo_retriever.service.services.job_tracker | Job registered: a (expected_documents=1, label=None)
+2026-08-20 18:15:55,185 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b (expected_documents=1, label=None)
+2026-08-20 18:15:55,187 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,189 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,201 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,203 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,205 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 2 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,247 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_service_start_mounts_mcp_0/service.log
+2026-08-20 18:15:55,257 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,259 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,260 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,262 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,267 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,269 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,270 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,272 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,296 | INFO | mcp.server.streamable_http_manager | Created new transport with session ID: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,298 | INFO | mcp.server.streamable_http | Terminating session: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,299 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,300 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,301 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,302 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,303 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,304 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,305 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,306 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,307 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,308 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,316 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,327 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,328 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,329 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,332 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,333 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,334 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,335 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,336 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,337 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,338 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,339 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,340 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,341 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,357 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ac445a69cfc74efc8126f535d699c19d (expected_documents=1, label=None)
+2026-08-20 18:15:55,362 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,363 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,364 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,365 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,366 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,367 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,368 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,369 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,370 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,371 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,373 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,384 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,385 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,386 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,389 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,390 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,391 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,392 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,393 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,394 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,395 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,396 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,397 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,398 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,415 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 58ac7310db284e8487ac4132eff5558f (expected_documents=1, label=None)
+2026-08-20 18:15:55,419 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,421 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,422 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,423 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,424 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,425 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,426 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,427 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,428 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,429 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,431 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,441 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,442 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,444 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,446 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,448 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,449 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,450 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,452 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,453 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,454 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,455 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,456 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,472 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 98348a991fe14684bd72baa3464fa231 (expected_documents=1, label=None)
+2026-08-20 18:15:55,476 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,477 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,478 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,480 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,481 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,482 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,483 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,484 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,485 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,486 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,489 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,500 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,502 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,503 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,506 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,507 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,508 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,509 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,511 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,512 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,513 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,514 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,516 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,517 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,532 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 982ba7b1c898422f9bcfd0d6c15ce711 (expected_documents=1, label=None)
+2026-08-20 18:15:55,537 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,539 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,540 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,541 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,542 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,543 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,544 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,545 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,547 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,548 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,550 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,560 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,562 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,563 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,565 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,567 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,568 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,569 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,570 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,571 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,572 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,573 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,575 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,576 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,591 | INFO | nemo_retriever.service.services.job_tracker | Job registered: fae3557728a941de97f5ffc0e1c8e820 (expected_documents=1, label=None)
+2026-08-20 18:15:55,594 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:55,597 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,599 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,600 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:55,601 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,602 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,603 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,604 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,605 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,606 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,607 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,610 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,623 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,626 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,627 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,628 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,629 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,630 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,631 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,632 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,633 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,635 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,636 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,651 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 678895b4c35942f19b6a2d617d600d62 (expected_documents=1, label=None)
+2026-08-20 18:15:55,656 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,657 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,658 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,660 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,662 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,663 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,664 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,665 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,666 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,669 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,672 | INFO | nemo_retriever.service.app | Media dependencies (ffmpeg, ffprobe) detected — audio/video ingestion enabled (mode=batch)
+2026-08-20 18:15:55,674 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,677 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:55,678 | WARNING | nemo_retriever.service.services.job_tracker | JobTracker.mark_failed: no record of document 'unknown' — callback dropped (likely gateway-pod restart between upload acceptance and worker callback); client may hang waiting for an SSE event that will never arrive
+2026-08-20 18:15:55,680 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,682 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,685 | WARNING | nemo_retriever.service.metrics_otel | OpenTelemetry metrics setup failed: OpenTelemetry metrics SDK/exporter packages are not importable
+2026-08-20 18:15:55,698 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,709 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,710 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,711 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,714 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,715 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,716 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,717 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,744 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,746 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,747 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,748 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,844 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,846 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,847 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:55,848 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,849 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,850 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,851 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,852 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,856 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,866 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,867 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,869 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,872 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,873 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,874 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,875 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,902 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,903 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,904 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,905 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,999 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,001 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,002 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:56,003 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,004 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,005 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,006 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,007 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,116 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for report.pdf — HTTP 200
+2026-08-20 18:15:56,118 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for document.pdf — HTTP 200
+2026-08-20 18:15:56,120 | ERROR | nemo_retriever.service.services.pipeline_executor | Failed to POST 1 records to vectordb for gamma.txt: timed out
+2026-08-20 18:15:56,122 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for gamma.txt — HTTP 200
+2026-08-20 18:15:56,125 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=parent-test
+2026-08-20 18:15:56,128 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context extraction failed for pipeline execution: bad carrier
+2026-08-20 18:15:56,131 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Realtime): extract=_Params, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:56,132 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context capture failed for pipeline execution: inject failed
+2026-08-20 18:15:56,134 | INFO | nemo_retriever.service.services.pipeline_executor | Realtime pipeline completed: id=item-1 file=contract.pdf rows=1 elapsed=0.01s
+2026-08-20 18:15:56,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,137 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' started: workers=3 queue_size=17 work_fn=noop
+2026-08-20 18:15:56,139 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' shut down (processed=0)
+2026-08-20 18:15:56,158 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' started: workers=1 queue_size=4 work_fn=slow_work
+2026-08-20 18:15:56,262 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' shut down (processed=4)
+2026-08-20 18:15:56,264 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' started: workers=2 queue_size=16 work_fn=work
+2026-08-20 18:15:56,320 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' shut down (processed=3)
+2026-08-20 18:15:56,322 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' started: workers=1 queue_size=4 work_fn=boom
+2026-08-20 18:15:56,324 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-0
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,326 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-1
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,346 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' shut down (processed=0)
+2026-08-20 18:15:56,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:56,351 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,402 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' shut down (processed=1)
+2026-08-20 18:15:56,404 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,406 | WARNING | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' trace context extraction failed for item doc-1; continuing without parent context: propagator unavailable
+2026-08-20 18:15:56,407 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' shut down (processed=1)
+2026-08-20 18:15:56,409 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,412 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,415 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,417 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,420 | WARNING | nemo_retriever.service.services.proxy | Gateway forwarding empty body to batch http://batch.test/v1/ingest/sidecar/sidecar-id — the body-cache middleware may not have run
+2026-08-20 18:15:56,444 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_main_0/service.log
+2026-08-20 18:15:56,454 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,456 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,457 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,460 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,461 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,462 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,463 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,464 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,466 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,467 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,468 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,469 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,470 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,488 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,489 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,491 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,492 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,493 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,494 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,495 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,496 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,497 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,498 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,503 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_defaults_r0/service.log
+2026-08-20 18:15:56,513 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,514 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,515 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,518 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,519 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,520 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,521 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,523 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,524 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,525 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,526 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,527 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,528 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,544 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,546 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,547 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,548 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,549 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,550 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,551 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,552 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,553 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,554 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,559 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_requires_m0/service.log
+2026-08-20 18:15:56,570 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,571 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,573 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,575 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,577 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,578 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,579 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,580 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,581 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,582 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,583 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,585 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,586 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,601 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,603 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,604 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,605 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,606 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,607 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,608 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,609 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,611 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,612 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,616 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_lazy_0/service.log
+2026-08-20 18:15:56,626 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,627 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,629 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,632 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,633 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,635 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,636 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,637 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,638 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,639 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,640 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,641 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,643 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,659 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,660 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,663 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,664 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,665 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,666 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,667 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,668 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,669 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,674 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_false_rerank_string_uses_0/service.log
+2026-08-20 18:15:56,685 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,686 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,688 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,691 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,692 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,693 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,694 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,695 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,697 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,698 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,699 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,700 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,701 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,717 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,718 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,720 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,721 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,722 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,723 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,724 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,725 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,727 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,728 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,751 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: persistent result failure
+2026-08-20 18:15:56,753 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: Server error '500 Internal Server Error' for url 'http://example:7670/v1/ingest/status/doc-a'
+For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+2026-08-20 18:15:56,755 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,757 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=Imq1oQh1lHrfqXVv76A5LQ filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,758 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,759 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,760 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,762 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=hs7jZxgJty7jhrB3K5W1JQ filename=meta.csv bytes=15 ttl=3600s
+2026-08-20 18:15:56,764 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=igLu5XyPcBPQqocZ0EIuOg filename=meta.csv bytes=8 ttl=3600s
+2026-08-20 18:15:56,766 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=rUXGfWIAp-j4EL6GwKOn-g filename=m.csv bytes=2 ttl=0s
+2026-08-20 18:15:56,868 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=xSTJT-pRaRTYQuJlV_NMRA filename=m.csv bytes=2 ttl=3600s
+2026-08-20 18:15:56,869 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got='eve')
+2026-08-20 18:15:56,870 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got=None)
+2026-08-20 18:15:56,872 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=zkaAdBIxvlJbKtlylUCxOw filename=a bytes=1 ttl=3600s
+2026-08-20 18:15:56,873 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=DEFQz9VJnxSEo8IPOP9uQw filename=b bytes=1 ttl=3600s
+2026-08-20 18:15:56,882 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,883 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=q9OPldT-uth9LrqNNksAaw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,884 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,886 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,887 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,891 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,901 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,902 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,904 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,906 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,907 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,908 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,911 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,912 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,913 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,914 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,915 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,917 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,934 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bWOIyS5Xmh67fSqJmBv2Aw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,936 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,939 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,940 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,941 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,942 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,944 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,945 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,946 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,947 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,949 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,960 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,961 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,963 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,965 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,967 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,968 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,969 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,970 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,971 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,972 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,974 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,975 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,992 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,994 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,995 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,996 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,998 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,999 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,000 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,001 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,002 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,003 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,006 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,017 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,018 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,020 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,022 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,023 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,025 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,026 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,027 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,028 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,029 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,031 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,032 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,033 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,049 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=0vlA8-E81KijVI3q7m8lLQ filename=m.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,053 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,054 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,056 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,057 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,058 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,059 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,060 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,061 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,063 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,064 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,066 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,077 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,078 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,080 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,082 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,084 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,085 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,086 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,087 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,088 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,089 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,091 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,092 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,093 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,109 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=w8p9knDLq7tZ6fVK9bjESg filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,113 | INFO | nemo_retriever.service.services.job_tracker | Job registered: bd7492d41b31416c9322537144154ed1 (expected_documents=1, label=None)
+2026-08-20 18:15:57,118 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,121 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,122 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,124 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,125 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,126 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,127 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,128 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,129 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,131 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,132 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,135 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,146 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,147 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,149 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:57,152 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,154 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,155 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,156 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,183 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:57,185 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,186 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:57,187 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,202 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bHdpDDCmiTkW8G8l1BgErw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b3ce5cfda3574e0584d9b5860a71ca2a (expected_documents=1, label=None)
+2026-08-20 18:15:57,230 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,232 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,233 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:57,235 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,236 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,237 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,239 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,240 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,243 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,255 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,256 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,258 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,261 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,269 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,270 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,271 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,273 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,289 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 36ffaab76fad4e888bdf9e64f7fcc36a (expected_documents=1, label=None)
+2026-08-20 18:15:57,293 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,295 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,296 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,297 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,299 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,300 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,301 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,302 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,304 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,305 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,307 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,318 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,319 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,321 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,325 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,326 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,327 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,328 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,330 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,331 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,332 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,334 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,335 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,353 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=NZXwpLNpgZqNSNyPD90i9Q filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,356 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,358 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,359 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,360 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,362 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,363 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:57,364 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,365 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,367 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,368 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,388 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,624 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,627 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,629 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,630 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,632 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,633 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,634 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,636 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,637 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,638 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,640 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,655 | INFO | nemo_retriever.service.services.job_tracker | Job registered: cb13321bd9cc4a7690a99333e2ece25a (expected_documents=1, label=None)
+2026-08-20 18:15:57,659 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,664 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,665 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,666 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,667 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,668 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,670 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,671 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,672 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,674 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,677 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,687 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,689 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,691 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,694 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,695 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,696 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,697 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,699 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,700 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,701 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,703 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,704 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,706 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,722 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 12789d144cbb460fa91ab1fefc91ed95 (expected_documents=1, label=None)
+2026-08-20 18:15:57,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,729 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,732 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,734 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,736 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,737 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,739 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,740 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,743 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,753 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,755 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,756 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,759 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,761 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,762 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,763 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,765 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,766 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,767 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,768 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,770 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,771 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,787 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 8e80a281c7b34a84b05ac04a83c08865 (expected_documents=1, label=None)
+2026-08-20 18:15:57,791 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,793 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,794 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,796 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,797 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,798 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,800 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,801 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,802 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,804 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,806 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,818 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,819 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,821 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,825 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,826 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,827 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,828 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,830 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,831 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,833 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,834 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,835 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,837 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,853 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,855 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,856 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,857 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,859 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,860 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,861 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,863 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,864 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,865 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,868 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,879 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,880 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,882 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,885 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,886 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,888 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,889 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,890 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,892 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,893 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,894 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,896 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,897 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,914 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,915 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,917 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,918 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,919 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,921 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,922 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,923 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,925 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,926 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,929 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,940 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,942 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,944 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,947 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,949 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,950 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,951 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,953 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,954 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,955 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,957 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,958 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,960 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,978 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,979 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,981 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,982 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,983 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,985 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,986 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,988 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,989 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,992 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,002 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,004 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,005 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,009 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,014 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,016 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,017 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,019 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,020 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,022 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,039 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,041 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,043 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,044 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,045 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,047 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,048 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,049 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,051 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,052 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,055 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,065 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,067 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,068 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,072 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,073 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,074 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,076 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,077 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,078 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,080 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,081 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,083 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,084 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,175 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,177 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,179 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,180 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,182 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,183 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,184 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,186 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,187 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,188 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,191 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,201 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,203 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,205 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,208 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,210 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,211 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,212 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,214 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,215 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,217 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,218 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,220 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,221 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,311 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,313 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,314 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,316 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,317 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,318 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,320 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,321 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,324 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,335 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: tracer unavailable
+2026-08-20 18:15:58,337 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: span enter failed
+2026-08-20 18:15:58,341 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,346 | WARNING | nemo_retriever.service.tracing | OpenTelemetry tracing setup failed: processor install failed
+2026-08-20 18:15:58,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,352 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,355 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,358 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,369 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:58,371 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,373 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,391 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,393 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,405 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=2
+2026-08-20 18:15:58,407 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,422 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,434 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,447 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,450 | INFO | nemo_retriever.service.vectordb_app | Unsupported VDB operation: Collection retrieval mode is unsupported
+2026-08-20 18:15:58,453 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,457 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,470 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,477 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,492 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,502 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,515 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,528 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,537 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,550 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,554 | ERROR | nemo_retriever.service.vectordb_app | VectorDB retrieval contract violation
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 254, in retrieve_collection
+    raise RetrievalContractError("physical table secret must not be returned")
+nemo_retriever.common.vdb.records.RetrievalContractError: physical table secret must not be returned
+2026-08-20 18:15:58,558 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,571 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,575 | ERROR | nemo_retriever.service.vectordb_app | Unexpected VectorDB service failure
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
+    await self.app(scope, receive, _send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 193, in __call__
+    response = await self.dispatch_func(request, call_next)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 417, in require_internal_credential
+    return await call_next(request)
+           ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 168, in call_next
+    raise app_exc from app_exc.__cause__ or app_exc.__context__
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro
+    await self.app(scope, receive_or_disconnect, send_no_error)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
+    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 670, in __call__
+    await self.middleware_stack(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 2734, in app
+    await route.handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 1281, in handle
+    await super().handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 280, in handle
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 158, in app
+    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 259, in retrieve_collection
+    raise ValueError("backend parsing failed")
+ValueError: backend parsing failed
+2026-08-20 18:15:58,578 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,591 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,595 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,607 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,611 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,626 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=none max_concurrent_queries=4
+2026-08-20 18:15:58,627 | ERROR | nemo_retriever.service.vectordb_app | VectorDB started without an embedding backend; /v1/query will return HTTP 501 until --embed-endpoint or --local-embed is configured.
+2026-08-20 18:15:58,631 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,643 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,647 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,660 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,664 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,677 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,679 | ERROR | nemo_retriever.service.vectordb_app | VectorDB backend health inspection failed
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 243, in _safe_backend_health
+    health = state.vdb.health()
+             ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 264, in health
+    raise RuntimeError("backend unavailable")
+RuntimeError: backend unavailable
+2026-08-20 18:15:58,681 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,686 | INFO | nemo_retriever.service.vectordb_app | Loaded local query embedder model=nvidia/llama-nemotron-embed-1b-v2 backend=hf
+2026-08-20 18:15:58,700 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,710 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'nemo_retriever' because build_index=False.
+2026-08-20 18:15:58,725 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,772 | WARNING | nemo_retriever.service.services.work_queue | Heartbeat request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 598, in heartbeat
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,776 | WARNING | nemo_retriever.service.services.work_queue | Release request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 616, in release
+    await client.post(
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,779 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=2 queue_size=99 work_fn=work
+2026-08-20 18:15:58,781 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,839 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,840 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:58,842 | ERROR | nemo_retriever.service.services.work_queue | Failed to spool payload for work 'work' (job 'job'); rolling back admission
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 255, in enqueue
+    await asyncio.to_thread(self._write_spool, spool_path, payload)
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 855, in fail_write
+    raise OSError("injected payload fsync failure")
+OSError: injected payload fsync failure
+2026-08-20 18:15:58,845 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,849 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_upload_claim_payl0/service.log
+2026-08-20 18:15:58,851 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,853 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,858 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,859 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,861 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,889 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,891 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,893 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:58,908 | INFO | nemo_retriever.service.services.job_tracker | Job registered: aa41f4bceb1b41e0aa6cc1571e7b7303 (expected_documents=1, label=None)
+2026-08-20 18:15:58,933 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=c8b3b455e394483b9187bde445f49903 job_id=aa41f4bceb1b41e0aa6cc1571e7b7303 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:58,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,939 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:58,941 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,942 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,943 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,945 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,946 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,951 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_callback_treats_s0/service.log
+2026-08-20 18:15:58,953 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,955 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,960 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,962 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,963 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,964 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,992 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,993 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,995 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,010 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ae13dee2d4f543b6ade0f7542a4a9ca9 (expected_documents=1, label=None)
+2026-08-20 18:15:59,028 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=643920c51f4841af8f2cf54ac4985e42 job_id=ae13dee2d4f543b6ade0f7542a4a9ca9 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:59,029 | WARNING | nemo_retriever.service.routers.ingest | Work lease for 643920c51f4841af8f2cf54ac4985e42 was already superseded at acknowledge; tracker already updated
+2026-08-20 18:15:59,033 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,035 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,036 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,038 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,039 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,041 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,042 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,047 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_internal_work_endpoints_r0/service.log
+2026-08-20 18:15:59,049 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,050 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,054 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,055 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,057 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,058 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,085 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,087 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,089 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,136 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,138 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,139 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,141 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,142 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,144 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,149 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_dry_run_does_not_0/service.log
+2026-08-20 18:15:59,151 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,152 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,156 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,157 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,159 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,160 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,187 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,189 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,190 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 75e734ec8d3b435e8cae58b72a5c1307 (expected_documents=2, label=None)
+2026-08-20 18:15:59,264 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,266 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,267 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,268 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,270 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,272 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,273 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,277 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,279 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,281 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,287 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,289 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,290 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,292 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,319 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,321 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,322 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,340 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 498e74549207425b90495819b296c02b (expected_documents=1, label=None)
+2026-08-20 18:15:59,355 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,358 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,359 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,361 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,362 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,364 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,365 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,368 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,370 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,372 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,380 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,382 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,383 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,385 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,411 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,413 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,415 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,441 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,443 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,444 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,445 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,448 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,450 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,455 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,469 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,470 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,472 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,476 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,478 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,484 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,486 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,487 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:59,489 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,491 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,505 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,521 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,526 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,528 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,530 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,531 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,532 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,534 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,536 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,553 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'doc-read-error'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 310, in _get_from_filesystem
+    with candidate.open(encoding="utf-8") as stream:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_worker_callback.py", line 153, in fail_generation_read_once
+    raise OSError(errno.EIO, "I/O error")
+OSError: [Errno 5] I/O error
+2026-08-20 18:15:59,558 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'invalid'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 311, in _get_from_filesystem
+    rows = json.load(stream)
+           ^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 293, in load
+    return loads(fp.read(),
+           ^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+    return _default_decoder.decode(s)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 353, in raw_decode
+    obj, end = self.scan_once(s, idx)
+               ^^^^^^^^^^^^^^^^^^^^^^
+json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
+2026-08-20 18:15:59,562 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,567 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,578 | INFO | nemo_retriever.service.services.worker_result_store | Removed 2 expired shared result file(s) from /tmp/pytest-of-ubuntu/pytest-98/test_shared_result_store_remov0/.worker-results-v1
+2026-08-20 18:15:59,594 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,605 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,607 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,609 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,615 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,628 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,630 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,632 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,635 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,636 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,638 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=16, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,640 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=16 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,642 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=8w/2048q, batch=16w/4096q)
+2026-08-20 18:15:59,644 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,645 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,667 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,671 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 1 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,674 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 2 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,677 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 3 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,680 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 4 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,683 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 6 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,686 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 7 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,689 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 5 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,691 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 8 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,694 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 10 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,697 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 9 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,700 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 11 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,703 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 13 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,706 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 14 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,709 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 15 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,712 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 12 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,730 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,734 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,736 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,738 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,766 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,777 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,779 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,781 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,789 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,791 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,793 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,794 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,821 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,823 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,824 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,826 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,828 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job-shared (expected_documents=2, label=None)
+2026-08-20 18:15:59,857 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,859 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,860 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,863 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,865 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 2, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,867 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,868 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,872 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item doc-retry (attempt 1)
+2026-08-20 18:15:59,875 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 410 for item permanently-rejected-doc (attempt 1)
+2026-08-20 18:15:59,876 | ERROR | nemo_retriever.service.services.pipeline_pool | Gateway callback permanently rejected item permanently-rejected-doc with HTTP 410
+2026-08-20 18:15:59,880 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,891 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,893 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,895 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,904 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,906 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,907 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,936 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,938 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,939 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,941 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,943 | INFO | nemo_retriever.service.services.job_tracker | Job registered: handoff-job (expected_documents=1, label=None)
+2026-08-20 18:15:59,962 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=handoff-doc job_id=handoff-job status=completed outcome=transitioned rows=1 subscribers=0
+2026-08-20 18:15:59,967 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,969 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,970 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,972 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,973 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,975 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,976 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,978 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,982 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,995 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,997 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,999 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,008 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,040 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,042 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,044 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,045 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,047 | INFO | nemo_retriever.service.services.job_tracker | Job registered: failed-handoff-job (expected_documents=1, label=None)
+2026-08-20 18:16:00,064 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,066 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,068 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,069 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,071 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,072 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 1, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,074 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,076 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,082 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:16:00,093 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:16:00,094 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:16:00,096 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,105 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,107 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,108 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,110 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,137 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,139 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,141 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,142 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,160 | WARNING | nemo_retriever.service.routers.ingest | Permanently rejecting retained result handoff for unknown document restart-orphaned-doc
+2026-08-20 18:16:00,162 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,164 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,166 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,167 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,169 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,170 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,172 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,173 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,180 | INFO | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback succeeded for item deferred-doc
+2026-08-20 18:16:00,184 | ERROR | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback permanently failed for item restart-orphaned-doc; result remains unacknowledged
+2026-08-20 18:16:00,196 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item retry-after-doc (attempt 1)
+2026-08-20 18:16:01,436 | INFO | nemo_retriever.graph.ingestor_runtime | Selected OCR engine: v2 (OCRActor)
+2026-08-20 18:16:01,694 | WARNING | nemo_retriever.common.api.util.exception_handlers.pdf | PDF Processing:boom error:x
+2026-08-20 18:16:01,960 | WARNING | nemo_retriever.operators.extract.txt.ray_data | Failed to split text source 'bad.txt'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/extract/txt/ray_data.py", line 113, in process
+    chunk_df = txt_bytes_to_chunks_df(bytes(raw), path_str, params=params)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_tokenizer_provider.py", line 165, in split_document
+    raise ValueError("malformed document")
+ValueError: malformed document
+2026-08-20 18:16:02,032 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 3 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,040 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 12 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,048 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 4 frame rows -> 2 (max_dropped_frames=2)
+2026-08-20 18:16:02,056 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 2 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,117 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['missing']
+2026-08-20 18:16:02,121 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['nope']
+2026-08-20 18:16:02,132 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 2 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,136 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 1 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,140 | ERROR | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: failed to POST to https://hook.example.com/ingest
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/graph_ops/webhook_operator.py", line 123, in process
+    response = session.post(url, json=records, timeout=timeout)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1134, in __call__
+    return self._mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
+    raise effect
+ConnectionError: boom

--- a/retriever-service.log.3
+++ b/retriever-service.log.3
@@ -1,0 +1,2404 @@
+2026-08-20 18:15:55,170 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=3, label=None)
+2026-08-20 18:15:55,178 | INFO | nemo_retriever.service.services.job_tracker | Job registered: a (expected_documents=1, label=None)
+2026-08-20 18:15:55,185 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b (expected_documents=1, label=None)
+2026-08-20 18:15:55,187 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,189 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,201 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,203 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,205 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 2 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,247 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_service_start_mounts_mcp_0/service.log
+2026-08-20 18:15:55,257 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,259 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,260 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,262 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,267 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,269 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,270 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,272 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,296 | INFO | mcp.server.streamable_http_manager | Created new transport with session ID: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,298 | INFO | mcp.server.streamable_http | Terminating session: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,299 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,300 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,301 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,302 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,303 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,304 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,305 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,306 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,307 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,308 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,316 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,327 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,328 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,329 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,332 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,333 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,334 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,335 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,336 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,337 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,338 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,339 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,340 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,341 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,357 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ac445a69cfc74efc8126f535d699c19d (expected_documents=1, label=None)
+2026-08-20 18:15:55,362 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,363 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,364 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,365 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,366 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,367 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,368 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,369 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,370 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,371 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,373 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,384 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,385 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,386 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,389 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,390 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,391 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,392 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,393 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,394 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,395 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,396 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,397 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,398 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,415 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 58ac7310db284e8487ac4132eff5558f (expected_documents=1, label=None)
+2026-08-20 18:15:55,419 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,421 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,422 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,423 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,424 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,425 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,426 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,427 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,428 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,429 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,431 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,441 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,442 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,444 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,446 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,448 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,449 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,450 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,452 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,453 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,454 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,455 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,456 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,472 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 98348a991fe14684bd72baa3464fa231 (expected_documents=1, label=None)
+2026-08-20 18:15:55,476 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,477 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,478 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,480 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,481 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,482 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,483 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,484 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,485 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,486 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,489 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,500 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,502 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,503 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,506 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,507 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,508 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,509 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,511 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,512 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,513 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,514 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,516 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,517 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,532 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 982ba7b1c898422f9bcfd0d6c15ce711 (expected_documents=1, label=None)
+2026-08-20 18:15:55,537 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,539 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,540 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,541 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,542 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,543 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,544 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,545 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,547 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,548 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,550 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,560 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,562 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,563 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,565 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,567 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,568 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,569 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,570 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,571 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,572 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,573 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,575 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,576 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,591 | INFO | nemo_retriever.service.services.job_tracker | Job registered: fae3557728a941de97f5ffc0e1c8e820 (expected_documents=1, label=None)
+2026-08-20 18:15:55,594 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:55,597 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,599 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,600 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:55,601 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,602 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,603 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,604 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,605 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,606 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,607 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,610 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,623 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,626 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,627 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,628 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,629 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,630 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,631 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,632 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,633 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,635 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,636 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,651 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 678895b4c35942f19b6a2d617d600d62 (expected_documents=1, label=None)
+2026-08-20 18:15:55,656 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,657 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,658 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,660 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,662 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,663 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,664 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,665 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,666 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,669 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,672 | INFO | nemo_retriever.service.app | Media dependencies (ffmpeg, ffprobe) detected — audio/video ingestion enabled (mode=batch)
+2026-08-20 18:15:55,674 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,677 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:55,678 | WARNING | nemo_retriever.service.services.job_tracker | JobTracker.mark_failed: no record of document 'unknown' — callback dropped (likely gateway-pod restart between upload acceptance and worker callback); client may hang waiting for an SSE event that will never arrive
+2026-08-20 18:15:55,680 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,682 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,685 | WARNING | nemo_retriever.service.metrics_otel | OpenTelemetry metrics setup failed: OpenTelemetry metrics SDK/exporter packages are not importable
+2026-08-20 18:15:55,698 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,709 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,710 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,711 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,714 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,715 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,716 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,717 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,744 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,746 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,747 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,748 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,844 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,846 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,847 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:55,848 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,849 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,850 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,851 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,852 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,856 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,866 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,867 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,869 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,872 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,873 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,874 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,875 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,902 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,903 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,904 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,905 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,999 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,001 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,002 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:56,003 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,004 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,005 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,006 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,007 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,116 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for report.pdf — HTTP 200
+2026-08-20 18:15:56,118 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for document.pdf — HTTP 200
+2026-08-20 18:15:56,120 | ERROR | nemo_retriever.service.services.pipeline_executor | Failed to POST 1 records to vectordb for gamma.txt: timed out
+2026-08-20 18:15:56,122 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for gamma.txt — HTTP 200
+2026-08-20 18:15:56,125 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=parent-test
+2026-08-20 18:15:56,128 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context extraction failed for pipeline execution: bad carrier
+2026-08-20 18:15:56,131 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Realtime): extract=_Params, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:56,132 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context capture failed for pipeline execution: inject failed
+2026-08-20 18:15:56,134 | INFO | nemo_retriever.service.services.pipeline_executor | Realtime pipeline completed: id=item-1 file=contract.pdf rows=1 elapsed=0.01s
+2026-08-20 18:15:56,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,137 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' started: workers=3 queue_size=17 work_fn=noop
+2026-08-20 18:15:56,139 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' shut down (processed=0)
+2026-08-20 18:15:56,158 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' started: workers=1 queue_size=4 work_fn=slow_work
+2026-08-20 18:15:56,262 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' shut down (processed=4)
+2026-08-20 18:15:56,264 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' started: workers=2 queue_size=16 work_fn=work
+2026-08-20 18:15:56,320 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' shut down (processed=3)
+2026-08-20 18:15:56,322 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' started: workers=1 queue_size=4 work_fn=boom
+2026-08-20 18:15:56,324 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-0
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,326 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-1
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,346 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' shut down (processed=0)
+2026-08-20 18:15:56,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:56,351 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,402 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' shut down (processed=1)
+2026-08-20 18:15:56,404 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,406 | WARNING | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' trace context extraction failed for item doc-1; continuing without parent context: propagator unavailable
+2026-08-20 18:15:56,407 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' shut down (processed=1)
+2026-08-20 18:15:56,409 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,412 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,415 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,417 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,420 | WARNING | nemo_retriever.service.services.proxy | Gateway forwarding empty body to batch http://batch.test/v1/ingest/sidecar/sidecar-id — the body-cache middleware may not have run
+2026-08-20 18:15:56,444 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_main_0/service.log
+2026-08-20 18:15:56,454 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,456 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,457 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,460 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,461 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,462 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,463 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,464 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,466 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,467 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,468 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,469 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,470 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,488 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,489 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,491 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,492 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,493 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,494 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,495 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,496 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,497 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,498 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,503 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_defaults_r0/service.log
+2026-08-20 18:15:56,513 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,514 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,515 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,518 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,519 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,520 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,521 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,523 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,524 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,525 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,526 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,527 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,528 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,544 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,546 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,547 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,548 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,549 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,550 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,551 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,552 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,553 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,554 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,559 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_requires_m0/service.log
+2026-08-20 18:15:56,570 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,571 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,573 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,575 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,577 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,578 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,579 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,580 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,581 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,582 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,583 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,585 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,586 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,601 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,603 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,604 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,605 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,606 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,607 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,608 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,609 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,611 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,612 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,616 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_lazy_0/service.log
+2026-08-20 18:15:56,626 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,627 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,629 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,632 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,633 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,635 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,636 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,637 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,638 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,639 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,640 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,641 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,643 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,659 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,660 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,663 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,664 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,665 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,666 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,667 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,668 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,669 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,674 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_false_rerank_string_uses_0/service.log
+2026-08-20 18:15:56,685 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,686 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,688 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,691 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,692 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,693 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,694 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,695 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,697 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,698 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,699 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,700 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,701 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,717 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,718 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,720 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,721 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,722 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,723 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,724 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,725 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,727 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,728 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,751 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: persistent result failure
+2026-08-20 18:15:56,753 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: Server error '500 Internal Server Error' for url 'http://example:7670/v1/ingest/status/doc-a'
+For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+2026-08-20 18:15:56,755 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,757 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=Imq1oQh1lHrfqXVv76A5LQ filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,758 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,759 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,760 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,762 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=hs7jZxgJty7jhrB3K5W1JQ filename=meta.csv bytes=15 ttl=3600s
+2026-08-20 18:15:56,764 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=igLu5XyPcBPQqocZ0EIuOg filename=meta.csv bytes=8 ttl=3600s
+2026-08-20 18:15:56,766 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=rUXGfWIAp-j4EL6GwKOn-g filename=m.csv bytes=2 ttl=0s
+2026-08-20 18:15:56,868 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=xSTJT-pRaRTYQuJlV_NMRA filename=m.csv bytes=2 ttl=3600s
+2026-08-20 18:15:56,869 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got='eve')
+2026-08-20 18:15:56,870 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got=None)
+2026-08-20 18:15:56,872 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=zkaAdBIxvlJbKtlylUCxOw filename=a bytes=1 ttl=3600s
+2026-08-20 18:15:56,873 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=DEFQz9VJnxSEo8IPOP9uQw filename=b bytes=1 ttl=3600s
+2026-08-20 18:15:56,882 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,883 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=q9OPldT-uth9LrqNNksAaw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,884 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,886 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,887 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,891 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,901 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,902 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,904 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,906 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,907 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,908 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,911 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,912 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,913 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,914 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,915 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,917 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,934 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bWOIyS5Xmh67fSqJmBv2Aw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,936 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,939 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,940 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,941 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,942 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,944 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,945 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,946 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,947 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,949 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,960 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,961 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,963 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,965 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,967 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,968 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,969 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,970 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,971 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,972 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,974 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,975 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,992 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,994 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,995 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,996 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,998 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,999 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,000 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,001 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,002 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,003 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,006 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,017 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,018 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,020 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,022 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,023 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,025 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,026 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,027 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,028 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,029 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,031 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,032 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,033 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,049 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=0vlA8-E81KijVI3q7m8lLQ filename=m.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,053 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,054 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,056 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,057 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,058 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,059 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,060 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,061 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,063 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,064 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,066 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,077 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,078 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,080 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,082 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,084 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,085 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,086 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,087 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,088 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,089 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,091 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,092 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,093 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,109 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=w8p9knDLq7tZ6fVK9bjESg filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,113 | INFO | nemo_retriever.service.services.job_tracker | Job registered: bd7492d41b31416c9322537144154ed1 (expected_documents=1, label=None)
+2026-08-20 18:15:57,118 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,121 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,122 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,124 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,125 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,126 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,127 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,128 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,129 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,131 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,132 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,135 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,146 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,147 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,149 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:57,152 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,154 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,155 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,156 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,183 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:57,185 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,186 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:57,187 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,202 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bHdpDDCmiTkW8G8l1BgErw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b3ce5cfda3574e0584d9b5860a71ca2a (expected_documents=1, label=None)
+2026-08-20 18:15:57,230 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,232 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,233 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:57,235 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,236 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,237 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,239 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,240 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,243 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,255 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,256 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,258 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,261 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,269 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,270 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,271 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,273 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,289 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 36ffaab76fad4e888bdf9e64f7fcc36a (expected_documents=1, label=None)
+2026-08-20 18:15:57,293 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,295 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,296 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,297 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,299 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,300 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,301 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,302 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,304 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,305 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,307 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,318 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,319 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,321 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,325 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,326 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,327 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,328 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,330 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,331 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,332 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,334 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,335 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,353 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=NZXwpLNpgZqNSNyPD90i9Q filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,356 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,358 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,359 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,360 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,362 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,363 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:57,364 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,365 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,367 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,368 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,388 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,624 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,627 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,629 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,630 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,632 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,633 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,634 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,636 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,637 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,638 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,640 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,655 | INFO | nemo_retriever.service.services.job_tracker | Job registered: cb13321bd9cc4a7690a99333e2ece25a (expected_documents=1, label=None)
+2026-08-20 18:15:57,659 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,664 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,665 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,666 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,667 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,668 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,670 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,671 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,672 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,674 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,677 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,687 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,689 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,691 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,694 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,695 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,696 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,697 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,699 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,700 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,701 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,703 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,704 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,706 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,722 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 12789d144cbb460fa91ab1fefc91ed95 (expected_documents=1, label=None)
+2026-08-20 18:15:57,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,729 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,732 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,734 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,736 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,737 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,739 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,740 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,743 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,753 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,755 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,756 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,759 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,761 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,762 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,763 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,765 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,766 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,767 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,768 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,770 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,771 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,787 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 8e80a281c7b34a84b05ac04a83c08865 (expected_documents=1, label=None)
+2026-08-20 18:15:57,791 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,793 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,794 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,796 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,797 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,798 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,800 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,801 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,802 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,804 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,806 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,818 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,819 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,821 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,825 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,826 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,827 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,828 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,830 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,831 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,833 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,834 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,835 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,837 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,853 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,855 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,856 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,857 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,859 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,860 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,861 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,863 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,864 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,865 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,868 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,879 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,880 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,882 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,885 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,886 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,888 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,889 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,890 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,892 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,893 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,894 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,896 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,897 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,914 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,915 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,917 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,918 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,919 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,921 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,922 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,923 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,925 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,926 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,929 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,940 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,942 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,944 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,947 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,949 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,950 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,951 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,953 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,954 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,955 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,957 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,958 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,960 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,978 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,979 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,981 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,982 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,983 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,985 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,986 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,988 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,989 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,992 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,002 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,004 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,005 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,009 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,014 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,016 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,017 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,019 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,020 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,022 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,039 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,041 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,043 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,044 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,045 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,047 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,048 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,049 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,051 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,052 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,055 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,065 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,067 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,068 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,072 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,073 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,074 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,076 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,077 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,078 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,080 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,081 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,083 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,084 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,175 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,177 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,179 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,180 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,182 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,183 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,184 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,186 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,187 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,188 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,191 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,201 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,203 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,205 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,208 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,210 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,211 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,212 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,214 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,215 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,217 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,218 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,220 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,221 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,311 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,313 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,314 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,316 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,317 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,318 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,320 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,321 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,324 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,335 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: tracer unavailable
+2026-08-20 18:15:58,337 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: span enter failed
+2026-08-20 18:15:58,341 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,346 | WARNING | nemo_retriever.service.tracing | OpenTelemetry tracing setup failed: processor install failed
+2026-08-20 18:15:58,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,352 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,355 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,358 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,369 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:58,371 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,373 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,391 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,393 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,405 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=2
+2026-08-20 18:15:58,407 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,422 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,434 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,447 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,450 | INFO | nemo_retriever.service.vectordb_app | Unsupported VDB operation: Collection retrieval mode is unsupported
+2026-08-20 18:15:58,453 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,457 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,470 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,477 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,492 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,502 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,515 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,528 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,537 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,550 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,554 | ERROR | nemo_retriever.service.vectordb_app | VectorDB retrieval contract violation
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 254, in retrieve_collection
+    raise RetrievalContractError("physical table secret must not be returned")
+nemo_retriever.common.vdb.records.RetrievalContractError: physical table secret must not be returned
+2026-08-20 18:15:58,558 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,571 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,575 | ERROR | nemo_retriever.service.vectordb_app | Unexpected VectorDB service failure
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
+    await self.app(scope, receive, _send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 193, in __call__
+    response = await self.dispatch_func(request, call_next)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 417, in require_internal_credential
+    return await call_next(request)
+           ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 168, in call_next
+    raise app_exc from app_exc.__cause__ or app_exc.__context__
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro
+    await self.app(scope, receive_or_disconnect, send_no_error)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
+    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 670, in __call__
+    await self.middleware_stack(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 2734, in app
+    await route.handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 1281, in handle
+    await super().handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 280, in handle
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 158, in app
+    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 259, in retrieve_collection
+    raise ValueError("backend parsing failed")
+ValueError: backend parsing failed
+2026-08-20 18:15:58,578 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,591 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,595 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,607 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,611 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,626 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=none max_concurrent_queries=4
+2026-08-20 18:15:58,627 | ERROR | nemo_retriever.service.vectordb_app | VectorDB started without an embedding backend; /v1/query will return HTTP 501 until --embed-endpoint or --local-embed is configured.
+2026-08-20 18:15:58,631 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,643 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,647 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,660 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,664 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,677 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,679 | ERROR | nemo_retriever.service.vectordb_app | VectorDB backend health inspection failed
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 243, in _safe_backend_health
+    health = state.vdb.health()
+             ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 264, in health
+    raise RuntimeError("backend unavailable")
+RuntimeError: backend unavailable
+2026-08-20 18:15:58,681 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,686 | INFO | nemo_retriever.service.vectordb_app | Loaded local query embedder model=nvidia/llama-nemotron-embed-1b-v2 backend=hf
+2026-08-20 18:15:58,700 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,710 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'nemo_retriever' because build_index=False.
+2026-08-20 18:15:58,725 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,772 | WARNING | nemo_retriever.service.services.work_queue | Heartbeat request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 598, in heartbeat
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,776 | WARNING | nemo_retriever.service.services.work_queue | Release request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 616, in release
+    await client.post(
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,779 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=2 queue_size=99 work_fn=work
+2026-08-20 18:15:58,781 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,839 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,840 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:58,842 | ERROR | nemo_retriever.service.services.work_queue | Failed to spool payload for work 'work' (job 'job'); rolling back admission
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 255, in enqueue
+    await asyncio.to_thread(self._write_spool, spool_path, payload)
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 855, in fail_write
+    raise OSError("injected payload fsync failure")
+OSError: injected payload fsync failure
+2026-08-20 18:15:58,845 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,849 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_upload_claim_payl0/service.log
+2026-08-20 18:15:58,851 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,853 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,858 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,859 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,861 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,889 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,891 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,893 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:58,908 | INFO | nemo_retriever.service.services.job_tracker | Job registered: aa41f4bceb1b41e0aa6cc1571e7b7303 (expected_documents=1, label=None)
+2026-08-20 18:15:58,933 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=c8b3b455e394483b9187bde445f49903 job_id=aa41f4bceb1b41e0aa6cc1571e7b7303 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:58,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,939 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:58,941 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,942 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,943 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,945 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,946 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,951 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_callback_treats_s0/service.log
+2026-08-20 18:15:58,953 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,955 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,960 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,962 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,963 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,964 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,992 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,993 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,995 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,010 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ae13dee2d4f543b6ade0f7542a4a9ca9 (expected_documents=1, label=None)
+2026-08-20 18:15:59,028 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=643920c51f4841af8f2cf54ac4985e42 job_id=ae13dee2d4f543b6ade0f7542a4a9ca9 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:59,029 | WARNING | nemo_retriever.service.routers.ingest | Work lease for 643920c51f4841af8f2cf54ac4985e42 was already superseded at acknowledge; tracker already updated
+2026-08-20 18:15:59,033 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,035 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,036 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,038 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,039 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,041 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,042 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,047 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_internal_work_endpoints_r0/service.log
+2026-08-20 18:15:59,049 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,050 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,054 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,055 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,057 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,058 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,085 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,087 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,089 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,136 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,138 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,139 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,141 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,142 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,144 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,149 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_dry_run_does_not_0/service.log
+2026-08-20 18:15:59,151 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,152 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,156 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,157 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,159 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,160 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,187 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,189 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,190 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 75e734ec8d3b435e8cae58b72a5c1307 (expected_documents=2, label=None)
+2026-08-20 18:15:59,264 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,266 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,267 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,268 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,270 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,272 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,273 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,277 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,279 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,281 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,287 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,289 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,290 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,292 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,319 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,321 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,322 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,340 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 498e74549207425b90495819b296c02b (expected_documents=1, label=None)
+2026-08-20 18:15:59,355 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,358 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,359 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,361 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,362 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,364 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,365 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,368 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,370 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,372 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,380 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,382 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,383 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,385 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,411 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,413 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,415 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,441 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,443 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,444 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,445 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,448 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,450 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,455 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,469 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,470 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,472 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,476 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,478 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,484 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,486 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,487 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:59,489 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,491 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,505 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,521 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,526 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,528 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,530 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,531 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,532 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,534 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,536 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,553 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'doc-read-error'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 310, in _get_from_filesystem
+    with candidate.open(encoding="utf-8") as stream:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_worker_callback.py", line 153, in fail_generation_read_once
+    raise OSError(errno.EIO, "I/O error")
+OSError: [Errno 5] I/O error
+2026-08-20 18:15:59,558 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'invalid'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 311, in _get_from_filesystem
+    rows = json.load(stream)
+           ^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 293, in load
+    return loads(fp.read(),
+           ^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+    return _default_decoder.decode(s)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 353, in raw_decode
+    obj, end = self.scan_once(s, idx)
+               ^^^^^^^^^^^^^^^^^^^^^^
+json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
+2026-08-20 18:15:59,562 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,567 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,578 | INFO | nemo_retriever.service.services.worker_result_store | Removed 2 expired shared result file(s) from /tmp/pytest-of-ubuntu/pytest-98/test_shared_result_store_remov0/.worker-results-v1
+2026-08-20 18:15:59,594 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,605 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,607 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,609 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,615 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,628 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,630 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,632 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,635 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,636 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,638 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=16, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,640 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=16 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,642 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=8w/2048q, batch=16w/4096q)
+2026-08-20 18:15:59,644 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,645 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,667 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,671 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 1 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,674 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 2 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,677 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 3 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,680 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 4 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,683 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 6 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,686 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 7 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,689 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 5 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,691 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 8 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,694 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 10 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,697 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 9 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,700 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 11 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,703 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 13 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,706 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 14 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,709 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 15 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,712 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 12 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,730 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,734 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,736 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,738 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,766 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,777 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,779 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,781 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,789 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,791 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,793 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,794 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,821 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,823 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,824 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,826 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,828 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job-shared (expected_documents=2, label=None)
+2026-08-20 18:15:59,857 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,859 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,860 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,863 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,865 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 2, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,867 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,868 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,872 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item doc-retry (attempt 1)
+2026-08-20 18:15:59,875 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 410 for item permanently-rejected-doc (attempt 1)
+2026-08-20 18:15:59,876 | ERROR | nemo_retriever.service.services.pipeline_pool | Gateway callback permanently rejected item permanently-rejected-doc with HTTP 410
+2026-08-20 18:15:59,880 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,891 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,893 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,895 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,904 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,906 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,907 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,936 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,938 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,939 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,941 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,943 | INFO | nemo_retriever.service.services.job_tracker | Job registered: handoff-job (expected_documents=1, label=None)
+2026-08-20 18:15:59,962 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=handoff-doc job_id=handoff-job status=completed outcome=transitioned rows=1 subscribers=0
+2026-08-20 18:15:59,967 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,969 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,970 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,972 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,973 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,975 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,976 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,978 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,982 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,995 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,997 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,999 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,008 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,040 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,042 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,044 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,045 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,047 | INFO | nemo_retriever.service.services.job_tracker | Job registered: failed-handoff-job (expected_documents=1, label=None)
+2026-08-20 18:16:00,064 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,066 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,068 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,069 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,071 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,072 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 1, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,074 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,076 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,082 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:16:00,093 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:16:00,094 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:16:00,096 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,105 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,107 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,108 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,110 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,137 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,139 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,141 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,142 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,160 | WARNING | nemo_retriever.service.routers.ingest | Permanently rejecting retained result handoff for unknown document restart-orphaned-doc
+2026-08-20 18:16:00,162 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,164 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,166 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,167 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,169 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,170 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,172 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,173 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,180 | INFO | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback succeeded for item deferred-doc
+2026-08-20 18:16:00,184 | ERROR | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback permanently failed for item restart-orphaned-doc; result remains unacknowledged
+2026-08-20 18:16:00,196 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item retry-after-doc (attempt 1)
+2026-08-20 18:16:01,436 | INFO | nemo_retriever.graph.ingestor_runtime | Selected OCR engine: v2 (OCRActor)
+2026-08-20 18:16:01,694 | WARNING | nemo_retriever.common.api.util.exception_handlers.pdf | PDF Processing:boom error:x
+2026-08-20 18:16:01,960 | WARNING | nemo_retriever.operators.extract.txt.ray_data | Failed to split text source 'bad.txt'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/extract/txt/ray_data.py", line 113, in process
+    chunk_df = txt_bytes_to_chunks_df(bytes(raw), path_str, params=params)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_tokenizer_provider.py", line 165, in split_document
+    raise ValueError("malformed document")
+ValueError: malformed document
+2026-08-20 18:16:02,032 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 3 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,040 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 12 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,048 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 4 frame rows -> 2 (max_dropped_frames=2)
+2026-08-20 18:16:02,056 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 2 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,117 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['missing']
+2026-08-20 18:16:02,121 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['nope']
+2026-08-20 18:16:02,132 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 2 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,136 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 1 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,140 | ERROR | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: failed to POST to https://hook.example.com/ingest
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/graph_ops/webhook_operator.py", line 123, in process
+    response = session.post(url, json=records, timeout=timeout)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1134, in __call__
+    return self._mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
+    raise effect
+ConnectionError: boom

--- a/retriever-service.log.4
+++ b/retriever-service.log.4
@@ -1,0 +1,2404 @@
+2026-08-20 18:15:55,170 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=3, label=None)
+2026-08-20 18:15:55,178 | INFO | nemo_retriever.service.services.job_tracker | Job registered: a (expected_documents=1, label=None)
+2026-08-20 18:15:55,185 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b (expected_documents=1, label=None)
+2026-08-20 18:15:55,187 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,189 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,201 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,203 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,205 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 2 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,247 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_service_start_mounts_mcp_0/service.log
+2026-08-20 18:15:55,257 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,259 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,260 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,262 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,267 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,269 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,270 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,272 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,296 | INFO | mcp.server.streamable_http_manager | Created new transport with session ID: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,298 | INFO | mcp.server.streamable_http | Terminating session: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,299 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,300 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,301 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,302 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,303 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,304 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,305 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,306 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,307 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,308 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,316 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,327 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,328 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,329 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,332 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,333 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,334 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,335 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,336 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,337 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,338 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,339 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,340 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,341 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,357 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ac445a69cfc74efc8126f535d699c19d (expected_documents=1, label=None)
+2026-08-20 18:15:55,362 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,363 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,364 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,365 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,366 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,367 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,368 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,369 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,370 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,371 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,373 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,384 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,385 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,386 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,389 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,390 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,391 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,392 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,393 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,394 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,395 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,396 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,397 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,398 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,415 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 58ac7310db284e8487ac4132eff5558f (expected_documents=1, label=None)
+2026-08-20 18:15:55,419 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,421 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,422 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,423 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,424 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,425 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,426 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,427 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,428 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,429 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,431 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,441 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,442 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,444 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,446 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,448 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,449 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,450 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,452 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,453 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,454 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,455 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,456 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,472 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 98348a991fe14684bd72baa3464fa231 (expected_documents=1, label=None)
+2026-08-20 18:15:55,476 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,477 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,478 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,480 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,481 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,482 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,483 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,484 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,485 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,486 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,489 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,500 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,502 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,503 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,506 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,507 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,508 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,509 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,511 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,512 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,513 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,514 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,516 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,517 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,532 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 982ba7b1c898422f9bcfd0d6c15ce711 (expected_documents=1, label=None)
+2026-08-20 18:15:55,537 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,539 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,540 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,541 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,542 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,543 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,544 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,545 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,547 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,548 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,550 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,560 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,562 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,563 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,565 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,567 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,568 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,569 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,570 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,571 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,572 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,573 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,575 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,576 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,591 | INFO | nemo_retriever.service.services.job_tracker | Job registered: fae3557728a941de97f5ffc0e1c8e820 (expected_documents=1, label=None)
+2026-08-20 18:15:55,594 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:55,597 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,599 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,600 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:55,601 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,602 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,603 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,604 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,605 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,606 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,607 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,610 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,623 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,626 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,627 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,628 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,629 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,630 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,631 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,632 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,633 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,635 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,636 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,651 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 678895b4c35942f19b6a2d617d600d62 (expected_documents=1, label=None)
+2026-08-20 18:15:55,656 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,657 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,658 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,660 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,662 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,663 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,664 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,665 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,666 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,669 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,672 | INFO | nemo_retriever.service.app | Media dependencies (ffmpeg, ffprobe) detected — audio/video ingestion enabled (mode=batch)
+2026-08-20 18:15:55,674 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,677 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:55,678 | WARNING | nemo_retriever.service.services.job_tracker | JobTracker.mark_failed: no record of document 'unknown' — callback dropped (likely gateway-pod restart between upload acceptance and worker callback); client may hang waiting for an SSE event that will never arrive
+2026-08-20 18:15:55,680 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,682 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,685 | WARNING | nemo_retriever.service.metrics_otel | OpenTelemetry metrics setup failed: OpenTelemetry metrics SDK/exporter packages are not importable
+2026-08-20 18:15:55,698 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,709 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,710 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,711 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,714 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,715 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,716 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,717 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,744 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,746 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,747 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,748 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,844 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,846 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,847 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:55,848 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,849 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,850 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,851 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,852 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,856 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,866 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,867 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,869 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,872 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,873 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,874 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,875 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,902 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,903 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,904 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,905 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,999 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,001 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,002 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:56,003 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,004 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,005 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,006 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,007 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,116 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for report.pdf — HTTP 200
+2026-08-20 18:15:56,118 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for document.pdf — HTTP 200
+2026-08-20 18:15:56,120 | ERROR | nemo_retriever.service.services.pipeline_executor | Failed to POST 1 records to vectordb for gamma.txt: timed out
+2026-08-20 18:15:56,122 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for gamma.txt — HTTP 200
+2026-08-20 18:15:56,125 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=parent-test
+2026-08-20 18:15:56,128 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context extraction failed for pipeline execution: bad carrier
+2026-08-20 18:15:56,131 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Realtime): extract=_Params, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:56,132 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context capture failed for pipeline execution: inject failed
+2026-08-20 18:15:56,134 | INFO | nemo_retriever.service.services.pipeline_executor | Realtime pipeline completed: id=item-1 file=contract.pdf rows=1 elapsed=0.01s
+2026-08-20 18:15:56,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,137 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' started: workers=3 queue_size=17 work_fn=noop
+2026-08-20 18:15:56,139 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' shut down (processed=0)
+2026-08-20 18:15:56,158 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' started: workers=1 queue_size=4 work_fn=slow_work
+2026-08-20 18:15:56,262 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' shut down (processed=4)
+2026-08-20 18:15:56,264 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' started: workers=2 queue_size=16 work_fn=work
+2026-08-20 18:15:56,320 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' shut down (processed=3)
+2026-08-20 18:15:56,322 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' started: workers=1 queue_size=4 work_fn=boom
+2026-08-20 18:15:56,324 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-0
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,326 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-1
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,346 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' shut down (processed=0)
+2026-08-20 18:15:56,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:56,351 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,402 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' shut down (processed=1)
+2026-08-20 18:15:56,404 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,406 | WARNING | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' trace context extraction failed for item doc-1; continuing without parent context: propagator unavailable
+2026-08-20 18:15:56,407 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' shut down (processed=1)
+2026-08-20 18:15:56,409 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,412 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,415 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,417 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,420 | WARNING | nemo_retriever.service.services.proxy | Gateway forwarding empty body to batch http://batch.test/v1/ingest/sidecar/sidecar-id — the body-cache middleware may not have run
+2026-08-20 18:15:56,444 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_main_0/service.log
+2026-08-20 18:15:56,454 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,456 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,457 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,460 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,461 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,462 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,463 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,464 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,466 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,467 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,468 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,469 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,470 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,488 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,489 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,491 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,492 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,493 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,494 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,495 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,496 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,497 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,498 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,503 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_defaults_r0/service.log
+2026-08-20 18:15:56,513 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,514 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,515 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,518 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,519 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,520 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,521 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,523 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,524 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,525 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,526 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,527 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,528 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,544 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,546 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,547 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,548 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,549 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,550 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,551 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,552 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,553 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,554 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,559 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_requires_m0/service.log
+2026-08-20 18:15:56,570 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,571 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,573 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,575 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,577 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,578 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,579 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,580 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,581 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,582 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,583 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,585 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,586 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,601 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,603 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,604 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,605 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,606 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,607 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,608 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,609 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,611 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,612 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,616 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_lazy_0/service.log
+2026-08-20 18:15:56,626 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,627 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,629 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,632 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,633 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,635 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,636 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,637 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,638 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,639 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,640 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,641 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,643 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,659 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,660 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,663 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,664 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,665 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,666 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,667 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,668 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,669 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,674 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_false_rerank_string_uses_0/service.log
+2026-08-20 18:15:56,685 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,686 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,688 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,691 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,692 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,693 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,694 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,695 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,697 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,698 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,699 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,700 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,701 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,717 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,718 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,720 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,721 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,722 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,723 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,724 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,725 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,727 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,728 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,751 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: persistent result failure
+2026-08-20 18:15:56,753 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: Server error '500 Internal Server Error' for url 'http://example:7670/v1/ingest/status/doc-a'
+For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+2026-08-20 18:15:56,755 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,757 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=Imq1oQh1lHrfqXVv76A5LQ filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,758 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,759 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,760 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,762 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=hs7jZxgJty7jhrB3K5W1JQ filename=meta.csv bytes=15 ttl=3600s
+2026-08-20 18:15:56,764 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=igLu5XyPcBPQqocZ0EIuOg filename=meta.csv bytes=8 ttl=3600s
+2026-08-20 18:15:56,766 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=rUXGfWIAp-j4EL6GwKOn-g filename=m.csv bytes=2 ttl=0s
+2026-08-20 18:15:56,868 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=xSTJT-pRaRTYQuJlV_NMRA filename=m.csv bytes=2 ttl=3600s
+2026-08-20 18:15:56,869 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got='eve')
+2026-08-20 18:15:56,870 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got=None)
+2026-08-20 18:15:56,872 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=zkaAdBIxvlJbKtlylUCxOw filename=a bytes=1 ttl=3600s
+2026-08-20 18:15:56,873 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=DEFQz9VJnxSEo8IPOP9uQw filename=b bytes=1 ttl=3600s
+2026-08-20 18:15:56,882 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,883 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=q9OPldT-uth9LrqNNksAaw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,884 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,886 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,887 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,891 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,901 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,902 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,904 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,906 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,907 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,908 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,911 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,912 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,913 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,914 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,915 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,917 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,934 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bWOIyS5Xmh67fSqJmBv2Aw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,936 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,939 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,940 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,941 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,942 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,944 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,945 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,946 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,947 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,949 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,960 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,961 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,963 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,965 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,967 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,968 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,969 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,970 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,971 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,972 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,974 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,975 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,992 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,994 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,995 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,996 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,998 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,999 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,000 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,001 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,002 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,003 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,006 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,017 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,018 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,020 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,022 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,023 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,025 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,026 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,027 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,028 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,029 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,031 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,032 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,033 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,049 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=0vlA8-E81KijVI3q7m8lLQ filename=m.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,053 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,054 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,056 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,057 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,058 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,059 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,060 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,061 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,063 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,064 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,066 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,077 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,078 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,080 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,082 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,084 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,085 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,086 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,087 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,088 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,089 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,091 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,092 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,093 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,109 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=w8p9knDLq7tZ6fVK9bjESg filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,113 | INFO | nemo_retriever.service.services.job_tracker | Job registered: bd7492d41b31416c9322537144154ed1 (expected_documents=1, label=None)
+2026-08-20 18:15:57,118 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,121 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,122 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,124 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,125 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,126 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,127 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,128 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,129 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,131 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,132 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,135 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,146 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,147 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,149 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:57,152 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,154 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,155 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,156 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,183 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:57,185 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,186 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:57,187 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,202 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bHdpDDCmiTkW8G8l1BgErw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b3ce5cfda3574e0584d9b5860a71ca2a (expected_documents=1, label=None)
+2026-08-20 18:15:57,230 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,232 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,233 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:57,235 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,236 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,237 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,239 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,240 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,243 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,255 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,256 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,258 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,261 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,269 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,270 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,271 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,273 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,289 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 36ffaab76fad4e888bdf9e64f7fcc36a (expected_documents=1, label=None)
+2026-08-20 18:15:57,293 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,295 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,296 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,297 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,299 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,300 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,301 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,302 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,304 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,305 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,307 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,318 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,319 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,321 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,325 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,326 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,327 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,328 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,330 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,331 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,332 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,334 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,335 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,353 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=NZXwpLNpgZqNSNyPD90i9Q filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,356 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,358 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,359 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,360 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,362 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,363 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:57,364 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,365 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,367 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,368 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,388 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,624 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,627 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,629 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,630 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,632 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,633 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,634 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,636 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,637 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,638 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,640 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,655 | INFO | nemo_retriever.service.services.job_tracker | Job registered: cb13321bd9cc4a7690a99333e2ece25a (expected_documents=1, label=None)
+2026-08-20 18:15:57,659 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,664 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,665 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,666 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,667 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,668 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,670 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,671 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,672 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,674 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,677 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,687 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,689 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,691 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,694 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,695 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,696 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,697 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,699 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,700 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,701 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,703 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,704 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,706 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,722 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 12789d144cbb460fa91ab1fefc91ed95 (expected_documents=1, label=None)
+2026-08-20 18:15:57,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,729 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,732 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,734 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,736 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,737 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,739 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,740 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,743 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,753 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,755 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,756 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,759 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,761 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,762 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,763 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,765 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,766 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,767 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,768 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,770 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,771 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,787 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 8e80a281c7b34a84b05ac04a83c08865 (expected_documents=1, label=None)
+2026-08-20 18:15:57,791 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,793 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,794 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,796 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,797 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,798 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,800 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,801 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,802 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,804 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,806 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,818 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,819 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,821 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,825 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,826 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,827 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,828 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,830 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,831 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,833 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,834 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,835 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,837 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,853 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,855 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,856 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,857 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,859 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,860 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,861 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,863 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,864 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,865 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,868 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,879 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,880 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,882 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,885 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,886 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,888 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,889 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,890 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,892 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,893 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,894 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,896 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,897 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,914 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,915 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,917 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,918 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,919 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,921 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,922 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,923 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,925 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,926 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,929 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,940 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,942 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,944 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,947 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,949 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,950 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,951 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,953 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,954 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,955 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,957 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,958 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,960 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,978 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,979 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,981 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,982 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,983 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,985 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,986 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,988 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,989 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,992 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,002 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,004 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,005 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,009 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,014 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,016 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,017 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,019 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,020 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,022 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,039 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,041 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,043 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,044 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,045 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,047 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,048 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,049 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,051 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,052 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,055 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,065 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,067 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,068 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,072 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,073 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,074 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,076 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,077 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,078 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,080 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,081 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,083 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,084 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,175 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,177 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,179 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,180 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,182 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,183 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,184 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,186 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,187 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,188 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,191 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,201 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,203 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,205 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,208 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,210 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,211 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,212 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,214 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,215 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,217 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,218 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,220 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,221 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,311 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,313 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,314 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,316 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,317 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,318 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,320 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,321 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,324 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,335 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: tracer unavailable
+2026-08-20 18:15:58,337 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: span enter failed
+2026-08-20 18:15:58,341 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,346 | WARNING | nemo_retriever.service.tracing | OpenTelemetry tracing setup failed: processor install failed
+2026-08-20 18:15:58,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,352 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,355 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,358 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,369 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:58,371 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,373 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,391 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,393 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,405 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=2
+2026-08-20 18:15:58,407 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,422 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,434 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,447 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,450 | INFO | nemo_retriever.service.vectordb_app | Unsupported VDB operation: Collection retrieval mode is unsupported
+2026-08-20 18:15:58,453 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,457 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,470 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,477 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,492 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,502 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,515 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,528 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,537 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,550 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,554 | ERROR | nemo_retriever.service.vectordb_app | VectorDB retrieval contract violation
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 254, in retrieve_collection
+    raise RetrievalContractError("physical table secret must not be returned")
+nemo_retriever.common.vdb.records.RetrievalContractError: physical table secret must not be returned
+2026-08-20 18:15:58,558 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,571 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,575 | ERROR | nemo_retriever.service.vectordb_app | Unexpected VectorDB service failure
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
+    await self.app(scope, receive, _send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 193, in __call__
+    response = await self.dispatch_func(request, call_next)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 417, in require_internal_credential
+    return await call_next(request)
+           ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 168, in call_next
+    raise app_exc from app_exc.__cause__ or app_exc.__context__
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro
+    await self.app(scope, receive_or_disconnect, send_no_error)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
+    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 670, in __call__
+    await self.middleware_stack(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 2734, in app
+    await route.handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 1281, in handle
+    await super().handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 280, in handle
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 158, in app
+    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 259, in retrieve_collection
+    raise ValueError("backend parsing failed")
+ValueError: backend parsing failed
+2026-08-20 18:15:58,578 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,591 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,595 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,607 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,611 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,626 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=none max_concurrent_queries=4
+2026-08-20 18:15:58,627 | ERROR | nemo_retriever.service.vectordb_app | VectorDB started without an embedding backend; /v1/query will return HTTP 501 until --embed-endpoint or --local-embed is configured.
+2026-08-20 18:15:58,631 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,643 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,647 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,660 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,664 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,677 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,679 | ERROR | nemo_retriever.service.vectordb_app | VectorDB backend health inspection failed
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 243, in _safe_backend_health
+    health = state.vdb.health()
+             ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 264, in health
+    raise RuntimeError("backend unavailable")
+RuntimeError: backend unavailable
+2026-08-20 18:15:58,681 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,686 | INFO | nemo_retriever.service.vectordb_app | Loaded local query embedder model=nvidia/llama-nemotron-embed-1b-v2 backend=hf
+2026-08-20 18:15:58,700 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,710 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'nemo_retriever' because build_index=False.
+2026-08-20 18:15:58,725 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,772 | WARNING | nemo_retriever.service.services.work_queue | Heartbeat request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 598, in heartbeat
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,776 | WARNING | nemo_retriever.service.services.work_queue | Release request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 616, in release
+    await client.post(
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,779 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=2 queue_size=99 work_fn=work
+2026-08-20 18:15:58,781 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,839 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,840 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:58,842 | ERROR | nemo_retriever.service.services.work_queue | Failed to spool payload for work 'work' (job 'job'); rolling back admission
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 255, in enqueue
+    await asyncio.to_thread(self._write_spool, spool_path, payload)
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 855, in fail_write
+    raise OSError("injected payload fsync failure")
+OSError: injected payload fsync failure
+2026-08-20 18:15:58,845 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,849 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_upload_claim_payl0/service.log
+2026-08-20 18:15:58,851 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,853 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,858 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,859 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,861 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,889 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,891 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,893 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:58,908 | INFO | nemo_retriever.service.services.job_tracker | Job registered: aa41f4bceb1b41e0aa6cc1571e7b7303 (expected_documents=1, label=None)
+2026-08-20 18:15:58,933 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=c8b3b455e394483b9187bde445f49903 job_id=aa41f4bceb1b41e0aa6cc1571e7b7303 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:58,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,939 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:58,941 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,942 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,943 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,945 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,946 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,951 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_callback_treats_s0/service.log
+2026-08-20 18:15:58,953 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,955 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,960 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,962 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,963 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,964 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,992 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,993 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,995 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,010 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ae13dee2d4f543b6ade0f7542a4a9ca9 (expected_documents=1, label=None)
+2026-08-20 18:15:59,028 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=643920c51f4841af8f2cf54ac4985e42 job_id=ae13dee2d4f543b6ade0f7542a4a9ca9 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:59,029 | WARNING | nemo_retriever.service.routers.ingest | Work lease for 643920c51f4841af8f2cf54ac4985e42 was already superseded at acknowledge; tracker already updated
+2026-08-20 18:15:59,033 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,035 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,036 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,038 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,039 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,041 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,042 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,047 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_internal_work_endpoints_r0/service.log
+2026-08-20 18:15:59,049 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,050 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,054 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,055 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,057 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,058 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,085 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,087 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,089 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,136 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,138 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,139 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,141 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,142 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,144 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,149 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_dry_run_does_not_0/service.log
+2026-08-20 18:15:59,151 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,152 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,156 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,157 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,159 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,160 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,187 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,189 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,190 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 75e734ec8d3b435e8cae58b72a5c1307 (expected_documents=2, label=None)
+2026-08-20 18:15:59,264 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,266 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,267 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,268 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,270 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,272 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,273 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,277 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,279 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,281 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,287 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,289 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,290 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,292 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,319 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,321 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,322 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,340 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 498e74549207425b90495819b296c02b (expected_documents=1, label=None)
+2026-08-20 18:15:59,355 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,358 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,359 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,361 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,362 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,364 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,365 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,368 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,370 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,372 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,380 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,382 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,383 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,385 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,411 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,413 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,415 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,441 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,443 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,444 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,445 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,448 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,450 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,455 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,469 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,470 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,472 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,476 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,478 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,484 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,486 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,487 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:59,489 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,491 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,505 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,521 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,526 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,528 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,530 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,531 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,532 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,534 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,536 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,553 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'doc-read-error'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 310, in _get_from_filesystem
+    with candidate.open(encoding="utf-8") as stream:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_worker_callback.py", line 153, in fail_generation_read_once
+    raise OSError(errno.EIO, "I/O error")
+OSError: [Errno 5] I/O error
+2026-08-20 18:15:59,558 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'invalid'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 311, in _get_from_filesystem
+    rows = json.load(stream)
+           ^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 293, in load
+    return loads(fp.read(),
+           ^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+    return _default_decoder.decode(s)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 353, in raw_decode
+    obj, end = self.scan_once(s, idx)
+               ^^^^^^^^^^^^^^^^^^^^^^
+json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
+2026-08-20 18:15:59,562 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,567 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,578 | INFO | nemo_retriever.service.services.worker_result_store | Removed 2 expired shared result file(s) from /tmp/pytest-of-ubuntu/pytest-98/test_shared_result_store_remov0/.worker-results-v1
+2026-08-20 18:15:59,594 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,605 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,607 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,609 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,615 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,628 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,630 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,632 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,635 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,636 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,638 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=16, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,640 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=16 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,642 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=8w/2048q, batch=16w/4096q)
+2026-08-20 18:15:59,644 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,645 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,667 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,671 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 1 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,674 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 2 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,677 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 3 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,680 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 4 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,683 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 6 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,686 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 7 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,689 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 5 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,691 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 8 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,694 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 10 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,697 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 9 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,700 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 11 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,703 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 13 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,706 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 14 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,709 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 15 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,712 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 12 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,730 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,734 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,736 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,738 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,766 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,777 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,779 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,781 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,789 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,791 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,793 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,794 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,821 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,823 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,824 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,826 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,828 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job-shared (expected_documents=2, label=None)
+2026-08-20 18:15:59,857 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,859 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,860 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,863 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,865 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 2, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,867 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,868 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,872 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item doc-retry (attempt 1)
+2026-08-20 18:15:59,875 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 410 for item permanently-rejected-doc (attempt 1)
+2026-08-20 18:15:59,876 | ERROR | nemo_retriever.service.services.pipeline_pool | Gateway callback permanently rejected item permanently-rejected-doc with HTTP 410
+2026-08-20 18:15:59,880 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,891 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,893 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,895 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,904 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,906 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,907 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,936 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,938 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,939 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,941 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,943 | INFO | nemo_retriever.service.services.job_tracker | Job registered: handoff-job (expected_documents=1, label=None)
+2026-08-20 18:15:59,962 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=handoff-doc job_id=handoff-job status=completed outcome=transitioned rows=1 subscribers=0
+2026-08-20 18:15:59,967 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,969 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,970 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,972 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,973 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,975 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,976 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,978 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,982 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,995 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,997 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,999 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,008 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,040 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,042 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,044 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,045 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,047 | INFO | nemo_retriever.service.services.job_tracker | Job registered: failed-handoff-job (expected_documents=1, label=None)
+2026-08-20 18:16:00,064 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,066 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,068 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,069 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,071 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,072 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 1, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,074 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,076 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,082 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:16:00,093 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:16:00,094 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:16:00,096 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,105 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,107 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,108 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,110 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,137 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,139 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,141 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,142 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,160 | WARNING | nemo_retriever.service.routers.ingest | Permanently rejecting retained result handoff for unknown document restart-orphaned-doc
+2026-08-20 18:16:00,162 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,164 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,166 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,167 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,169 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,170 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,172 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,173 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,180 | INFO | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback succeeded for item deferred-doc
+2026-08-20 18:16:00,184 | ERROR | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback permanently failed for item restart-orphaned-doc; result remains unacknowledged
+2026-08-20 18:16:00,196 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item retry-after-doc (attempt 1)
+2026-08-20 18:16:01,436 | INFO | nemo_retriever.graph.ingestor_runtime | Selected OCR engine: v2 (OCRActor)
+2026-08-20 18:16:01,694 | WARNING | nemo_retriever.common.api.util.exception_handlers.pdf | PDF Processing:boom error:x
+2026-08-20 18:16:01,960 | WARNING | nemo_retriever.operators.extract.txt.ray_data | Failed to split text source 'bad.txt'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/extract/txt/ray_data.py", line 113, in process
+    chunk_df = txt_bytes_to_chunks_df(bytes(raw), path_str, params=params)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_tokenizer_provider.py", line 165, in split_document
+    raise ValueError("malformed document")
+ValueError: malformed document
+2026-08-20 18:16:02,032 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 3 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,040 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 12 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,048 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 4 frame rows -> 2 (max_dropped_frames=2)
+2026-08-20 18:16:02,056 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 2 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,117 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['missing']
+2026-08-20 18:16:02,121 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['nope']
+2026-08-20 18:16:02,132 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 2 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,136 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 1 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,140 | ERROR | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: failed to POST to https://hook.example.com/ingest
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/graph_ops/webhook_operator.py", line 123, in process
+    response = session.post(url, json=records, timeout=timeout)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1134, in __call__
+    return self._mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
+    raise effect
+ConnectionError: boom

--- a/retriever-service.log.5
+++ b/retriever-service.log.5
@@ -1,0 +1,2404 @@
+2026-08-20 18:15:55,170 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=3, label=None)
+2026-08-20 18:15:55,178 | INFO | nemo_retriever.service.services.job_tracker | Job registered: a (expected_documents=1, label=None)
+2026-08-20 18:15:55,185 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b (expected_documents=1, label=None)
+2026-08-20 18:15:55,187 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,189 | INFO | nemo_retriever.service.services.job_tracker | Job registered: j (expected_documents=1, label=None)
+2026-08-20 18:15:55,201 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,203 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 1 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,205 | WARNING | nemo_retriever.service.config | local_models.enabled: capping pipeline workers to 2 per pool (was realtime=8 batch=16). Raise local_models.max_process_pool_workers only if GPU memory allows num_workers × model stack.
+2026-08-20 18:15:55,247 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_service_start_mounts_mcp_0/service.log
+2026-08-20 18:15:55,257 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,259 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,260 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,262 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,267 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,269 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,270 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,272 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,296 | INFO | mcp.server.streamable_http_manager | Created new transport with session ID: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,298 | INFO | mcp.server.streamable_http | Terminating session: 1f468b5c61ee4d77913994b791b9085e
+2026-08-20 18:15:55,299 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,300 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,301 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,302 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,303 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,304 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,305 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,306 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,307 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,308 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,316 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,327 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,328 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,329 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,332 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,333 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,334 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,335 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,336 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,337 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,338 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,339 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,340 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,341 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,357 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ac445a69cfc74efc8126f535d699c19d (expected_documents=1, label=None)
+2026-08-20 18:15:55,362 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,363 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,364 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,365 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,366 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,367 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,368 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,369 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,370 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,371 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,373 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,384 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,385 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,386 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,389 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,390 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,391 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,392 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,393 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,394 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,395 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,396 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,397 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,398 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,415 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 58ac7310db284e8487ac4132eff5558f (expected_documents=1, label=None)
+2026-08-20 18:15:55,419 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,421 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,422 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,423 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,424 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,425 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,426 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,427 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,428 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,429 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,431 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,441 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,442 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,444 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,446 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,448 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,449 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,450 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,452 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,453 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,454 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,455 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,456 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,472 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 98348a991fe14684bd72baa3464fa231 (expected_documents=1, label=None)
+2026-08-20 18:15:55,476 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,477 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,478 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,480 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,481 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,482 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,483 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,484 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,485 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,486 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,489 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,500 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,502 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,503 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,506 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,507 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,508 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,509 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,511 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,512 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,513 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,514 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,516 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,517 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,532 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 982ba7b1c898422f9bcfd0d6c15ce711 (expected_documents=1, label=None)
+2026-08-20 18:15:55,537 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,539 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,540 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,541 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,542 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,543 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,544 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,545 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,547 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,548 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,550 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,560 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,562 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,563 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,565 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,567 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,568 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,569 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,570 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,571 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,572 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,573 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,575 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,576 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,591 | INFO | nemo_retriever.service.services.job_tracker | Job registered: fae3557728a941de97f5ffc0e1c8e820 (expected_documents=1, label=None)
+2026-08-20 18:15:55,594 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:55,597 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,599 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,600 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:55,601 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,602 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,603 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,604 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,605 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,606 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,607 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,610 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:55,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,623 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:55,626 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,627 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,628 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,629 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,630 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:55,631 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:55,632 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:55,633 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,635 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:55,636 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,651 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 678895b4c35942f19b6a2d617d600d62 (expected_documents=1, label=None)
+2026-08-20 18:15:55,656 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,657 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,658 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:55,660 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:55,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:55,662 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,663 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,664 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,665 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,666 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,669 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg, ffprobe. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,672 | INFO | nemo_retriever.service.app | Media dependencies (ffmpeg, ffprobe) detected — audio/video ingestion enabled (mode=batch)
+2026-08-20 18:15:55,674 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,677 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:55,678 | WARNING | nemo_retriever.service.services.job_tracker | JobTracker.mark_failed: no record of document 'unknown' — callback dropped (likely gateway-pod restart between upload acceptance and worker callback); client may hang waiting for an SSE event that will never arrive
+2026-08-20 18:15:55,680 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,682 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=2, label=None)
+2026-08-20 18:15:55,685 | WARNING | nemo_retriever.service.metrics_otel | OpenTelemetry metrics setup failed: OpenTelemetry metrics SDK/exporter packages are not importable
+2026-08-20 18:15:55,698 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,709 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,710 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,711 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,714 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,715 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,716 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,717 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,744 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,746 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,747 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,748 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,844 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:55,846 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:55,847 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:55,848 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:55,849 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:55,850 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:55,851 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:55,852 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:55,856 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:55,866 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:55,867 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:55,869 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:55,872 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:55,873 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:55,874 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:55,875 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:55,902 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:55,903 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:55,904 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:55,905 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:55,999 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,001 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,002 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:56,003 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,004 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,005 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,006 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,007 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,116 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for report.pdf — HTTP 200
+2026-08-20 18:15:56,118 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for document.pdf — HTTP 200
+2026-08-20 18:15:56,120 | ERROR | nemo_retriever.service.services.pipeline_executor | Failed to POST 1 records to vectordb for gamma.txt: timed out
+2026-08-20 18:15:56,122 | INFO | nemo_retriever.service.services.pipeline_executor | Posted 1 records to vectordb for gamma.txt — HTTP 200
+2026-08-20 18:15:56,125 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=parent-test
+2026-08-20 18:15:56,128 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context extraction failed for pipeline execution: bad carrier
+2026-08-20 18:15:56,131 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Realtime): extract=_Params, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:56,132 | WARNING | nemo_retriever.service.services.pipeline_executor | OpenTelemetry trace context capture failed for pipeline execution: inject failed
+2026-08-20 18:15:56,134 | INFO | nemo_retriever.service.services.pipeline_executor | Realtime pipeline completed: id=item-1 file=contract.pdf rows=1 elapsed=0.01s
+2026-08-20 18:15:56,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,137 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' started: workers=3 queue_size=17 work_fn=noop
+2026-08-20 18:15:56,139 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-cap' shut down (processed=0)
+2026-08-20 18:15:56,158 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' started: workers=1 queue_size=4 work_fn=slow_work
+2026-08-20 18:15:56,262 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-depth' shut down (processed=4)
+2026-08-20 18:15:56,264 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' started: workers=2 queue_size=16 work_fn=work
+2026-08-20 18:15:56,320 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-obs' shut down (processed=3)
+2026-08-20 18:15:56,322 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' started: workers=1 queue_size=4 work_fn=boom
+2026-08-20 18:15:56,324 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-0
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,326 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' worker 0 failed on item fail-1
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 561, in _worker_loop
+    result = await result
+             ^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_pool_metrics.py", line 168, in boom
+    raise RuntimeError("oops")
+RuntimeError: oops
+2026-08-20 18:15:56,346 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-fail' shut down (processed=0)
+2026-08-20 18:15:56,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:56,351 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,402 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace' shut down (processed=1)
+2026-08-20 18:15:56,404 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' started: workers=1 queue_size=4 work_fn=work
+2026-08-20 18:15:56,406 | WARNING | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' trace context extraction failed for item doc-1; continuing without parent context: propagator unavailable
+2026-08-20 18:15:56,407 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'rt-trace-fallback' shut down (processed=1)
+2026-08-20 18:15:56,409 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,412 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=gateway
+2026-08-20 18:15:56,415 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,417 | WARNING | nemo_retriever.service.services.proxy | Skipping outbound trace context injection after tracing failure: propagator unavailable
+2026-08-20 18:15:56,420 | WARNING | nemo_retriever.service.services.proxy | Gateway forwarding empty body to batch http://batch.test/v1/ingest/sidecar/sidecar-id — the body-cache middleware may not have run
+2026-08-20 18:15:56,444 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_main_0/service.log
+2026-08-20 18:15:56,454 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,456 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,457 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,460 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,461 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,462 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,463 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,464 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,466 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,467 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,468 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,469 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,470 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,488 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,489 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,491 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,492 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,493 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,494 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,495 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,496 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,497 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,498 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,503 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_defaults_r0/service.log
+2026-08-20 18:15:56,513 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,514 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,515 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,518 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,519 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,520 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,521 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,523 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,524 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,525 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,526 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,527 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,528 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,544 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,546 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,547 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,548 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,549 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,550 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,551 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,552 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,553 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,554 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,559 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_requires_m0/service.log
+2026-08-20 18:15:56,570 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,571 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,573 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,575 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,577 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,578 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,579 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,580 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,581 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,582 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,583 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,585 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,586 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,601 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,603 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,604 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,605 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,606 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,607 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,608 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,609 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,611 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,612 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,616 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_reranked_query_uses_lazy_0/service.log
+2026-08-20 18:15:56,626 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,627 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,629 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,632 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,633 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,635 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,636 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,637 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,638 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,639 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,640 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,641 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,643 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,659 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,660 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,661 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,663 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,664 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,665 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,666 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,667 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,668 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,669 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,674 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_false_rerank_string_uses_0/service.log
+2026-08-20 18:15:56,685 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,686 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,688 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,691 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,692 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,693 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,694 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,695 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,697 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,698 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,699 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,700 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,701 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,717 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,718 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,720 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,721 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,722 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,723 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,724 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,725 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,727 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,728 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,751 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: persistent result failure
+2026-08-20 18:15:56,753 | WARNING | nemo_retriever.service.service_ingestor | return_results: failed to fetch/persist doc-a: Server error '500 Internal Server Error' for url 'http://example:7670/v1/ingest/status/doc-a'
+For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+2026-08-20 18:15:56,755 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,757 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=Imq1oQh1lHrfqXVv76A5LQ filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,758 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,759 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,760 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,762 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=hs7jZxgJty7jhrB3K5W1JQ filename=meta.csv bytes=15 ttl=3600s
+2026-08-20 18:15:56,764 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=igLu5XyPcBPQqocZ0EIuOg filename=meta.csv bytes=8 ttl=3600s
+2026-08-20 18:15:56,766 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=rUXGfWIAp-j4EL6GwKOn-g filename=m.csv bytes=2 ttl=0s
+2026-08-20 18:15:56,868 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=xSTJT-pRaRTYQuJlV_NMRA filename=m.csv bytes=2 ttl=3600s
+2026-08-20 18:15:56,869 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got='eve')
+2026-08-20 18:15:56,870 | WARNING | nemo_retriever.service.services.sidecar_store | SidecarStore: sidecar_id=xSTJT-pRaRTYQuJlV_NMRA owner mismatch (expected='alice' got=None)
+2026-08-20 18:15:56,872 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=zkaAdBIxvlJbKtlylUCxOw filename=a bytes=1 ttl=3600s
+2026-08-20 18:15:56,873 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=DEFQz9VJnxSEo8IPOP9uQw filename=b bytes=1 ttl=3600s
+2026-08-20 18:15:56,882 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,883 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=q9OPldT-uth9LrqNNksAaw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,884 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,886 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,887 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:56,891 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,901 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,902 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,904 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,906 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,907 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,908 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,911 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,912 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,913 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,914 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,915 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,917 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,934 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bWOIyS5Xmh67fSqJmBv2Aw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:56,936 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,939 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,940 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,941 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,942 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:56,944 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:56,945 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:56,946 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:56,947 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:56,949 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:56,960 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:56,961 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:56,963 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:56,965 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:56,967 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:56,968 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:56,969 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:56,970 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:56,971 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:56,972 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:56,974 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:56,975 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:56,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:56,992 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:56,994 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:56,995 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:56,996 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:56,998 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:56,999 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,000 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,001 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,002 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,003 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,006 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,017 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,018 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,020 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,022 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,023 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,025 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,026 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,027 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,028 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,029 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,031 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,032 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,033 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,049 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=0vlA8-E81KijVI3q7m8lLQ filename=m.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,053 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,054 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,056 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,057 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,058 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,059 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,060 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,061 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,063 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,064 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,066 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,077 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,078 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,080 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,082 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,084 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,085 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,086 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,087 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,088 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,089 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,091 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,092 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,093 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,109 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=w8p9knDLq7tZ6fVK9bjESg filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,113 | INFO | nemo_retriever.service.services.job_tracker | Job registered: bd7492d41b31416c9322537144154ed1 (expected_documents=1, label=None)
+2026-08-20 18:15:57,118 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,121 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,122 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,124 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,125 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,126 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,127 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,128 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,129 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,131 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,132 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,135 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,146 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,147 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,149 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:57,152 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,154 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,155 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,156 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,183 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:57,185 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,186 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:57,187 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,202 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=bHdpDDCmiTkW8G8l1BgErw filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: b3ce5cfda3574e0584d9b5860a71ca2a (expected_documents=1, label=None)
+2026-08-20 18:15:57,230 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,232 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,233 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:57,235 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,236 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,237 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,239 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,240 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,243 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,255 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,256 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,258 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,261 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,263 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,264 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,265 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,266 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,268 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,269 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,270 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,271 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,273 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,289 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 36ffaab76fad4e888bdf9e64f7fcc36a (expected_documents=1, label=None)
+2026-08-20 18:15:57,293 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,295 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,296 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,297 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,299 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,300 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,301 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,302 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,304 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,305 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,307 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,318 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,319 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,321 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,325 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,326 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,327 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,328 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,330 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,331 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,332 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,334 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,335 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,353 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore: stored sidecar_id=NZXwpLNpgZqNSNyPD90i9Q filename=meta.csv bytes=37 ttl=3600s
+2026-08-20 18:15:57,356 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,358 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,359 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,360 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,362 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,363 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=1 bytes=37)
+2026-08-20 18:15:57,364 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,365 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,367 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,368 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,388 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,621 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,622 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,624 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,627 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,629 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,630 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,632 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,633 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,634 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,636 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,637 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,638 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,640 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,655 | INFO | nemo_retriever.service.services.job_tracker | Job registered: cb13321bd9cc4a7690a99333e2ece25a (expected_documents=1, label=None)
+2026-08-20 18:15:57,659 | WARNING | nemo_retriever.service.routers.ingest | Could not determine PDF page count; defaulting to 1 page: Failed to load document (PDFium: Data format error).
+2026-08-20 18:15:57,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,664 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,665 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=1)
+2026-08-20 18:15:57,666 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,667 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,668 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,670 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,671 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,672 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,674 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,677 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,687 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,689 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,691 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,694 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,695 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,696 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,697 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,699 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,700 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,701 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,703 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,704 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,706 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,722 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 12789d144cbb460fa91ab1fefc91ed95 (expected_documents=1, label=None)
+2026-08-20 18:15:57,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,729 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,732 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,734 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,736 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,737 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,739 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,740 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,743 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,753 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,755 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,756 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,759 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,761 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,762 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,763 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,765 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,766 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,767 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,768 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,770 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,771 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,787 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 8e80a281c7b34a84b05ac04a83c08865 (expected_documents=1, label=None)
+2026-08-20 18:15:57,791 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,793 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,794 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,796 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,797 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,798 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,800 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,801 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,802 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,804 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,806 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,818 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,819 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,821 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,825 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,826 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,827 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,828 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,830 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,831 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,833 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,834 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,835 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,837 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,853 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,855 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,856 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,857 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,859 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,860 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,861 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,863 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,864 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,865 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,868 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,879 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,880 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,882 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,885 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,886 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,888 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,889 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,890 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,892 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,893 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,894 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,896 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,897 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,914 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,915 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,917 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,918 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,919 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,921 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,922 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,923 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,925 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,926 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,929 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:57,940 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:57,942 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:57,944 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:57,947 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:57,949 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:57,950 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:57,951 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:57,953 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:57,954 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:57,955 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:57,957 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:57,958 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:57,960 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:57,976 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:57,978 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:57,979 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:57,981 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:57,982 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:57,983 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:57,985 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:57,986 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:57,988 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:57,989 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:57,992 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,002 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,004 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,005 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,009 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,014 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,016 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,017 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,019 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,020 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,022 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,039 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,041 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,043 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,044 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,045 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,047 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,048 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,049 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,051 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,052 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,055 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,065 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,067 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,068 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,072 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,073 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,074 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,076 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,077 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,078 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,080 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,081 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,083 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,084 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,175 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,177 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,179 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,180 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,182 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,183 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,184 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,186 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,187 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,188 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,191 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:58,201 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,203 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,205 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=standalone)
+2026-08-20 18:15:58,208 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,210 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,211 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,212 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,214 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' started: workers=1 queue_size=2048 work_fn=_stub_work
+2026-08-20 18:15:58,215 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_stub_work
+2026-08-20 18:15:58,217 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=standalone, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:58,218 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=standalone). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,220 | INFO | nemo_retriever.service.app | Retriever service started — mode=standalone host=0.0.0.0 port=7670
+2026-08-20 18:15:58,221 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:58,311 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:58,313 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,314 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'realtime' shut down (processed=0)
+2026-08-20 18:15:58,316 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,317 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:58,318 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,320 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,321 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,323 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,324 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,335 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: tracer unavailable
+2026-08-20 18:15:58,337 | WARNING | nemo_retriever.service.tracing | OpenTelemetry span setup failed: span enter failed
+2026-08-20 18:15:58,341 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,346 | WARNING | nemo_retriever.service.tracing | OpenTelemetry tracing setup failed: processor install failed
+2026-08-20 18:15:58,349 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,352 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,355 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,358 | INFO | nemo_retriever.service.tracing | OpenTelemetry tracing configured: service=nemo-retriever-service role=standalone
+2026-08-20 18:15:58,369 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:58,371 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:58,373 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,391 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,393 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,405 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=2
+2026-08-20 18:15:58,407 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,422 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,434 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,447 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,450 | INFO | nemo_retriever.service.vectordb_app | Unsupported VDB operation: Collection retrieval mode is unsupported
+2026-08-20 18:15:58,453 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,457 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,470 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,477 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,492 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,502 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'legacy' because build_index=False.
+2026-08-20 18:15:58,515 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,528 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,537 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,550 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,554 | ERROR | nemo_retriever.service.vectordb_app | VectorDB retrieval contract violation
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 254, in retrieve_collection
+    raise RetrievalContractError("physical table secret must not be returned")
+nemo_retriever.common.vdb.records.RetrievalContractError: physical table secret must not be returned
+2026-08-20 18:15:58,558 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,571 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,575 | ERROR | nemo_retriever.service.vectordb_app | Unexpected VectorDB service failure
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
+    await self.app(scope, receive, _send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 193, in __call__
+    response = await self.dispatch_func(request, call_next)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 417, in require_internal_credential
+    return await call_next(request)
+           ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 168, in call_next
+    raise app_exc from app_exc.__cause__ or app_exc.__context__
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro
+    await self.app(scope, receive_or_disconnect, send_no_error)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
+    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 670, in __call__
+    await self.middleware_stack(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 2734, in app
+    await route.handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 1281, in handle
+    await super().handle(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/routing.py", line 280, in handle
+    await self.app(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 158, in app
+    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
+    await app(scope, receive, sender)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 144, in app
+    response = await f(request)
+               ^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 706, in app
+    raw_response = await run_endpoint_function(
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/fastapi/routing.py", line 352, in run_endpoint_function
+    return await dependant.call(**values)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 705, in query
+    result = await asyncio.to_thread(
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/abstract_operator.py", line 34, in run
+    data = self.process(data, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/vdb.py", line 272, in process
+    result = self._vdb.retrieve_collection(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 259, in retrieve_collection
+    raise ValueError("backend parsing failed")
+ValueError: backend parsing failed
+2026-08-20 18:15:58,578 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,591 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,595 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,607 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,611 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,626 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=none max_concurrent_queries=4
+2026-08-20 18:15:58,627 | ERROR | nemo_retriever.service.vectordb_app | VectorDB started without an embedding backend; /v1/query will return HTTP 501 until --embed-endpoint or --local-embed is configured.
+2026-08-20 18:15:58,631 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,643 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,647 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,660 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,664 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,677 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,679 | ERROR | nemo_retriever.service.vectordb_app | VectorDB backend health inspection failed
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/vectordb_app.py", line 243, in _safe_backend_health
+    health = state.vdb.health()
+             ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_vectordb_app.py", line 264, in health
+    raise RuntimeError("backend unavailable")
+RuntimeError: backend unavailable
+2026-08-20 18:15:58,681 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,686 | INFO | nemo_retriever.service.vectordb_app | Loaded local query embedder model=nvidia/llama-nemotron-embed-1b-v2 backend=hf
+2026-08-20 18:15:58,700 | INFO | nemo_retriever.service.vectordb_app | VectorDB service started: embed_mode=remote max_concurrent_queries=4
+2026-08-20 18:15:58,710 | INFO | nemo_retriever.common.vdb.lancedb | Skipping LanceDB index creation for table 'nemo_retriever' because build_index=False.
+2026-08-20 18:15:58,725 | INFO | nemo_retriever.service.vectordb_app | VectorDB service stopped
+2026-08-20 18:15:58,772 | WARNING | nemo_retriever.service.services.work_queue | Heartbeat request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 598, in heartbeat
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,776 | WARNING | nemo_retriever.service.services.work_queue | Release request failed for work work
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 616, in release
+    await client.post(
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 336, in post
+    raise httpx.ConnectError("injected heartbeat failure")
+httpx.ConnectError: injected heartbeat failure
+2026-08-20 18:15:58,779 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=2 queue_size=99 work_fn=work
+2026-08-20 18:15:58,781 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:58,839 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,840 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job (expected_documents=1, label=None)
+2026-08-20 18:15:58,842 | ERROR | nemo_retriever.service.services.work_queue | Failed to spool payload for work 'work' (job 'job'); rolling back admission
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 255, in enqueue
+    await asyncio.to_thread(self._write_spool, spool_path, payload)
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_work_queue.py", line 855, in fail_write
+    raise OSError("injected payload fsync failure")
+OSError: injected payload fsync failure
+2026-08-20 18:15:58,845 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,849 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_upload_claim_payl0/service.log
+2026-08-20 18:15:58,851 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,853 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,858 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,859 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,861 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,889 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,891 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,893 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:58,908 | INFO | nemo_retriever.service.services.job_tracker | Job registered: aa41f4bceb1b41e0aa6cc1571e7b7303 (expected_documents=1, label=None)
+2026-08-20 18:15:58,933 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=c8b3b455e394483b9187bde445f49903 job_id=aa41f4bceb1b41e0aa6cc1571e7b7303 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:58,938 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:58,939 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:58,941 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:58,942 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:58,943 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:58,945 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:58,946 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:58,951 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_callback_treats_s0/service.log
+2026-08-20 18:15:58,953 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:58,955 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:58,960 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:58,962 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:58,963 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:58,964 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:58,992 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:58,993 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:58,995 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,010 | INFO | nemo_retriever.service.services.job_tracker | Job registered: ae13dee2d4f543b6ade0f7542a4a9ca9 (expected_documents=1, label=None)
+2026-08-20 18:15:59,028 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=643920c51f4841af8f2cf54ac4985e42 job_id=ae13dee2d4f543b6ade0f7542a4a9ca9 status=completed outcome=transitioned rows=0 subscribers=0
+2026-08-20 18:15:59,029 | WARNING | nemo_retriever.service.routers.ingest | Work lease for 643920c51f4841af8f2cf54ac4985e42 was already superseded at acknowledge; tracker already updated
+2026-08-20 18:15:59,033 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,035 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,036 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,038 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,039 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,041 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,042 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,047 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_internal_work_endpoints_r0/service.log
+2026-08-20 18:15:59,049 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=True, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,050 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,054 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,055 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,057 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,058 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,085 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,087 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,089 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,135 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,136 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,138 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,139 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,141 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,142 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,144 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,149 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_dry_run_does_not_0/service.log
+2026-08-20 18:15:59,151 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,152 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,156 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,157 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,159 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,160 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,187 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,189 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,190 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,206 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 75e734ec8d3b435e8cae58b72a5c1307 (expected_documents=2, label=None)
+2026-08-20 18:15:59,264 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,266 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,267 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,268 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,270 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 0, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,272 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,273 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,277 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,279 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,281 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,287 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,289 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,290 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,292 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,319 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,321 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,322 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,340 | INFO | nemo_retriever.service.services.job_tracker | Job registered: 498e74549207425b90495819b296c02b (expected_documents=1, label=None)
+2026-08-20 18:15:59,355 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,358 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,359 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,361 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,362 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 1, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,364 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,365 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,368 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=/tmp/pytest-of-ubuntu/pytest-98/test_gateway_restart_is_explic0/service.log
+2026-08-20 18:15:59,370 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,372 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,380 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,382 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,383 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,385 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,411 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,413 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,415 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,441 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,443 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,444 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,445 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,447 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,448 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,450 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,455 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,469 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,470 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,472 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,476 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,478 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,484 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=1, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,486 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=1 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,487 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=1w/2048q, batch=1w/4096q)
+2026-08-20 18:15:59,489 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,491 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,505 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,521 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,526 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,528 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,530 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,531 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,532 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,534 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,536 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,553 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'doc-read-error'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 310, in _get_from_filesystem
+    with candidate.open(encoding="utf-8") as stream:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_service_worker_callback.py", line 153, in fail_generation_read_once
+    raise OSError(errno.EIO, "I/O error")
+OSError: [Errno 5] I/O error
+2026-08-20 18:15:59,558 | WARNING | nemo_retriever.service.services.worker_result_store | Unable to read shared result payload for 'invalid'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/worker_result_store.py", line 311, in _get_from_filesystem
+    rows = json.load(stream)
+           ^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 293, in load
+    return loads(fp.read(),
+           ^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+    return _default_decoder.decode(s)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/json/decoder.py", line 353, in raw_decode
+    obj, end = self.scan_once(s, idx)
+               ^^^^^^^^^^^^^^^^^^^^^^
+json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
+2026-08-20 18:15:59,562 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,567 | WARNING | nemo_retriever.service.services.worker_result_store | Shared result payload for 'invalid' is not a JSON list of objects
+2026-08-20 18:15:59,578 | INFO | nemo_retriever.service.services.worker_result_store | Removed 2 expired shared result file(s) from /tmp/pytest-of-ubuntu/pytest-98/test_shared_result_store_remov0/.worker-results-v1
+2026-08-20 18:15:59,594 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,605 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=False)
+2026-08-20 18:15:59,607 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,609 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,615 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,628 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,630 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,632 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=batch)
+2026-08-20 18:15:59,635 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,636 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,638 | INFO | nemo_retriever.service.services.pipeline_executor | Pipeline work function created (Batch): extract=ExtractParams, embed=disabled, local_models=False, process_pool_workers=16, max_tasks_per_child=100, warmup_on_startup=False
+2026-08-20 18:15:59,640 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' started: workers=16 queue_size=4096 work_fn=_work
+2026-08-20 18:15:59,642 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool initialised (mode=batch, realtime=8w/2048q, batch=16w/4096q)
+2026-08-20 18:15:59,644 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=batch). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,645 | INFO | nemo_retriever.service.app | Retriever service started — mode=batch host=0.0.0.0 port=7670
+2026-08-20 18:15:59,662 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,667 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 0 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,671 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 1 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,674 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 2 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,677 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 3 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,680 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 4 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,683 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 6 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,686 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 7 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,689 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 5 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,691 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 8 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,694 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 10 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,697 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 9 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,700 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 11 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,703 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 13 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,706 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 14 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,709 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 15 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,712 | ERROR | nemo_retriever.service.services.pipeline_pool | Pool 'batch' worker 12 claim failed
+Traceback (most recent call last):
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
+    yield
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
+    resp = await self._pool.handle_async_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
+    raise exc from None
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
+    response = await connection.handle_async_request(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
+    raise exc
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
+    stream = await self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
+    stream = await self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
+    return await self._backend.connect_tcp(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore.ConnectError: [Errno -2] Name or service not known
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/pipeline_pool.py", line 503, in _worker_loop
+    item = await self._pull_client.claim()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/src/nemo_retriever/service/services/work_queue.py", line 528, in claim
+    response = await client.post(
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1859, in post
+    return await self.request(
+           ^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request
+    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
+    response = await self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
+    response = await self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
+    response = await self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
+    response = await transport.handle_async_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
+    with map_httpcore_exceptions():
+  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
+    self.gen.throw(value)
+  File "/home/ubuntu/.local/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx.ConnectError: [Errno -2] Name or service not known
+2026-08-20 18:15:59,728 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,730 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,731 | INFO | nemo_retriever.service.services.pipeline_pool | Pool 'batch' shut down (processed=0)
+2026-08-20 18:15:59,733 | INFO | nemo_retriever.service.services.pipeline_pool | Pipeline pool shut down
+2026-08-20 18:15:59,734 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,736 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,738 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,766 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,777 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,779 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,781 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,789 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,791 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,793 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,794 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,821 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,823 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,824 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,826 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,828 | INFO | nemo_retriever.service.services.job_tracker | Job registered: job-shared (expected_documents=2, label=None)
+2026-08-20 18:15:59,857 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,859 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,860 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,862 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,863 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,865 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 2, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,867 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,868 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,872 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item doc-retry (attempt 1)
+2026-08-20 18:15:59,875 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 410 for item permanently-rejected-doc (attempt 1)
+2026-08-20 18:15:59,876 | ERROR | nemo_retriever.service.services.pipeline_pool | Gateway callback permanently rejected item permanently-rejected-doc with HTTP 410
+2026-08-20 18:15:59,880 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,891 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,893 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,895 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:15:59,904 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:15:59,906 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:15:59,907 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:15:59,909 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:15:59,936 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:15:59,938 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:15:59,939 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:15:59,941 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:15:59,943 | INFO | nemo_retriever.service.services.job_tracker | Job registered: handoff-job (expected_documents=1, label=None)
+2026-08-20 18:15:59,962 | INFO | nemo_retriever.service.routers.ingest | Gateway callback: id=handoff-doc job_id=handoff-job status=completed outcome=transitioned rows=1 subscribers=0
+2026-08-20 18:15:59,967 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:15:59,969 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:15:59,970 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:15:59,972 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:15:59,973 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:15:59,975 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 0, 'completed': 1, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:15:59,976 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:15:59,978 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:15:59,982 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:15:59,995 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:15:59,997 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:15:59,999 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,008 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,010 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,012 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,013 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,040 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,042 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,044 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,045 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,047 | INFO | nemo_retriever.service.services.job_tracker | Job registered: failed-handoff-job (expected_documents=1, label=None)
+2026-08-20 18:16:00,064 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,066 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,068 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,069 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,071 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,072 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 1, 'total_documents': 1, 'pending': 0, 'processing': 1, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,074 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,076 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,082 | INFO | nemo_retriever.service.app | Logging configured: level=INFO file=retriever-service.log
+2026-08-20 18:16:00,093 | INFO | nemo_retriever.service.app | Scope authorization configured (enabled=False, header=Authorization, secret_file=False, allow_unscoped_dev=True)
+2026-08-20 18:16:00,094 | INFO | nemo_retriever.service.app | FastMCP service endpoint mounted at /mcp
+2026-08-20 18:16:00,096 | INFO | nemo_retriever.service.services.prometheus | Prometheus /metrics endpoint registered (role=gateway)
+2026-08-20 18:16:00,105 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service initialised
+2026-08-20 18:16:00,107 | INFO | nemo_retriever.service.services.job_tracker | Job tracker initialised
+2026-08-20 18:16:00,108 | INFO | nemo_retriever.service.services.event_bus | Event bus initialised
+2026-08-20 18:16:00,110 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore initialised (ttl=3600s max_entries=1024)
+2026-08-20 18:16:00,137 | INFO | nemo_retriever.service.services.proxy | Gateway proxy initialised — realtime=http://nemo-retriever-realtime:7670  batch=http://nemo-retriever-batch:7670
+2026-08-20 18:16:00,139 | WARNING | nemo_retriever.service.app | Media dependencies missing in this container: ffmpeg-python. Audio and video uploads will be rejected with HTTP 501 (mode=gateway). To enable media ingestion, redeploy the Helm chart with `--set service.installFfmpeg=true`, install FFmpeg manually with `apt-get update && apt-get install -y --no-install-recommends ffmpeg`, or build a custom image that includes ffmpeg/ffprobe.
+2026-08-20 18:16:00,141 | INFO | nemo_retriever.service.app | Retriever service started — mode=gateway host=0.0.0.0 port=7670
+2026-08-20 18:16:00,142 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager started
+2026-08-20 18:16:00,160 | WARNING | nemo_retriever.service.routers.ingest | Permanently rejecting retained result handoff for unknown document restart-orphaned-doc
+2026-08-20 18:16:00,162 | INFO | mcp.server.streamable_http_manager | StreamableHTTP session manager shutting down
+2026-08-20 18:16:00,164 | INFO | nemo_retriever.service.services.pipeline_executor | All pipeline process executors shut down
+2026-08-20 18:16:00,166 | INFO | nemo_retriever.service.services.proxy | Gateway proxy shut down
+2026-08-20 18:16:00,167 | INFO | nemo_retriever.service.services.sidecar_store | SidecarStore shut down (entries=0 bytes=0)
+2026-08-20 18:16:00,169 | INFO | nemo_retriever.service.services.event_bus | Event bus shut down (subscribers=0)
+2026-08-20 18:16:00,170 | INFO | nemo_retriever.service.services.job_tracker | Job tracker shut down: {'total_jobs': 0, 'total_documents': 0, 'pending': 0, 'processing': 0, 'completed': 0, 'failed': 0, 'partial_success': 0}
+2026-08-20 18:16:00,172 | INFO | nemo_retriever.service.services.metrics | Ingest metrics service shut down
+2026-08-20 18:16:00,173 | INFO | nemo_retriever.service.app | Retriever service stopped
+2026-08-20 18:16:00,180 | INFO | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback succeeded for item deferred-doc
+2026-08-20 18:16:00,184 | ERROR | nemo_retriever.service.services.pipeline_pool | Deferred gateway callback permanently failed for item restart-orphaned-doc; result remains unacknowledged
+2026-08-20 18:16:00,196 | WARNING | nemo_retriever.service.services.pipeline_pool | Gateway callback returned HTTP 503 for item retry-after-doc (attempt 1)
+2026-08-20 18:16:01,436 | INFO | nemo_retriever.graph.ingestor_runtime | Selected OCR engine: v2 (OCRActor)
+2026-08-20 18:16:01,694 | WARNING | nemo_retriever.common.api.util.exception_handlers.pdf | PDF Processing:boom error:x
+2026-08-20 18:16:01,960 | WARNING | nemo_retriever.operators.extract.txt.ray_data | Failed to split text source 'bad.txt'
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/extract/txt/ray_data.py", line 113, in process
+    chunk_df = txt_bytes_to_chunks_df(bytes(raw), path_str, params=params)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/nemo_retriever/tests/test_tokenizer_provider.py", line 165, in split_document
+    raise ValueError("malformed document")
+ValueError: malformed document
+2026-08-20 18:16:02,032 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 3 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,040 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 12 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,048 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 4 frame rows -> 2 (max_dropped_frames=2)
+2026-08-20 18:16:02,056 | INFO | nemo_retriever.operators.extract.video.text_dedup | VideoFrameTextDedup: merged 2 frame rows -> 1 (max_dropped_frames=2)
+2026-08-20 18:16:02,117 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['missing']
+2026-08-20 18:16:02,121 | WARNING | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: requested columns missing from batch: ['nope']
+2026-08-20 18:16:02,132 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 2 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,136 | INFO | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: POST 1 records to https://hook.example.com/ingest — 200
+2026-08-20 18:16:02,140 | ERROR | nemo_retriever.operators.graph_ops.webhook_operator | WebhookNotifyOperator: failed to POST to https://hook.example.com/ingest
+Traceback (most recent call last):
+  File "/workspace/nemo_retriever/src/nemo_retriever/operators/graph_ops/webhook_operator.py", line 123, in process
+    response = session.post(url, json=records, timeout=timeout)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1134, in __call__
+    return self._mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
+    raise effect
+ConnectionError: boom


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the 26.08-RC9 regression where concurrent public Retriever Service ingests returned `rc=0` and a positive row count while the records were neither durable nor queryable.

## Root cause

Three separate defects combined. Each one is fixed independently below.

1. **The index-readiness wait was not scoped to the index being built.** After creating or replacing the vector index, `write_to_index` iterated `table.list_indices()` and waited on *every* index it found, so the vector phase blocked on the pre-existing FTS `text_idx` for up to 600s.

2. **`wait_for_index` cannot be satisfied while other writers are active.** It requires zero unindexed rows. Concurrent writers keep committing rows, so that condition can stay false until the timeout expires even when the index this phase built is complete. This is what turned a scoping bug into a 600s stall.

3. **`_write_lock` covered both row admission and the index rebuild.** Commit 41ab2753 wrapped append/create *and* the full index rebuild-and-wait in one critical section, so later writers could not get their rows committed until an earlier writer's index wait finished or timed out.

Separately, the Service caller suppressed VectorDB write failures for legacy fixed-table writes, which is why the job still reported `completed` with `rows=1`.

## Changes

**Scope index waits to the current phase** (`lancedb_capabilities.py`). New `wait_for_column_index(table, column, *, covered_rows)` waits only on indexes covering the column this phase built, and waits for `num_indexed_rows >= covered_rows` rather than for a zero unindexed tail. On timeout it logs a warning instead of raising: rows outside an index are still returned by search because Lance scans them, so an unindexed tail is a performance property, not a correctness one, and the next rebuild folds it in. Applied in both `lancedb.py` and `lancedb_bulk.py`.

**Separate row admission from index maintenance** (`lancedb.py`). `_write_lock` now covers only the table create/append, so rows are durable and queryable as soon as that short section commits. Index maintenance moves to `_maintain_indexes` under a separate `_index_lock`, keeping index commits serialized as LanceDB requires. Rebuilds are **coalesced by generation**: a rebuild that starts after a batch was committed also indexes that batch, so concurrent writers share one rebuild rather than queueing one each. The rebuild calls `checkout_latest()` first so it indexes the newest committed version rather than the snapshot its caller happened to open.

**Fail the document when the write is not acknowledged** (`pipeline_executor.py`). `_post_records_to_vectordb` now raises on timeout or rejection for legacy fixed-table writes too, instead of logging a warning and continuing; the log moves from `WARNING` to `ERROR`. The previously hardcoded 30s caller timeout is now configurable and defaults to 300s, via `vectordb.write_timeout_s` (`ServiceConfig`) and `serviceConfig.vectordb.writeTimeoutSeconds` (Helm).

**Bound the readiness wait below the write acknowledgement timeout** (`lancedb_capabilities.py`). `INDEX_READY_TIMEOUT` drops from 600s to 60s. A write is acknowledged only after index maintenance and a hybrid table waits once per index, so at 600s a write could spend up to 1200s in advisory waits while the worker gave up at 300s — failing a document whose rows were already committed, the mirror image of the bug being fixed. The 600s value was inherited from `wait_for_index`, where the wait raised and so was load-bearing; now that it is advisory a long budget has no upside. `MAX_INDEX_READY_WAITS_PER_WRITE` records the per-write wait count and a test asserts the invariant against the default write timeout, so changing either constant cannot silently reintroduce the mismatch.

## Reproduction and verification

A version-agnostic script reproduced the field evidence against a real LanceDB table in the service's `hybrid` index mode (so `text_idx` exists), using only public backend behavior so it runs unchanged on both trees: seed two rows, issue two concurrent writes, then sample durable row count and FTS queryability.

| | rows before | rows immediately | rows at +45s | writes finished | sentinels queryable |
|---|---|---|---|---|---|
| Baseline `41ab2753` | 2 | 3 | 3 | neither | 1/2 |
| This branch | 2 | 4 | 4 (done in ~2s) | both | 2/2 |

The baseline column matches the reported RC9 A/B (2 → 3 rows, 1/2 queryable); this branch matches the RC7 control (2 → 4, 2/2).

## Tests

New `nemo_retriever/tests/test_lancedb_concurrent_writes.py` runs against a real LanceDB table and never replaces `write_to_index` with a no-op:

- each index phase waits only on its own column's index, and leaves the other column's unindexed tail untouched (both directions)
- two concurrent writes are durable and queryable
- a later writer's rows are committed while another writer is parked in its index build
- index builds never overlap, and writers queued behind one build share exactly one follow-up rebuild

These assert on recorded wait scope and on the pending-writer count rather than on elapsed wall-clock time, so they state the requirement directly and do not make machine speed part of the assertion. `test_run_serializes_write_and_index_transactions` is renamed to `test_run_serializes_row_admission` to reflect what its mocked index phase can actually observe, and points at the new file.

Also added: `test_helm_vectordb_write_timeout.py`, pipeline-executor cases for the raise-on-timeout behavior and the configurable timeout, and the timeout-ordering invariant test.

**Results.** The full suite (`-m "not integration"`) was run on this branch and on baseline `41ab2753` in an identical environment: the two failure sets are identical, so this change introduces no new failures. The remaining failures are all missing optional dependencies in the sandbox (`torch`, `transformers`, `neo4j`) and fail on baseline too. The concurrency file passed 8/8 consecutive runs under coverage pinned to two CPUs.

`helm` cannot be installed in this sandbox (`get.helm.sh` is firewalled and Helm publishes no GitHub release assets), so the Helm render tests skip locally and were validated in CI.

## Docs

`docs/docs/extraction/troubleshoot.md` rewrites the LanceDB concurrent-index section for the new commit/maintenance split and coalesced rebuilds, and adds a section on the new unacknowledged-write failure surface. Release notes and the Helm README (new value, timeout table, tuning guidance) are updated. `mkdocs build --strict` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01f7c-fa73-71b5-a64f-1be485b139c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01f7c-fa73-71b5-a64f-1be485b139c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

