### PR TITLE
Return full metadata with agentic retrieval hits

### DIFF
--- a/docs/docs/extraction/agentic-retrieval-concept.md
+++ b/docs/docs/extraction/agentic-retrieval-concept.md
@@ -4,7 +4,7 @@
 
 NeMo Retriever Library includes a first-class agentic query path. `retriever query --agentic`, `POST /v1/query` with `agentic=true`, and the `agentic_query` Model Context Protocol (MCP) tool run a Reason and Act (ReAct) loop over the same LanceDB table that one-pass retrieval uses. You do not have to implement the agent loop in application code.
 
-The agentic path returns ranked document IDs rather than text-enriched chunks. Local CLI and harness runs default to an in-process vLLM agent LLM. Retriever Service requires a remote OpenAI-compatible chat-completions endpoint. A self-hosted vLLM-backed NIM must enable automatic tool choice and a tool-call parser. Helm `answer_llm` does not turn those options on by default.
+The agentic path ranks documents rather than chunks, and returns the same hit fields as one-pass retrieval for each selected document. Local CLI and harness runs default to an in-process vLLM agent LLM. Retriever Service requires a remote OpenAI-compatible chat-completions endpoint. A self-hosted vLLM-backed NIM must enable automatic tool choice and a tool-call parser. Helm `answer_llm` does not turn those options on by default.
 
 For commands, service configuration, request and response contracts, and failure behavior, refer to [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
 

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -231,7 +231,7 @@ Every agentic hit carries the one-pass hit fields (`text`, `metadata`, `source`,
 
 CLI `retriever query --agentic` prints those hits as JSON objects.
 
-Service `POST /v1/query` with `agentic=true` uses the same hits envelope as classic retrieval. Successful responses set `query_mode` to `"agentic"`. Classic dense or hybrid `/v1/query` (including `format=evidence`) sets `query_mode` to `"classic"`.
+Service `POST /v1/query` with `agentic=true` uses the same hits envelope as classic retrieval. Successful responses set `query_mode` to `"agentic"`. Classic dense or hybrid `/v1/query` (including `format=evidence`) sets `query_mode` to `"classic"`. For backward compatibility with the previous agentic service contract, service and MCP hits also copy `rank` and `result_source` under `metadata`; the top-level fields are authoritative and carry the same values.
 
 An agent can name a document that no retrieval hop returned, which leaves nothing to rehydrate. Those hits report null one-pass fields, and `source` falls back to `doc_id`.
 

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -221,16 +221,19 @@ The `ingest_documents` MCP tool accepts either paths visible to the MCP server p
 
 ## Result contract { #result-contract }
 
-One-pass retrieval returns text-enriched chunk hits. Agentic retrieval returns a document-level ranking.
+One-pass retrieval returns text-enriched chunk hits. Agentic retrieval ranks documents, and returns the same hit fields as one-pass retrieval for each selected document. The agent works with reduced candidate records internally, but the selected documents are rehydrated at the end of the loop from the retrieval hop that returned them.
 
-CLI `retriever query --agentic` prints JSON objects with `rank`, `doc_id`, and `result_source`. `result_source` is `final_results`, `rrf`, or `selection_agent`, depending on which stage produced the ranked ID.
+Every agentic hit carries the one-pass hit fields (`text`, `metadata`, `source`, `source_id`, `path`, `page_number`, `pdf_basename`, `pdf_page`, scores, and related) plus these agentic annotations:
 
-Service `POST /v1/query` with `agentic=true` uses the same hits envelope as classic retrieval:
+- `doc_id` — the document identifier the agent selected.
+- `rank` — the position in the final ranking.
+- `result_source` — `final_results`, `rrf`, or `selection_agent`, depending on which stage produced the ranked ID.
 
-- Successful responses set `query_mode` to `"agentic"`. Classic dense or hybrid `/v1/query` (including `format=evidence`) sets `query_mode` to `"classic"`.
-- Each hit places the selected `doc_id` in `source`.
-- `metadata` carries `result_source` and `rank`.
-- Chunk-level fields (`text`, `page_number`, scores, and related) are unset.
+CLI `retriever query --agentic` prints those hits as JSON objects.
+
+Service `POST /v1/query` with `agentic=true` uses the same hits envelope as classic retrieval. Successful responses set `query_mode` to `"agentic"`. Classic dense or hybrid `/v1/query` (including `format=evidence`) sets `query_mode` to `"classic"`.
+
+An agent can name a document that no retrieval hop returned, which leaves nothing to rehydrate. Those hits report null one-pass fields, and `source` falls back to `doc_id`.
 
 ## Failure and retry behavior { #failure-and-retry-behavior }
 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -221,9 +221,12 @@ retriever query "summarize the deployment options" \
   --agentic-react-max-steps 5
 ```
 
-Unlike the dense path (which returns text-enriched hits), agentic mode returns
-the agent's ranked document IDs as JSON, each annotated with the source that
-produced it (`final_results`, `rrf`, or `selection_agent`). It reuses the same
+Agentic mode returns the agent's ranked documents as JSON, with the same hit
+fields as the dense path (`text`, `metadata`, `source`, `page_number`, and
+related) plus `doc_id`, `rank`, and the stage that produced the ranking
+(`final_results`, `rrf`, or `selection_agent`). Hit fields are rehydrated at the
+end of the loop from the retrieval hop that returned the document, so a document
+the agent named without retrieving it reports null hit fields. It reuses the same
 `--top-k`, `--lancedb-uri`, `--table-name`, `--embed-invoke-url`, and
 `--embed-model-name` options as standard retrieval. Agentic retrieval uses the
 selected table's model automatically when `--embed-model-name` is omitted.
@@ -237,7 +240,7 @@ fusion) -> SelectionAgentOperator -> ranked results`:
 - `RRFAggregatorOperator` fuses candidates from the loop's multiple searches with
   reciprocal rank fusion.
 - `SelectionAgentOperator` runs a final LLM selection pass over the fused set and
-  emits the ranked document IDs.
+  emits the ranked document IDs, which are then rehydrated into full hits.
 
 Agentic-only knobs (apply only with `--agentic`):
 

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextvars import ContextVar
 from typing import Any, Callable, Dict, List, Optional
 
 import pandas as pd
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 _LOG_PREVIEW_CHARS = 300
 _LOG_DOC_ID_LIMIT = 20
 _FATAL_AGENT_ERROR_CATEGORIES = frozenset({ERROR_LLM_CALL_FAILED, ERROR_TOOL_FAILED, ERROR_UNEXPECTED})
+_ACTIVE_QUERY_ID: ContextVar[Optional[str]] = ContextVar("react_agent_query_id", default=None)
 
 
 class _FatalAgentError(RuntimeError):
@@ -102,9 +104,14 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
     llm_model : str
         Model identifier forwarded verbatim to the backend (litellm
         provider-prefix transform is deferred).
-    retriever_fn : Callable[[str, int], list[dict]]
-        ``(query_text, top_k) → [{doc_id: str, text: str, score: float}]``.
+    retriever_fn : callable
+        By default, ``(query_text, top_k) → [{doc_id, text, score}]``. When
+        ``retriever_fn_accepts_query_id`` is true, the operator also passes the
+        current input ``query_id`` as a keyword argument.
         Wrapped by ``create_retrieve_tool`` after renaming ``doc_id`` → ``id``.
+    retriever_fn_accepts_query_id : bool
+        Pass ``query_id=...`` to ``retriever_fn``. Defaults to false for backward
+        compatibility with two-argument callbacks.
     retriever_top_k : int
         Default number of documents requested per retrieve call (the tool's
         ``default_top_k``). Defaults to ``500``.
@@ -155,7 +162,8 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
         *,
         invoke_url: Optional[str] = None,
         llm_model: str,
-        retriever_fn: Callable[[str, int], List[Dict[str, Any]]],
+        retriever_fn: Callable[..., List[Dict[str, Any]]],
+        retriever_fn_accepts_query_id: bool = False,
         retriever_top_k: int = 500,
         target_top_k: int = 10,
         max_steps: int = 200,
@@ -172,6 +180,7 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
         self._invoke_url = invoke_url or self._NVIDIA_BUILD_ENDPOINT
         self._llm_model = llm_model
         self._retriever_fn = retriever_fn
+        self._retriever_fn_accepts_query_id = retriever_fn_accepts_query_id
         self._retriever_top_k = retriever_top_k
         self._target_top_k = target_top_k
         self._max_steps = max_steps
@@ -219,7 +228,14 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
         """Adapt ``retriever_fn`` output to the private agent's ``id``/``score``/``text`` contract."""
         top_k = min(top_k, 1_000)
         out: List[Dict[str, Any]] = []
-        for doc in self._retriever_fn(query, top_k):
+        if self._retriever_fn_accepts_query_id:
+            query_id = _ACTIVE_QUERY_ID.get()
+            if query_id is None:
+                raise RuntimeError("ReAct retrieval callback ran outside an active query context.")
+            docs = self._retriever_fn(query, top_k, query_id=query_id)
+        else:
+            docs = self._retriever_fn(query, top_k)
+        for doc in docs:
             doc_id = str(doc.get("doc_id", doc.get("id", "")))
             if not doc_id:
                 continue
@@ -325,7 +341,11 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             int(self._target_top_k),
             _preview_text(query_text),
         )
-        result = agent.run_sync(str(query_text), query_id=str(query_id), raw_log_dir=None)
+        query_id_token = _ACTIVE_QUERY_ID.set(str(query_id))
+        try:
+            result = agent.run_sync(str(query_text), query_id=str(query_id), raw_log_dir=None)
+        finally:
+            _ACTIVE_QUERY_ID.reset(query_id_token)
 
         if result.error is not None and result.error.category in _FATAL_AGENT_ERROR_CATEGORIES:
             raise _FatalAgentError(

--- a/nemo_retriever/src/nemo_retriever/query/agentic.py
+++ b/nemo_retriever/src/nemo_retriever/query/agentic.py
@@ -63,6 +63,15 @@ AGENTIC_LOCAL_LLM_BACKEND = "vllm"
 AGENTIC_LOCAL_LLM_MODEL = "nemotron-8b"
 AGENTIC_LOCAL_LLM_BACKENDS = frozenset({"vllm"})
 
+# Raw embeddings are large and are not part of the classic hit envelope, so they
+# are dropped from the hits kept for rehydration.
+_UNCACHED_HIT_FIELDS = frozenset({"vector", "embedding"})
+
+# Selection stages that can only rank documents a retrieve hop returned. A hit
+# missing for one of these means the captured metadata and the selected ids
+# disagree, which is an internal inconsistency rather than agent behavior.
+_RETRIEVED_ONLY_RESULT_SOURCES = frozenset({"rrf", "selection_agent"})
+
 
 class AgenticQueryInputOperator(AbstractOperator):
     """Adapt ``Retriever(graph=...)`` input DataFrames to agentic query schema."""
@@ -392,6 +401,13 @@ class AgenticRetriever:
         )
         self._lock = threading.Lock()
         self._chat_completion_fn: Any | None = None
+        # Classic hits keyed by (graph query_id, doc_id), captured on every
+        # retrieve hop before the agent boundary reduces them to
+        # doc_id/text/score. The query component keeps query-dependent fields
+        # (especially scores) isolated when a batch retrieves the same document.
+        # Only final selected ids are rehydrated; reset for each retrieve().
+        self._hit_cache: dict[tuple[str, str], dict[str, Any]] = {}
+        self._hit_cache_lock = threading.Lock()
 
     def _get_chat_completion_fn(self) -> Any | None:
         if self._cfg.llm_backend == "openai_compatible":
@@ -424,12 +440,19 @@ class AgenticRetriever:
     def retrieve(self, query_ids: Sequence[str], query_texts: Sequence[str]) -> pd.DataFrame:
         """Return selected ranked documents for each query.
 
-        The output schema matches ``SelectionAgentOperator``: ``query_id``,
-        ``doc_id``, ``rank``, and ``message``.
+        Columns are ``SelectionAgentOperator``'s (``query_id``, ``doc_id``,
+        ``rank``, ``message``, ``result_source``) plus ``hit``: the classic
+        ``RetrievalHit`` (``text``, ``source``, ``page_number``, ``metadata``, …)
+        captured on the retrieve hop that first returned the document, or ``{}``
+        when no hop returned it. Use :func:`rehydrated_agentic_hit` to layer the
+        agentic annotations onto that hit.
         """
 
         if len(query_ids) != len(query_texts):
             raise ValueError("query_ids and query_texts must have the same length.")
+
+        with self._hit_cache_lock:
+            self._hit_cache.clear()
 
         from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
         from nemo_retriever.operators.graph_ops.rrf_aggregator_operator import RRFAggregatorOperator
@@ -448,6 +471,7 @@ class AgenticRetriever:
                 invoke_url=_none_if_empty(self._cfg.invoke_url),
                 llm_model=str(self._cfg.llm_model),
                 retriever_fn=self._retrieve_for_agent,
+                retriever_fn_accepts_query_id=True,
                 retriever_top_k=per_hop_top_k,
                 target_top_k=target_top_k,
                 max_steps=int(self._cfg.react_max_steps),
@@ -485,9 +509,12 @@ class AgenticRetriever:
             [str(query_text) for query_text in query_texts],
             top_k=target_top_k,
         )
-        return _raw_hits_to_agentic_result([str(query_id) for query_id in query_ids], raw_hits)
+        result = _raw_hits_to_agentic_result([str(query_id) for query_id in query_ids], raw_hits)
+        with self._hit_cache_lock:
+            hit_cache = dict(self._hit_cache)
+        return _rehydrate_selected_hits(result, hit_cache)
 
-    def _retrieve_for_agent(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+    def _retrieve_for_agent(self, query_text: str, top_k: int, *, query_id: str = "") -> list[dict[str, Any]]:
         """Retriever callback used by ``ReActAgentOperator``.
 
         Retrieval is serialized across concurrent ReAct workers via ``self._lock``
@@ -512,6 +539,14 @@ class AgenticRetriever:
             )
             if not doc_id:
                 continue
+            # Keep the untruncated hit for rehydration; truncation below only
+            # bounds what the agent LLM sees. First occurrence per query and
+            # doc_id wins.
+            with self._hit_cache_lock:
+                self._hit_cache.setdefault(
+                    (str(query_id), doc_id),
+                    {key: value for key, value in hit_dict.items() if key not in _UNCACHED_HIT_FIELDS},
+                )
             text = str(hit_dict.get("text", ""))
             if int(self._cfg.text_truncation) > 0:
                 text = text[: int(self._cfg.text_truncation)]
@@ -525,6 +560,69 @@ class AgenticRetriever:
             if len(docs) >= int(top_k):
                 break
         return docs
+
+
+def rehydrated_agentic_hit(hit: Any, *, doc_id: str, rank: int, result_source: str) -> dict[str, Any]:
+    """Layer the agentic annotations onto one rehydrated classic hit.
+
+    ``hit`` is a value from the ``hit`` column of
+    :meth:`AgenticRetriever.retrieve`. The result carries the classic
+    ``RetrievalHit`` fields plus ``doc_id``, ``rank``, and ``result_source``, so
+    agentic output matches classic retrieval output while still reporting which
+    stage selected the document.
+    """
+
+    rehydrated: dict[str, Any] = dict(hit) if isinstance(hit, dict) else {}
+    rehydrated.update({"doc_id": doc_id, "rank": rank, "result_source": result_source})
+    return rehydrated
+
+
+def _rehydrate_selected_hits(
+    result: pd.DataFrame,
+    hit_cache: dict[tuple[str, str], dict[str, Any]],
+) -> pd.DataFrame:
+    """Attach the captured classic hit for each selected doc_id."""
+
+    doc_ids = result["doc_id"].astype(str).tolist() if "doc_id" in result.columns else []
+    retrieval_query_ids = (
+        result["_retrieval_query_id"].astype(str).tolist()
+        if "_retrieval_query_id" in result.columns
+        else [""] * len(doc_ids)
+    )
+    if "result_source" in result.columns:
+        result_sources = result["result_source"].astype(str).tolist()
+    else:
+        result_sources = [""] * len(doc_ids)
+
+    hits: list[dict[str, Any]] = []
+    for retrieval_query_id, doc_id, result_source in zip(retrieval_query_ids, doc_ids, result_sources):
+        hit = hit_cache.get((retrieval_query_id, doc_id))
+        if hit is None:
+            _log_missing_rehydration_hit(doc_id, result_source)
+            hit = {}
+        hits.append(dict(hit))
+    result["hit"] = pd.Series(hits, dtype="object", index=result.index)
+    result.drop(columns=["_retrieval_query_id"], inplace=True, errors="ignore")
+    return result
+
+
+def _log_missing_rehydration_hit(doc_id: str, result_source: str) -> None:
+    if result_source in _RETRIEVED_ONLY_RESULT_SOURCES:
+        logger.error(
+            "Agentic hit metadata is missing for doc_id=%r selected by result_source=%r, which can only rank "
+            "documents a retrieve hop returned; the selected id and the captured hits disagree. "
+            "Returning agentic annotations without classic hit fields.",
+            doc_id,
+            result_source,
+        )
+        return
+    logger.warning(
+        "Agentic hit metadata is missing for doc_id=%r selected by result_source=%r: no retrieve hop returned "
+        "this document, so the agent named an id it never saw. Returning agentic annotations without classic "
+        "hit fields.",
+        doc_id,
+        result_source,
+    )
 
 
 def _raw_hits_to_agentic_result(query_ids: Sequence[str], raw_hits: Sequence[Sequence[dict[str, Any]]]) -> pd.DataFrame:
@@ -542,6 +640,7 @@ def _raw_hits_to_agentic_result(query_ids: Sequence[str], raw_hits: Sequence[Seq
     for pos, hits in enumerate(raw_hits):
         for rank, hit in enumerate(hits, start=1):
             raw_qid = hit.get("query_id")
+            retrieval_query_id = str(raw_qid) if raw_qid is not None else str(pos)
             if raw_qid is not None and str(raw_qid).isdigit() and int(raw_qid) < n:
                 qid = str(query_ids[int(raw_qid)])
             elif pos < n:
@@ -555,10 +654,11 @@ def _raw_hits_to_agentic_result(query_ids: Sequence[str], raw_hits: Sequence[Seq
                     "rank": int(hit.get("rank", rank)),
                     "message": str(hit.get("message", "")),
                     "result_source": str(hit.get("result_source", "")),
+                    "_retrieval_query_id": retrieval_query_id,
                 }
             )
     if not rows:
-        return pd.DataFrame(columns=["query_id", "doc_id", "rank", "message", "result_source"])
+        return pd.DataFrame(columns=["query_id", "doc_id", "rank", "message", "result_source", "_retrieval_query_id"])
     return pd.DataFrame(rows)
 
 

--- a/nemo_retriever/src/nemo_retriever/query/agentic.py
+++ b/nemo_retriever/src/nemo_retriever/query/agentic.py
@@ -570,6 +570,19 @@ def rehydrated_agentic_hit(hit: Any, *, doc_id: str, rank: int, result_source: s
     ``RetrievalHit`` fields plus ``doc_id``, ``rank``, and ``result_source``, so
     agentic output matches classic retrieval output while still reporting which
     stage selected the document.
+
+    Args:
+        hit: Rehydrated classic hit mapping from ``AgenticRetriever.retrieve``.
+            Non-dict values represent unavailable hit metadata and produce an
+            annotation-only result.
+        doc_id: Non-empty document identifier selected by the agentic pipeline.
+        rank: One-based position in the final selected result list.
+        result_source: Stage that produced the final selection, normally
+            ``final_results``, ``selection_agent``, or ``rrf``.
+
+    Returns:
+        A new dictionary containing the classic hit fields, when available,
+        plus top-level ``doc_id``, ``rank``, and ``result_source`` annotations.
     """
 
     rehydrated: dict[str, Any] = dict(hit) if isinstance(hit, dict) else {}

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -216,18 +216,20 @@ def build_agentic_retriever(request: QueryRequest) -> "AgenticRetriever":
 
 
 def agentic_query_documents(request: QueryRequest) -> list[dict[str, Any]]:
-    """Run agentic (ReAct) retrieval for a single query and return the agent's
-    ranked document IDs.
+    """Run agentic (ReAct) retrieval for a single query and return ranked hits.
 
-    Unlike the dense ``query_documents`` path (which returns enriched hits with
-    text), the agent operates at the document-ID granularity of the configured
-    index, so the result is the ranked ``doc_id`` list the agent selected,
-    annotated with the source that produced it (``final_results`` / ``rrf`` /
-    ``selection_agent``). The LanceDB ``uri``/``table_name``, embedding config,
-    and (when ``--rerank`` is enabled) reranker config are passed straight
-    through to the wrapped ``Retriever`` that backs the agent's ``retrieve``
-    tool. Reranking therefore applies per agent retrieval hop.
+    The agent selects documents rather than chunks, but each returned hit carries
+    the same fields as the dense ``query_documents`` path (``text``, ``source``,
+    ``page_number``, ``metadata``, …), rehydrated from the retrieve hop that
+    returned the document, plus the agentic annotations ``doc_id``, ``rank``, and
+    ``result_source`` (``final_results`` / ``rrf`` / ``selection_agent``). The
+    LanceDB ``uri``/``table_name``, embedding config, and (when ``--rerank`` is
+    enabled) reranker config are passed straight through to the wrapped
+    ``Retriever`` that backs the agent's ``retrieve`` tool. Reranking therefore
+    applies per agent retrieval hop.
     """
+    from nemo_retriever.query.agentic import rehydrated_agentic_hit
+
     retriever = build_agentic_retriever(request)
     try:
         result = retriever.retrieve(["0"], [str(request.query)])
@@ -239,11 +241,12 @@ def agentic_query_documents(request: QueryRequest) -> list[dict[str, Any]]:
             if not doc_id:
                 continue
             ranked.append(
-                {
-                    "rank": int(row.get("rank", len(ranked) + 1)),
-                    "doc_id": doc_id,
-                    "result_source": str(row.get("result_source", "")),
-                }
+                rehydrated_agentic_hit(
+                    row.get("hit"),
+                    doc_id=doc_id,
+                    rank=int(row.get("rank", len(ranked) + 1)),
+                    result_source=str(row.get("result_source", "")),
+                )
             )
             if len(ranked) >= request.retrieval.top_k:
                 break

--- a/nemo_retriever/src/nemo_retriever/service/agentic_query.py
+++ b/nemo_retriever/src/nemo_retriever/service/agentic_query.py
@@ -25,7 +25,7 @@ _AGENTIC_ANNOTATION_FIELDS = frozenset({"doc_id", "rank", "result_source"})
 
 #: Classic fields reported as null when no retrieve hop captured the selected
 #: document, so the envelope keeps a stable key set either way.
-_UNRESOLVED_HIT_FIELDS = ("text", "metadata", "source_id", "path", "page_number", "pdf_basename", "pdf_page")
+_UNRESOLVED_HIT_FIELDS = ("text", "source_id", "path", "page_number", "pdf_basename", "pdf_page")
 
 
 def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -40,6 +40,22 @@ def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]
     Rows without a non-empty ``doc_id`` are a contract violation: the agentic
     workflow already skips blank ids on retrieve hops, and a hit with
     ``source=null`` is useless to clients. Raise rather than emit a null source.
+
+    For backward compatibility, ``rank`` and ``result_source`` are emitted both
+    as top-level agentic annotations and under ``metadata``. Existing content
+    metadata is copied before those keys are added.
+
+    Args:
+        ranked: Ranked agentic results. Each item must contain a non-empty
+            ``doc_id`` and may contain rehydrated classic hit fields plus
+            ``rank`` and ``result_source``.
+
+    Returns:
+        Hits in the service ``/v1/query`` envelope, preserving rehydrated classic
+        fields and adding top-level and nested agentic annotations.
+
+    Raises:
+        ValueError: If any ranked item has a missing or blank ``doc_id``.
     """
     hits: list[dict[str, Any]] = []
     for item in ranked:
@@ -54,6 +70,15 @@ def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]
             hit = {field: None for field in _UNRESOLVED_HIT_FIELDS}
         if not str(hit.get("source") or "").strip():
             hit["source"] = doc_id
+        raw_metadata = hit.get("metadata")
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
+        metadata.update(
+            {
+                "rank": item.get("rank"),
+                "result_source": item.get("result_source"),
+            }
+        )
+        hit["metadata"] = metadata
         hit.update(
             {
                 "doc_id": doc_id,

--- a/nemo_retriever/src/nemo_retriever/service/agentic_query.py
+++ b/nemo_retriever/src/nemo_retriever/service/agentic_query.py
@@ -20,13 +20,22 @@ from nemo_retriever.service.config import AgenticConfig
 from nemo_retriever.service.query_schema import QueryResponse, QueryResult
 
 
-def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Map agentic document ranks onto the ``/v1/query`` hits envelope.
+#: Annotations the agentic workflow layers on top of the classic hit fields.
+_AGENTIC_ANNOTATION_FIELDS = frozenset({"doc_id", "rank", "result_source"})
 
-    Agentic retrieval selects documents (``doc_id``), not chunks. Each hit places
-    ``doc_id`` in ``source``, records ``result_source`` / ``rank`` under
-    ``metadata``, and leaves chunk-level fields (``text``, ``page_number``,
-    scores, …) unset.
+#: Classic fields reported as null when no retrieve hop captured the selected
+#: document, so the envelope keeps a stable key set either way.
+_UNRESOLVED_HIT_FIELDS = ("text", "metadata", "source_id", "path", "page_number", "pdf_basename", "pdf_page")
+
+
+def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Map agentic ranked hits onto the ``/v1/query`` hits envelope.
+
+    Agentic retrieval selects documents (``doc_id``), not chunks, but each hit
+    carries the classic chunk-level fields (``text``, ``metadata``, ``source``,
+    ``page_number``, scores, …) rehydrated from the retrieve hop that returned the
+    document, plus ``doc_id`` / ``rank`` / ``result_source``. When no hop captured
+    the document, those fields are null and ``source`` falls back to ``doc_id``.
 
     Rows without a non-empty ``doc_id`` are a contract violation: the agentic
     workflow already skips blank ids on retrieve hops, and a hit with
@@ -40,21 +49,19 @@ def agentic_ranked_to_hits(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]
                 "agentic ranked result is missing a non-empty doc_id "
                 f"(rank={item.get('rank')!r}, result_source={item.get('result_source')!r})"
             )
-        hits.append(
+        hit = {key: value for key, value in item.items() if key not in _AGENTIC_ANNOTATION_FIELDS}
+        if not hit:
+            hit = {field: None for field in _UNRESOLVED_HIT_FIELDS}
+        if not str(hit.get("source") or "").strip():
+            hit["source"] = doc_id
+        hit.update(
             {
-                "text": None,
-                "metadata": {
-                    "result_source": item.get("result_source"),
-                    "rank": item.get("rank"),
-                },
-                "source": doc_id,
-                "source_id": None,
-                "path": None,
-                "page_number": None,
-                "pdf_basename": None,
-                "pdf_page": None,
+                "doc_id": doc_id,
+                "rank": item.get("rank"),
+                "result_source": item.get("result_source"),
             }
         )
+        hits.append(hit)
     return hits
 
 

--- a/nemo_retriever/src/nemo_retriever/service/mcp_server.py
+++ b/nemo_retriever/src/nemo_retriever/service/mcp_server.py
@@ -583,7 +583,8 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
                 "Run the configured agentic (ReAct) retrieval workflow over ingested "
                 "documents via POST /v1/query with agentic=true. Returns the standard "
                 "hits envelope with the same chunk-level fields as classic retrieval, "
-                "plus doc_id, rank, and result_source for the selecting stage."
+                "plus top-level doc_id, rank, and result_source for the selecting "
+                "stage; rank and result_source also remain under metadata for compatibility."
             ),
         )
         async def agentic_query(query: str, top_k: int = 5) -> dict[str, Any]:

--- a/nemo_retriever/src/nemo_retriever/service/mcp_server.py
+++ b/nemo_retriever/src/nemo_retriever/service/mcp_server.py
@@ -582,8 +582,8 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
             description=(
                 "Run the configured agentic (ReAct) retrieval workflow over ingested "
                 "documents via POST /v1/query with agentic=true. Returns the standard "
-                "hits envelope: source holds doc_id; result_source and rank are under "
-                "metadata; chunk-level fields are unset for document-level results."
+                "hits envelope with the same chunk-level fields as classic retrieval, "
+                "plus doc_id, rank, and result_source for the selecting stage."
             ),
         )
         async def agentic_query(query: str, top_k: int = 5) -> dict[str, Any]:

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -36,8 +36,9 @@ class QueryRequest(BaseModel):
             "Requires agentic.enabled in service configuration. Response uses the same "
             "hits envelope as dense/hybrid query: each hit carries the classic hit "
             "fields (text, metadata, source, page_number, scores, ...) plus doc_id, "
-            "rank, and result_source. Documents the agent selected without retrieving "
-            "them have null classic fields and source falls back to doc_id."
+            "rank, and result_source. For compatibility, metadata also carries rank "
+            "and result_source. Documents the agent selected without retrieving them "
+            "have null classic fields and source falls back to doc_id."
         ),
     )
 

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -34,9 +34,10 @@ class QueryRequest(BaseModel):
         description=(
             "When true, run the server-configured agentic (ReAct) retrieval workflow. "
             "Requires agentic.enabled in service configuration. Response uses the same "
-            "hits envelope as dense/hybrid query; document-level agentic results map "
-            "doc_id onto source, keep result_source/rank in metadata, and leave "
-            "chunk-level fields unset (null)."
+            "hits envelope as dense/hybrid query: each hit carries the classic hit "
+            "fields (text, metadata, source, page_number, scores, ...) plus doc_id, "
+            "rank, and result_source. Documents the agent selected without retrieving "
+            "them have null classic fields and source falls back to doc_id."
         ),
     )
 

--- a/nemo_retriever/tests/test_agentic_eval.py
+++ b/nemo_retriever/tests/test_agentic_eval.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+import logging
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -126,10 +127,167 @@ def test_agentic_retriever_runs_graph_with_wrapped_retriever():
         result = retriever.retrieve(["0"], ["find doc"])
 
     assert "local_ingest_embed_backend" not in retriever._retriever.kwargs["embed_kwargs"]
-    assert list(result.columns) == ["query_id", "doc_id", "rank", "message", "result_source"]
+    assert list(result.columns) == ["query_id", "doc_id", "rank", "message", "result_source", "hit"]
     assert result["query_id"].tolist() == ["0"] * 10
     assert result["doc_id"].tolist()[0] == "doc_1"
     assert result["rank"].tolist() == list(range(1, 11))
+
+
+@patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
+def test_agentic_retriever_rehydrates_only_retrieved_documents():
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    # doc_1 comes back from the retrieve hop; the extras are ids the agent named
+    # without ever retrieving them, so there is nothing to rehydrate for them.
+    final_ids = ["doc_1"] + [f"extra_{i}" for i in range(9)]
+    chat_fn = _dispatch_chat_fn(
+        _make_tool_call_response(
+            "final_results", {"doc_ids": final_ids, "message": "done", "search_successful": "true"}
+        ),
+        _make_tool_call_response("log_selected_documents", {"doc_ids": ["doc_1"], "message": "doc_1 is best"}),
+    )
+
+    cfg = AgenticRetrievalConfig(llm_model="nemotron-8b")
+    with patch("nemo_retriever.query.agentic._build_agent_chat_completion_fn", return_value=chat_fn):
+        result = AgenticRetriever(cfg, match_mode="pdf_page").retrieve(["0"], ["find doc"])
+
+    hits = dict(zip(result["doc_id"], result["hit"]))
+    assert hits["doc_1"]["text"] == "matching document"
+    assert hits["doc_1"]["source_id"] == "/tmp/doc.pdf"
+    assert hits["doc_1"]["page_number"] == 1
+    assert hits["doc_1"]["_score"] == 0.9
+    assert hits["extra_0"] == {}
+
+
+@patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
+def test_agentic_retriever_caches_untruncated_text_for_rehydration():
+    """Truncation bounds what the agent sees; rehydration returns the stored text."""
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    cfg = AgenticRetrievalConfig(llm_model="m", invoke_url=_REMOTE_URL, text_truncation=5)
+    retriever = AgenticRetriever(cfg, match_mode="pdf_page")
+
+    docs = retriever._retrieve_for_agent("find doc", 10, query_id="q1")
+
+    assert docs[0]["text"] == "match"
+    assert retriever._hit_cache[("q1", "doc_1")]["text"] == "matching document"
+
+
+def test_rehydrated_agentic_hit_layers_annotations_onto_classic_fields():
+    from nemo_retriever.query.agentic import rehydrated_agentic_hit
+
+    hit = rehydrated_agentic_hit(
+        {"text": "body", "source": "/tmp/doc.pdf", "page_number": 3},
+        doc_id="doc_3",
+        rank=1,
+        result_source="selection_agent",
+    )
+
+    assert hit == {
+        "text": "body",
+        "source": "/tmp/doc.pdf",
+        "page_number": 3,
+        "doc_id": "doc_3",
+        "rank": 1,
+        "result_source": "selection_agent",
+    }
+
+
+def test_rehydrated_agentic_hit_without_captured_metadata():
+    from nemo_retriever.query.agentic import rehydrated_agentic_hit
+
+    assert rehydrated_agentic_hit({}, doc_id="doc_3", rank=2, result_source="final_results") == {
+        "doc_id": "doc_3",
+        "rank": 2,
+        "result_source": "final_results",
+    }
+
+
+def test_rehydration_miss_severity_depends_on_selecting_stage(caplog):
+    """A stage that can only rank retrieved candidates must never miss the cache."""
+    from nemo_retriever.query.agentic import _rehydrate_selected_hits
+
+    result = pd.DataFrame(
+        {
+            "doc_id": ["seen", "unretrieved_candidate", "invented"],
+            "rank": [1, 2, 3],
+            "result_source": ["selection_agent", "selection_agent", "final_results"],
+            "_retrieval_query_id": ["q1", "q1", "q1"],
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="nemo_retriever.query.agentic"):
+        rehydrated = _rehydrate_selected_hits(result, {("q1", "seen"): {"text": "body"}})
+
+    assert rehydrated["hit"].tolist() == [{"text": "body"}, {}, {}]
+    assert "_retrieval_query_id" not in rehydrated.columns
+    levels = {record.levelno: record.getMessage() for record in caplog.records}
+    assert "unretrieved_candidate" in levels[logging.ERROR]
+    assert "invented" in levels[logging.WARNING]
+
+
+def test_rehydration_isolates_same_doc_id_per_query():
+    from nemo_retriever.query.agentic import _rehydrate_selected_hits
+
+    result = pd.DataFrame(
+        {
+            "query_id": ["customer-query-a", "customer-query-b"],
+            "doc_id": ["shared_doc", "shared_doc"],
+            "rank": [1, 1],
+            "result_source": ["selection_agent", "selection_agent"],
+            "_retrieval_query_id": ["0", "1"],
+        }
+    )
+    cache = {
+        ("0", "shared_doc"): {"text": "query a hit", "_score": 0.9},
+        ("1", "shared_doc"): {"text": "query b hit", "_score": 0.4},
+    }
+
+    rehydrated = _rehydrate_selected_hits(result, cache)
+
+    assert rehydrated["hit"].tolist() == [
+        {"text": "query a hit", "_score": 0.9},
+        {"text": "query b hit", "_score": 0.4},
+    ]
+    assert "_retrieval_query_id" not in rehydrated.columns
+
+
+def test_agentic_query_documents_returns_classic_hit_fields_with_annotations():
+    from nemo_retriever.query.options import QueryAgenticOptions, QueryRequest, QueryRetrievalOptions
+    from nemo_retriever.query.workflow import agentic_query_documents
+
+    retriever = MagicMock()
+    retriever.retrieve.return_value = pd.DataFrame(
+        {
+            "query_id": ["0", "0"],
+            "doc_id": ["doc_1", "invented"],
+            "rank": [1, 2],
+            "message": ["", ""],
+            "result_source": ["selection_agent", "final_results"],
+            "hit": [{"text": "body", "source": "/tmp/doc.pdf", "page_number": 1}, {}],
+        }
+    )
+    request = QueryRequest(
+        query="find doc",
+        retrieval=QueryRetrievalOptions(top_k=2),
+        agentic=QueryAgenticOptions(enabled=True, llm_model="m", invoke_url=_REMOTE_URL),
+    )
+
+    with patch("nemo_retriever.query.workflow.build_agentic_retriever", return_value=retriever):
+        ranked = agentic_query_documents(request)
+
+    assert ranked == [
+        {
+            "text": "body",
+            "source": "/tmp/doc.pdf",
+            "page_number": 1,
+            "doc_id": "doc_1",
+            "rank": 1,
+            "result_source": "selection_agent",
+        },
+        {"doc_id": "invented", "rank": 2, "result_source": "final_results"},
+    ]
+    retriever.unload.assert_called_once()
 
 
 @patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
@@ -159,8 +317,8 @@ def test_agentic_retriever_forwards_candidate_k_per_hop():
     cfg = AgenticRetrievalConfig(llm_model="m", invoke_url=_REMOTE_URL, top_k=10, candidate_k=20)
     retriever = AgenticRetriever(cfg, match_mode="pdf_page")
 
-    retriever._retrieve_for_agent("first", 10)
-    retriever._retrieve_for_agent("later", 25)
+    retriever._retrieve_for_agent("first", 10, query_id="q1")
+    retriever._retrieve_for_agent("later", 25, query_id="q1")
 
     assert retriever._retriever.query_calls == [
         {"query": "first", "top_k": 10, "candidate_k": 20},

--- a/nemo_retriever/tests/test_agentic_operators.py
+++ b/nemo_retriever/tests/test_agentic_operators.py
@@ -202,6 +202,28 @@ class TestReActAgentOperator:
             {"id": "d2", "score": 0.4, "text": "u"},
         ]
 
+    def test_retrieve_adapter_passes_active_query_id_when_enabled(self):
+        from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
+
+        calls = []
+
+        def retrieve(query, top_k, *, query_id):
+            calls.append((query, top_k, query_id))
+            return []
+
+        op = self._op(retriever_fn=retrieve, retriever_fn_accepts_query_id=True)
+        mock_agent = MagicMock()
+
+        def run_sync(query, *, query_id=None, raw_log_dir=None):
+            op._retrieve_adapter("agent subquery", 5)
+            return _agent_result()
+
+        mock_agent.run_sync.side_effect = run_sync
+        with patch.object(ReActAgentOperator, "_ensure_agent", return_value=mock_agent):
+            op.run(self._input())
+
+        assert calls == [("agent subquery", 5, "q1")]
+
     def test_translates_retrieval_log_and_final(self):
         from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
 

--- a/nemo_retriever/tests/test_service_agentic_query.py
+++ b/nemo_retriever/tests/test_service_agentic_query.py
@@ -106,7 +106,7 @@ def test_agentic_ranked_to_hits_keeps_rehydrated_classic_fields() -> None:
     assert hits == [
         {
             "text": "revenue grew 4%",
-            "metadata": {"type": "text"},
+            "metadata": {"type": "text", "rank": 1, "result_source": "selection_agent"},
             "source": "/indexes/report.pdf",
             "source_id": "/indexes/report.pdf",
             "page_number": 7,
@@ -123,7 +123,7 @@ def test_agentic_ranked_to_hits_falls_back_to_doc_id_without_rehydrated_metadata
     assert hits == [
         {
             "text": None,
-            "metadata": None,
+            "metadata": {"rank": 1, "result_source": "final_results"},
             "source": "report.pdf",
             "source_id": None,
             "path": None,
@@ -225,7 +225,7 @@ def test_agentic_true_runs_react_workflow_on_v1_query(tmp_path) -> None:
                 "hits": [
                     {
                         "text": "revenue grew 4%",
-                        "metadata": {"type": "text"},
+                        "metadata": {"type": "text", "rank": 1, "result_source": "selection_agent"},
                         "source": "/indexes/report.pdf",
                         "page_number": 7,
                         "doc_id": "report_7",

--- a/nemo_retriever/tests/test_service_agentic_query.py
+++ b/nemo_retriever/tests/test_service_agentic_query.py
@@ -87,18 +87,52 @@ def test_build_agentic_query_request_maps_server_owned_configuration() -> None:
     assert request.agentic.react_max_steps == 7
 
 
-def test_agentic_ranked_to_hits_maps_doc_id_onto_query_hit_envelope() -> None:
-    hits = agentic_ranked_to_hits([{"rank": 1, "doc_id": "report.pdf", "result_source": "selection_agent"}])
+def test_agentic_ranked_to_hits_keeps_rehydrated_classic_fields() -> None:
+    hits = agentic_ranked_to_hits(
+        [
+            {
+                "text": "revenue grew 4%",
+                "metadata": {"type": "text"},
+                "source": "/indexes/report.pdf",
+                "source_id": "/indexes/report.pdf",
+                "page_number": 7,
+                "_score": 0.42,
+                "rank": 1,
+                "doc_id": "report_7",
+                "result_source": "selection_agent",
+            }
+        ]
+    )
+    assert hits == [
+        {
+            "text": "revenue grew 4%",
+            "metadata": {"type": "text"},
+            "source": "/indexes/report.pdf",
+            "source_id": "/indexes/report.pdf",
+            "page_number": 7,
+            "_score": 0.42,
+            "doc_id": "report_7",
+            "rank": 1,
+            "result_source": "selection_agent",
+        }
+    ]
+
+
+def test_agentic_ranked_to_hits_falls_back_to_doc_id_without_rehydrated_metadata() -> None:
+    hits = agentic_ranked_to_hits([{"rank": 1, "doc_id": "report.pdf", "result_source": "final_results"}])
     assert hits == [
         {
             "text": None,
-            "metadata": {"result_source": "selection_agent", "rank": 1},
+            "metadata": None,
             "source": "report.pdf",
             "source_id": None,
             "path": None,
             "page_number": None,
             "pdf_basename": None,
             "pdf_page": None,
+            "doc_id": "report.pdf",
+            "rank": 1,
+            "result_source": "final_results",
         }
     ]
 
@@ -159,8 +193,12 @@ def test_agentic_true_runs_react_workflow_on_v1_query(tmp_path) -> None:
                 hits=agentic_ranked_to_hits(
                     [
                         {
+                            "text": "revenue grew 4%",
+                            "metadata": {"type": "text"},
+                            "source": "/indexes/report.pdf",
+                            "page_number": 7,
                             "rank": 1,
-                            "doc_id": "report.pdf",
+                            "doc_id": "report_7",
                             "result_source": "selection_agent",
                         }
                     ]
@@ -186,14 +224,13 @@ def test_agentic_true_runs_react_workflow_on_v1_query(tmp_path) -> None:
             {
                 "hits": [
                     {
-                        "text": None,
-                        "metadata": {"result_source": "selection_agent", "rank": 1},
-                        "source": "report.pdf",
-                        "source_id": None,
-                        "path": None,
-                        "page_number": None,
-                        "pdf_basename": None,
-                        "pdf_page": None,
+                        "text": "revenue grew 4%",
+                        "metadata": {"type": "text"},
+                        "source": "/indexes/report.pdf",
+                        "page_number": 7,
+                        "doc_id": "report_7",
+                        "rank": 1,
+                        "result_source": "selection_agent",
                     }
                 ]
             }


### PR DESCRIPTION
## Description
- Retain full classic retrieval hits during ReAct retrieval hops and rehydrate only the final selected hits.
- Isolate cached hits by query and document ID to prevent cross-query metadata or score mixing.
- Return classic fields such as text, source, page number, and metadata alongside top-level `doc_id`, `rank`, and `result_source`.
- Apply the unified response shape to Python/CLI, service, and MCP entrypoints.
- Log missing metadata as a warning for unseen ReAct final IDs and as an error for RRF or selection-agent inconsistencies.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
