### PR TITLE
docs(extraction): pass NVIDIA_API_KEY explicitly in Live RAG examples (NVBug 6622594)

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -23,6 +23,8 @@ On Windows PowerShell you can use `$env:NVIDIA_API_KEY = "nvapi-..."`.
 
 The SDK and CLI do not load a `.env` file automatically. For a full list of related variables and how to source a `.env` file into the shell, refer to [Environment configuration variables](environment-config.md).
 
+For `LiteLLMClient` and `LLMJudge` with a `nvidia_nim/...` model, pass `api_key="os.environ/NVIDIA_API_KEY"`. LiteLLM does not read `NVIDIA_API_KEY` for that provider.
+
 Hosted object-detection NIMs (Page Elements, Table Structure, Graphic Elements) cap inline base64 image payloads at about 180,000 characters (roughly 180 KB). This key authorizes those hosted inference calls. For size limits and what to do when an image exceeds the cap, refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits).
 
 !!! note
@@ -38,6 +40,8 @@ api_key="os.environ/NVIDIA_API_KEY"
 ```
 
 Use the provider's own variable name, for example `os.environ/OPENAI_API_KEY` for an OpenAI model. The reference is stored in graph JSON and resolved only when the operator is constructed or invoked on the worker.
+
+For LiteLLM `nvidia_nim/...` models, use `os.environ/NVIDIA_API_KEY`. The worker resolves that reference and passes the value as `api_key`. If you omit `api_key`, LiteLLM looks up `NVIDIA_NIM_API_KEY` instead.
 
 Literal keys remain available for non-persisted local execution, but attempting to serialize one raises an error. This prevents graph persistence from silently substituting an NVIDIA credential for another provider's key.
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -257,6 +257,8 @@ QAGenerationOperator(
 )
 ```
 
+For LiteLLM `nvidia_nim/...` models, including the default `LiteLLMClient` and `LLMJudge` models, use `os.environ/NVIDIA_API_KEY`. Refer to [Authentication and API keys](api-keys.md#credential-references-in-persisted-graphs).
+
 Serializing a graph containing a literal API key fails with a contextual error instead of guessing which provider credential should be used on a worker.
 
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -482,6 +482,10 @@ uv pip install "nemo-retriever[llm]"
 export NVIDIA_API_KEY=nvapi-...
 ```
 
+The default Live RAG model uses LiteLLM's `nvidia_nim` provider. LiteLLM does not
+read `NVIDIA_API_KEY` for that provider. Pass `api_key="os.environ/NVIDIA_API_KEY"`
+so the same key is forwarded on each request.
+
 Single-query live RAG. Point `vdb_kwargs["uri"]` at any table built above; the
 embedding model in `embed_kwargs` must match the one used during ingestion so
 query vectors land in the same embedding space as the stored chunks.
@@ -501,6 +505,7 @@ retriever = Retriever(
 )
 llm = LiteLLMClient.from_kwargs(
     model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    api_key="os.environ/NVIDIA_API_KEY",
     temperature=0.0,
     max_tokens=512,
 )
@@ -522,6 +527,7 @@ from nemo_retriever.models.llm import LLMJudge
 
 judge = LLMJudge.from_kwargs(
     model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    api_key="os.environ/NVIDIA_API_KEY",
     temperature=0.1,
     max_tokens=4096,
 )


### PR DESCRIPTION
﻿## Summary
- Live RAG `LiteLLMClient` / `LLMJudge` examples now pass `api_key="os.environ/NVIDIA_API_KEY"` so the default `nvidia_nim` model receives the hosted-inference key.
- Published API-key and Python API pages state that LiteLLM does not read `NVIDIA_API_KEY` for `nvidia_nim`; omit-`api_key` looks up `NVIDIA_NIM_API_KEY`.
- Docs-only. The `LiteLLMClient` class docstring still lists `NVIDIA_API_KEY` as auto-read (`litellm.py:57-58`); that is source drift for a follow-up eng change.

Fixes NVBug 6622594.

## Test plan
- [ ] Copy the Live RAG README example with only `NVIDIA_API_KEY` set and confirm the request is sent (not `error='transport_error'` from a missing LiteLLM key name)
- [ ] Confirm `api_key="os.environ/NVIDIA_API_KEY"` still matches the working OpenAI example earlier on the same README
- [ ] Confirm the PR diff is only the three documentation files

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** `docs/docs/extraction/api-keys.md`, `docs/docs/extraction/nemo-retriever-api-reference.md`, `nemo_retriever/README.md`

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — no `see [` CTAs on these three files; no `nimOperator` / `nvcr.io/nim` / `installFfmpeg` on faq.md, overview.md, or multimodal-extraction.md. Leakage script vs `origin/main` reported leftover untracked `custom-metadata.md` (not in this diff; fork `origin/main` is behind `upstream/main`). |
| Allowed paths | PASS — 3 documentation files |
| mkdocs --strict | PASS for this change — exit 1 from untracked leftover pages `custom-metadata.md` and `user-defined-stages.md`, which are not in this diff |
| ::a audit | PASS — 4 claims at ~95%: `os.environ/NVIDIA_API_KEY` resolves at call time (`resolve_environment_reference`, `LiteLLMClient.complete`, `test_llm_params.py`); default models are `nvidia_nim/...` (`litellm.py:70`, `judge.py:237`); omit-`api_key` is provider-native (`LLMRemoteClientParams`); `nvidia_nim` lookup name is `NVIDIA_NIM_API_KEY` (evaluation README). Dropped `NVIDIA_NIM_ADMIN_KEY` (no in-repo evidence). |
| ::p polish | Applied — aligned README wording with api-keys; used "worker" instead of "library"; removed unverified admin-key name |
| ::r style | 95% — no blocking issues on the new prose |

**Code drift (not in this docs PR):** `nemo_retriever/src/nemo_retriever/models/llm/clients/litellm.py:57-58` still lists `NVIDIA_API_KEY` as auto-read. Evaluation README `LLMJudge` `nvidia_nim` example still omits `api_key`. `transport_error` masking is a separate product defect.

**PR:** this draft
