### PR TITLE
docs(extraction): pin GitHub source links to the 26.08.1 tag (NVBug 6628516)

### DIFF
--- a/docs/docs/extraction/agentic-retrieval-concept.md
+++ b/docs/docs/extraction/agentic-retrieval-concept.md
@@ -12,4 +12,4 @@ For commands, service configuration, request and response contracts, and failure
 
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Semantic retrieval](vdbs.md#semantic-retrieval)
-- [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md)
+- [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md)

--- a/docs/docs/extraction/agentic-retrieval-concept.md
+++ b/docs/docs/extraction/agentic-retrieval-concept.md
@@ -12,4 +12,4 @@ For commands, service configuration, request and response contracts, and failure
 
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Semantic retrieval](vdbs.md#semantic-retrieval)
-- [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md)
+- [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md)

--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -3,7 +3,7 @@
 NeMo Retriever uses different credentials depending on what you are doing:
 
 - **`NVIDIA_API_KEY`** — Authorizes HTTP calls to [NVIDIA-hosted NIMs](https://build.nvidia.com/) (for example `ai.api.nvidia.com` and `integrate.api.nvidia.com`). Obtain this key from [build.nvidia.com](https://build.nvidia.com/). Keys typically start with `nvapi-`.
-- **NGC personal key** — Used when you install the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) so the cluster can authenticate to NGC Helm repos, pull images from `nvcr.io`, and provide `NGC_API_KEY` to in-cluster NIM workloads.
+- **NGC personal key** — Used when you install the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md) so the cluster can authenticate to NGC Helm repos, pull images from `nvcr.io`, and provide `NGC_API_KEY` to in-cluster NIM workloads.
 
 You may need one or both, for example if you deploy with Helm from NGC and also call hosted inference APIs.
 
@@ -70,7 +70,7 @@ On Windows PowerShell you can use `$env:NGC_API_KEY = "<ngc-personal-key>"`.
 
 ## Using your NGC key with Helm { #using-your-ngc-key-with-helm }
 
-Set the chart values in the [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#secrets) section of the Helm chart README so the chart renders `ngc-secret` and `ngc-api`:
+Set the chart values in the [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#secrets) section of the Helm chart README so the chart renders `ngc-secret` and `ngc-api`:
 
 - `ngcImagePullSecret.create` and `ngcImagePullSecret.password` create the `ngc-secret` dockerconfigjson Secret for pulls from `nvcr.io`.
 - `ngcApiSecret.create` and `ngcApiSecret.password` create the `ngc-api` Secret with `NGC_API_KEY` and `NGC_CLI_API_KEY`. The service container maps `NGC_API_KEY` and `NVIDIA_API_KEY` from the Secret `NGC_API_KEY` key when the Secret exists.
@@ -86,4 +86,4 @@ helm install retriever ./nemo_retriever/helm \
 
 Helm accepts unknown `--set` paths without error. Paths such as `imagePullSecret`, `nimApiKey`, and `nims.ngcApiKey` do not create either Secret.
 
-For defaults and additional fields, refer to [`values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/values.yaml).
+For defaults and additional fields, refer to [`values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/values.yaml).

--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -3,7 +3,7 @@
 NeMo Retriever uses different credentials depending on what you are doing:
 
 - **`NVIDIA_API_KEY`** — Authorizes HTTP calls to [NVIDIA-hosted NIMs](https://build.nvidia.com/) (for example `ai.api.nvidia.com` and `integrate.api.nvidia.com`). Obtain this key from [build.nvidia.com](https://build.nvidia.com/). Keys typically start with `nvapi-`.
-- **NGC personal key** — Used when you install the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md) so the cluster can authenticate to NGC Helm repos, pull images from `nvcr.io`, and provide `NGC_API_KEY` to in-cluster NIM workloads.
+- **NGC personal key** — Used when you install the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md) so the cluster can authenticate to NGC Helm repos, pull images from `nvcr.io`, and provide `NGC_API_KEY` to in-cluster NIM workloads.
 
 You may need one or both, for example if you deploy with Helm from NGC and also call hosted inference APIs.
 
@@ -70,7 +70,7 @@ On Windows PowerShell you can use `$env:NGC_API_KEY = "<ngc-personal-key>"`.
 
 ## Using your NGC key with Helm { #using-your-ngc-key-with-helm }
 
-Set the chart values in the [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#secrets) section of the Helm chart README so the chart renders `ngc-secret` and `ngc-api`:
+Set the chart values in the [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#secrets) section of the Helm chart README so the chart renders `ngc-secret` and `ngc-api`:
 
 - `ngcImagePullSecret.create` and `ngcImagePullSecret.password` create the `ngc-secret` dockerconfigjson Secret for pulls from `nvcr.io`.
 - `ngcApiSecret.create` and `ngcApiSecret.password` create the `ngc-api` Secret with `NGC_API_KEY` and `NGC_CLI_API_KEY`. The service container maps `NGC_API_KEY` and `NVIDIA_API_KEY` from the Secret `NGC_API_KEY` key when the Secret exists.
@@ -86,4 +86,4 @@ helm install retriever ./nemo_retriever/helm \
 
 Helm accepts unknown `--set` paths without error. Paths such as `imagePullSecret`, `nimApiKey`, and `nims.ngcApiKey` do not create either Secret.
 
-For defaults and additional fields, refer to [`values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/values.yaml).
+For defaults and additional fields, refer to [`values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/values.yaml).

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -10,7 +10,7 @@ For air-gapped or disconnected deployments, refer to [Air-gapped and disconnecte
 
 This documentation describes two ways to run [NeMo Retriever Library](overview.md) with the [parakeet-1-1b-ctc-en-us ASR NIM microservice](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) (`nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us`) to extract speech from audio files:
 
-- Run the NIM locally on your cluster with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
+- Run the NIM locally on your cluster with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md)
 - Use NVIDIA Cloud Functions (NVCF) endpoints for cloud-based inference
 
 Supported file types for speech extraction today:
@@ -45,7 +45,7 @@ requirements.
 
 For Kubernetes deployments with network access to package repositories, set
 `service.installFfmpeg=true` in the
-[Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#1-service-image)
+[Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#1-service-image)
 to install ffmpeg/ffprobe at service startup. This runtime path requires
 package-repository network egress, a writable root filesystem, and a security
 policy that allows the image's scoped sudo use. For air-gapped clusters, refer to
@@ -61,9 +61,9 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 ## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
-Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes through the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md). Parakeet is disabled by default and is not auto-wired into the retriever service. Refer to [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) for the enablement table. GPU pinning is documented in [Parakeet ASR](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#audio-video-parakeet).
+Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes through the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md). Parakeet is disabled by default and is not auto-wired into the retriever service. Refer to [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) for the enablement table. GPU pinning is documented in [Parakeet ASR](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#audio-video-parakeet).
 
-1. Deploy or upgrade with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md). Set both of the following values, then follow [Deployment options](deployment-options.md).
+1. Deploy or upgrade with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md). Set both of the following values, then follow [Deployment options](deployment-options.md).
 
     ```yaml
     nimOperator:
@@ -79,7 +79,7 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
     Enabling only the audio NIM deploys Parakeet and leaves `audio_grpc_endpoint` set to `null`.
 
-2. If the service will process audio or video files, set `service.installFfmpeg=true` in the Helm chart when your cluster allows runtime package installation; for air-gapped clusters, refer to [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#1-service-image) for `service.image` overrides.
+2. If the service will process audio or video files, set `service.installFfmpeg=true` in the Helm chart when your cluster allows runtime package installation; for air-gapped clusters, refer to [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#1-service-image) for `service.image` overrides.
 
 3. After the services are running, interact with the pipeline from Python (refer to the [Python API guide](nemo-retriever-api-reference.md) for parameter details).
 

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -10,7 +10,7 @@ For air-gapped or disconnected deployments, refer to [Air-gapped and disconnecte
 
 This documentation describes two ways to run [NeMo Retriever Library](overview.md) with the [parakeet-1-1b-ctc-en-us ASR NIM microservice](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) (`nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us`) to extract speech from audio files:
 
-- Run the NIM locally on your cluster with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
+- Run the NIM locally on your cluster with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
 - Use NVIDIA Cloud Functions (NVCF) endpoints for cloud-based inference
 
 Supported file types for speech extraction today:
@@ -45,7 +45,7 @@ requirements.
 
 For Kubernetes deployments with network access to package repositories, set
 `service.installFfmpeg=true` in the
-[Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image)
+[Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#1-service-image)
 to install ffmpeg/ffprobe at service startup. This runtime path requires
 package-repository network egress, a writable root filesystem, and a security
 policy that allows the image's scoped sudo use. For air-gapped clusters, refer to
@@ -61,9 +61,9 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 ## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
-Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes through the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Parakeet is disabled by default and is not auto-wired into the retriever service. Refer to [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) for the enablement table. GPU pinning is documented in [Parakeet ASR](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#audio-video-parakeet).
+Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes through the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md). Parakeet is disabled by default and is not auto-wired into the retriever service. Refer to [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) for the enablement table. GPU pinning is documented in [Parakeet ASR](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#audio-video-parakeet).
 
-1. Deploy or upgrade with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Set both of the following values, then follow [Deployment options](deployment-options.md).
+1. Deploy or upgrade with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md). Set both of the following values, then follow [Deployment options](deployment-options.md).
 
     ```yaml
     nimOperator:
@@ -79,7 +79,7 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
     Enabling only the audio NIM deploys Parakeet and leaves `audio_grpc_endpoint` set to `null`.
 
-2. If the service will process audio or video files, set `service.installFfmpeg=true` in the Helm chart when your cluster allows runtime package installation; for air-gapped clusters, refer to [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image) for `service.image` overrides.
+2. If the service will process audio or video files, set `service.installFfmpeg=true` in the Helm chart when your cluster allows runtime package installation; for air-gapped clusters, refer to [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#1-service-image) for `service.image` overrides.
 
 3. After the services are running, interact with the pipeline from Python (refer to the [Python API guide](nemo-retriever-api-reference.md) for parameter details).
 

--- a/docs/docs/extraction/concepts.md
+++ b/docs/docs/extraction/concepts.md
@@ -7,7 +7,7 @@ These terms appear throughout NeMo Retriever Library documentation.
 An **ingestion job** is a unit of work you run on input content (documents, audio, video, and other supported types). Submit jobs through any of these supported entry points:
 
 - **Python API** — `Ingestor` task chains such as `.extract(...)`. Library and batch modes run ingest in-process. Against a deployed Retriever service (`run_mode="service"`), the client wraps the REST contract below. Refer to the [Python API guide](nemo-retriever-api-reference.md).
-- **`retriever ingest` CLI** — including `retriever ingest service` for a running service. Refer to the [CLI reference](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
+- **`retriever ingest` CLI** — including `retriever ingest service` for a running service. Refer to the [CLI reference](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
 - **Retriever service REST API** — the public two-step ingest workflow:
   1. Create and configure the job aggregate with `POST /v1/ingest/job` and an `application/json` `JobCreateRequest` body. The JSON sets job-level fields such as `expected_documents`; it does not embed document bytes.
   2. Upload document content separately with multipart requests to job-scoped endpoints such as `POST /v1/ingest/job/{job_id}/document`.
@@ -45,7 +45,7 @@ Token-based splitting uses the revision-pinned tokenizer for the default embeddi
 ## Deployment modes { #deployment-modes }
 
 - **Library mode** — Run without the full container stack where appropriate; refer to [Deployment options](deployment-options.md).
-- **Kubernetes / Helm (self-hosted)** — Refer to [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and [deployment options](deployment-options.md) for running the full microservices pipeline on your infrastructure.
-- **Notebooks** — [Jupyter examples](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md) for experimentation and RAG demos.
+- **Kubernetes / Helm (self-hosted)** — Refer to [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md) and [deployment options](deployment-options.md) for running the full microservices pipeline on your infrastructure.
+- **Notebooks** — [Jupyter examples](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md) for experimentation and RAG demos.
 
 For a concise comparison, refer to [Deployment options](deployment-options.md).

--- a/docs/docs/extraction/concepts.md
+++ b/docs/docs/extraction/concepts.md
@@ -7,7 +7,7 @@ These terms appear throughout NeMo Retriever Library documentation.
 An **ingestion job** is a unit of work you run on input content (documents, audio, video, and other supported types). Submit jobs through any of these supported entry points:
 
 - **Python API** — `Ingestor` task chains such as `.extract(...)`. Library and batch modes run ingest in-process. Against a deployed Retriever service (`run_mode="service"`), the client wraps the REST contract below. Refer to the [Python API guide](nemo-retriever-api-reference.md).
-- **`retriever ingest` CLI** — including `retriever ingest service` for a running service. Refer to the [CLI reference](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
+- **`retriever ingest` CLI** — including `retriever ingest service` for a running service. Refer to the [CLI reference](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli).
 - **Retriever service REST API** — the public two-step ingest workflow:
   1. Create and configure the job aggregate with `POST /v1/ingest/job` and an `application/json` `JobCreateRequest` body. The JSON sets job-level fields such as `expected_documents`; it does not embed document bytes.
   2. Upload document content separately with multipart requests to job-scoped endpoints such as `POST /v1/ingest/job/{job_id}/document`.
@@ -45,7 +45,7 @@ Token-based splitting uses the revision-pinned tokenizer for the default embeddi
 ## Deployment modes { #deployment-modes }
 
 - **Library mode** — Run without the full container stack where appropriate; refer to [Deployment options](deployment-options.md).
-- **Kubernetes / Helm (self-hosted)** — Refer to [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md) and [deployment options](deployment-options.md) for running the full microservices pipeline on your infrastructure.
-- **Notebooks** — [Jupyter examples](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md) for experimentation and RAG demos.
+- **Kubernetes / Helm (self-hosted)** — Refer to [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md) and [deployment options](deployment-options.md) for running the full microservices pipeline on your infrastructure.
+- **Notebooks** — [Jupyter examples](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md) for experimentation and RAG demos.
 
 For a concise comparison, refer to [Deployment options](deployment-options.md).

--- a/docs/docs/extraction/content-metadata.md
+++ b/docs/docs/extraction/content-metadata.md
@@ -289,7 +289,7 @@ The following enums are used by this schema:
 
 The following is an example JSON representation of metadata. 
 This is an example only, and does not contain the full metadata.
-For the full file, refer to the [data folder](https://github.com/NVIDIA/NeMo-Retriever/blob/main/data/multimodal_test.json).
+For the full file, refer to the [data folder](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/data/multimodal_test.json).
 
 ```json
 {

--- a/docs/docs/extraction/content-metadata.md
+++ b/docs/docs/extraction/content-metadata.md
@@ -289,7 +289,7 @@ The following enums are used by this schema:
 
 The following is an example JSON representation of metadata. 
 This is an example only, and does not contain the full metadata.
-For the full file, refer to the [data folder](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/data/multimodal_test.json).
+For the full file, refer to the [data folder](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/data/multimodal_test.json).
 
 ```json
 {

--- a/docs/docs/extraction/customize-extend.md
+++ b/docs/docs/extraction/customize-extend.md
@@ -35,8 +35,8 @@ Use UDFs when you need a small, self-contained transformation that is not covere
 
 ### Repository guides
 
-- [NeMo Retriever graph README — `UDFOperator`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/graph#using-udfoperator) — API, lifecycle, and when to use `UDFOperator` versus a custom operator class
-- [NimClient and custom NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints) — call custom or self-hosted NIM microservices from UDF stages
+- [NeMo Retriever graph README — `UDFOperator`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/src/nemo_retriever/graph#using-udfoperator) — API, lifecycle, and when to use `UDFOperator` versus a custom operator class
+- [NimClient and custom NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints) — call custom or self-hosted NIM microservices from UDF stages
 
 ## Custom graph pipelines { #custom-graph-pipelines }
 
@@ -44,17 +44,17 @@ When you need to compose pipelines stage-by-stage, reuse operators across workfl
 
 The graph package provides `AbstractOperator`, executors (`InprocessExecutor`, `RayDataExecutor`), and operator chaining with `>>`. Built-in ingestion operators live under `nemo_retriever.operators`; you can add your own operators or UDF stages anywhere in the chain.
 
-For the full guide—including custom operator classes, executors, and graph shape constraints—refer to the [NeMo Retriever graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
+For the full guide—including custom operator classes, executors, and graph shape constraints—refer to the [NeMo Retriever graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
 
 ## Custom vector databases { #custom-vector-databases }
 
 The supported user path for vector storage is **[LanceDB](vdbs.md)** (`vdb_op="lancedb"`). That page covers upload, semantic retrieval, metadata filtering, and LanceDB deployment characteristics.
 
-To integrate a different vector store, implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface and wire it through graph [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py) / [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py). NVIDIA validates the first-party LanceDB operator; you are responsible for testing and maintaining other backends.
+To integrate a different vector store, implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface and wire it through graph [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/operators/vdb.py) / [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/operators/vdb.py). NVIDIA validates the first-party LanceDB operator; you are responsible for testing and maintaining other backends.
 
 ### Repository guides
 
-- [Vector DB package (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/common/vdb) — `VDB` abstract base and LanceDB reference implementation
+- [Vector DB package (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb) — `VDB` abstract base and LanceDB reference implementation
 
 Partner and blueprint integrations (Elasticsearch, Pinecone, Teradata, and others) are summarized on [Vector databases — Vector database partners](vdbs.md#vector-database-partners).
 

--- a/docs/docs/extraction/customize-extend.md
+++ b/docs/docs/extraction/customize-extend.md
@@ -35,8 +35,8 @@ Use UDFs when you need a small, self-contained transformation that is not covere
 
 ### Repository guides
 
-- [NeMo Retriever graph README — `UDFOperator`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#using-udfoperator) — API, lifecycle, and when to use `UDFOperator` versus a custom operator class
-- [NimClient and custom NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints) — call custom or self-hosted NIM microservices from UDF stages
+- [NeMo Retriever graph README — `UDFOperator`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/graph#using-udfoperator) — API, lifecycle, and when to use `UDFOperator` versus a custom operator class
+- [NimClient and custom NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints) — call custom or self-hosted NIM microservices from UDF stages
 
 ## Custom graph pipelines { #custom-graph-pipelines }
 
@@ -44,17 +44,17 @@ When you need to compose pipelines stage-by-stage, reuse operators across workfl
 
 The graph package provides `AbstractOperator`, executors (`InprocessExecutor`, `RayDataExecutor`), and operator chaining with `>>`. Built-in ingestion operators live under `nemo_retriever.operators`; you can add your own operators or UDF stages anywhere in the chain.
 
-For the full guide—including custom operator classes, executors, and graph shape constraints—refer to the [NeMo Retriever graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
+For the full guide—including custom operator classes, executors, and graph shape constraints—refer to the [NeMo Retriever graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
 
 ## Custom vector databases { #custom-vector-databases }
 
 The supported user path for vector storage is **[LanceDB](vdbs.md)** (`vdb_op="lancedb"`). That page covers upload, semantic retrieval, metadata filtering, and LanceDB deployment characteristics.
 
-To integrate a different vector store, implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface and wire it through graph [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/operators/vdb.py) / [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/operators/vdb.py). NVIDIA validates the first-party LanceDB operator; you are responsible for testing and maintaining other backends.
+To integrate a different vector store, implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface and wire it through graph [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py) / [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py). NVIDIA validates the first-party LanceDB operator; you are responsible for testing and maintaining other backends.
 
 ### Repository guides
 
-- [Vector DB package (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/common/vdb) — `VDB` abstract base and LanceDB reference implementation
+- [Vector DB package (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/common/vdb) — `VDB` abstract base and LanceDB reference implementation
 
 Partner and blueprint integrations (Elasticsearch, Pinecone, Teradata, and others) are summarized on [Vector databases — Vector database partners](vdbs.md#vector-database-partners).
 

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -9,16 +9,16 @@ Use the sections below to pick documentation and deployment options that match y
 ### I want to run locally or embed the library
 
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-2. [Use the Python API](nemo-retriever-api-reference.md) or [Use the CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli) — install and run the [`nemo_retriever`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever) package in your environment
+2. [Use the Python API](nemo-retriever-api-reference.md) or [Use the CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli) — install and run the [`nemo_retriever`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever) package in your environment
 
 ### I want a standalone Docker service container
 
-Build and run the NeMo Retriever service image with the [Docker service image guide](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docker.md). Use this for local service-container validation; use Helm for multi-service Kubernetes deployments.
+Build and run the NeMo Retriever service image with the [Docker service image guide](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docker.md). Use this for local service-container validation; use Helm for multi-service Kubernetes deployments.
 
 ### I want a Kubernetes / Helm deployment
 
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md). Chart sources are in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm) on GitHub. Before you install, confirm persistent-volume binding and four allocatable GPU slots across eligible nodes, or GPU sharing, for the four default NIMServices. Refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling). When you change a NIM image repository or tag on an existing release, delete the `NIMCache` before you upgrade. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md). Chart sources are in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/helm) on GitHub. Before you install, confirm persistent-volume binding and four allocatable GPU slots across eligible nodes, or GPU sharing, for the four default NIMServices. Refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling). When you change a NIM image repository or tag on an existing release, delete the `NIMCache` before you upgrade. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 3. **Published Library Helm charts (supported):** cluster install and upgrade procedures are covered in [About getting started](getting-started-about.md) — use alongside the NeMo Retriever chart README for your release
 4. [Environment variables](environment-config.md) and [Troubleshoot](troubleshoot.md) as needed
 
@@ -29,7 +29,7 @@ worker is unavailable, so Kubernetes removes the gateway from Service endpoints.
 In split topology, the realtime and batch init containers reach `/v1/live`
 through the chart's internal gateway startup Service
 (`<release>-nemo-retriever-gateway-startup`) so a clean install is not blocked
-by that readiness gate. Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#health-probes).
+by that readiness gate. Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#health-probes).
 In split topology, the gateway authenticates public requests. When internal
 service authentication is configured, the gateway uses it for restricted worker
 handoffs instead of forwarding public credentials. Without internal service
@@ -40,14 +40,14 @@ If you use `ServiceIngestor.vdb_upload()` sidecar metadata in split topology,
 upload and reference the metadata while the singleton gateway remains running.
 At ingest admission, the gateway binds the metadata to the work item. Workers
 receive the bound attachment and do not resolve sidecar IDs.
-Refer to [Sidecar metadata in split topology](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#sidecar-metadata-in-split-topology).
-**Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are enabled and auto-wired into the retriever service by default. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, **Parakeet ASR**, and the **answer-generation LLM** (`answer_llm`, Super-49B defaults) are optional and disabled by default. When you opt in, Omni captioning and VL reranking auto-wire into `nim_endpoints`; Parakeet ASR still needs an explicit `audioGrpcEndpoint`. Enabling the Omni caption key does not enable `POST /v1/answer`. For `/v1/answer`, enable `nimOperator.answer_llm` or point `serviceConfig.llm` at a supported OpenAI-compatible LLM or vision-language model (VLM), including Omni. For a minimal GPU footprint, leave optional keys disabled (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims), [Answer generation](prerequisites-support-matrix.md#answer-generation), and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
+Refer to [Sidecar metadata in split topology](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#sidecar-metadata-in-split-topology).
+**Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are enabled and auto-wired into the retriever service by default. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, **Parakeet ASR**, and the **answer-generation LLM** (`answer_llm`, Super-49B defaults) are optional and disabled by default. When you opt in, Omni captioning and VL reranking auto-wire into `nim_endpoints`; Parakeet ASR still needs an explicit `audioGrpcEndpoint`. Enabling the Omni caption key does not enable `POST /v1/answer`. For `/v1/answer`, enable `nimOperator.answer_llm` or point `serviceConfig.llm` at a supported OpenAI-compatible LLM or vision-language model (VLM), including Omni. For a minimal GPU footprint, leave optional keys disabled (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims), [Answer generation](prerequisites-support-matrix.md#answer-generation), and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 
 For audio and video extraction in Kubernetes, refer to [Audio and video](audio-video.md).
 
 ### I want examples and notebooks
 
-1. [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md)
+1. [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md)
 
 ### I need API details and keys
 
@@ -82,23 +82,23 @@ Consider self-hosting when:
 - You run at large scale where dedicated capacity can cost less than hosted API usage.
 - You must meet latency or locality requirements that hosted regions cannot satisfy.
 
-**GPU sharing.** Combined core NIM VRAM fits on one A10G or better GPU, but the default Helm chart still requests four exclusive GPU slots. Time-slicing creates logical slots. It does not pin the four NIM pods onto one physical GPU. Refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
+**GPU sharing.** Combined core NIM VRAM fits on one A10G or better GPU, but the default Helm chart still requests four exclusive GPU slots. Time-slicing creates logical slots. It does not pin the four NIM pods onto one physical GPU. Refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
 
 ## Air-gapped and disconnected deployment { #air-gapped-deployment }
 
 The **default document extraction pipeline** (page elements, table structure, OCR, and VL embed) runs disconnected when you mirror images and models into a private registry and configure the [NIM Operator for air-gapped environments](https://docs.nvidia.com/nim-operator/latest/air-gap.html).
 
-On a staging host with internet access, pull from NGC, retag to your private registry, stage chart archives, then install in the enclave with registry overrides. Procedures, the chart image inventory, and Helm value patterns are in [Helm — Air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#air-gapped-deployment).
+On a staging host with internet access, pull from NGC, retag to your private registry, stage chart archives, then install in the enclave with registry overrides. Procedures, the chart image inventory, and Helm value patterns are in [Helm — Air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#air-gapped-deployment).
 
 !!! warning "Audio and video extraction"
 
-    Audio and video workflows require `ffmpeg` and `ffprobe` on `PATH`; runtime package installation is not suitable for air-gapped clusters. Refer to [Audio and video](audio-video.md) and the Helm chart [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#air-gapped-deployment) guide. Skip this if you do not use audio or video.
+    Audio and video workflows require `ffmpeg` and `ffprobe` on `PATH`; runtime package installation is not suitable for air-gapped clusters. Refer to [Audio and video](audio-video.md) and the Helm chart [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#air-gapped-deployment) guide. Skip this if you do not use audio or video.
 
 For offline image captioning, deploy the in-cluster [Nemotron 3 Nano Omni](prerequisites-support-matrix.md#image-captioning) NIM and point your pipeline caption endpoint at the in-cluster HTTP URL instead of `integrate.api.nvidia.com` or other hosted APIs.
 
 **Related**
 
-- [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md) ([`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm) on GitHub) — [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#air-gapped-deployment)
+- [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md) ([`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/helm) on GitHub) — [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#air-gapped-deployment)
 - [About getting started](getting-started-about.md) (prerequisites through first deployment)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Audio and video](audio-video.md)

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -9,16 +9,16 @@ Use the sections below to pick documentation and deployment options that match y
 ### I want to run locally or embed the library
 
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-2. [Use the Python API](nemo-retriever-api-reference.md) or [Use the CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli) — install and run the [`nemo_retriever`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever) package in your environment
+2. [Use the Python API](nemo-retriever-api-reference.md) or [Use the CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli) — install and run the [`nemo_retriever`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever) package in your environment
 
 ### I want a standalone Docker service container
 
-Build and run the NeMo Retriever service image with the [Docker service image guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md). Use this for local service-container validation; use Helm for multi-service Kubernetes deployments.
+Build and run the NeMo Retriever service image with the [Docker service image guide](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docker.md). Use this for local service-container validation; use Helm for multi-service Kubernetes deployments.
 
 ### I want a Kubernetes / Helm deployment
 
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Chart sources are in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub. Before you install, confirm persistent-volume binding and four allocatable GPU slots across eligible nodes, or GPU sharing, for the four default NIMServices. Refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling). When you change a NIM image repository or tag on an existing release, delete the `NIMCache` before you upgrade. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+2. **NeMo Retriever Helm chart (supported):** [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md). Chart sources are in [`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm) on GitHub. Before you install, confirm persistent-volume binding and four allocatable GPU slots across eligible nodes, or GPU sharing, for the four default NIMServices. Refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling). When you change a NIM image repository or tag on an existing release, delete the `NIMCache` before you upgrade. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 3. **Published Library Helm charts (supported):** cluster install and upgrade procedures are covered in [About getting started](getting-started-about.md) — use alongside the NeMo Retriever chart README for your release
 4. [Environment variables](environment-config.md) and [Troubleshoot](troubleshoot.md) as needed
 
@@ -29,7 +29,7 @@ worker is unavailable, so Kubernetes removes the gateway from Service endpoints.
 In split topology, the realtime and batch init containers reach `/v1/live`
 through the chart's internal gateway startup Service
 (`<release>-nemo-retriever-gateway-startup`) so a clean install is not blocked
-by that readiness gate. Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes).
+by that readiness gate. Refer to the Helm chart [health probe guidance](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#health-probes).
 In split topology, the gateway authenticates public requests. When internal
 service authentication is configured, the gateway uses it for restricted worker
 handoffs instead of forwarding public credentials. Without internal service
@@ -40,14 +40,14 @@ If you use `ServiceIngestor.vdb_upload()` sidecar metadata in split topology,
 upload and reference the metadata while the singleton gateway remains running.
 At ingest admission, the gateway binds the metadata to the work item. Workers
 receive the bound attachment and do not resolve sidecar IDs.
-Refer to [Sidecar metadata in split topology](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#sidecar-metadata-in-split-topology).
-**Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are enabled and auto-wired into the retriever service by default. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, **Parakeet ASR**, and the **answer-generation LLM** (`answer_llm`, Super-49B defaults) are optional and disabled by default. When you opt in, Omni captioning and VL reranking auto-wire into `nim_endpoints`; Parakeet ASR still needs an explicit `audioGrpcEndpoint`. Enabling the Omni caption key does not enable `POST /v1/answer`. For `/v1/answer`, enable `nimOperator.answer_llm` or point `serviceConfig.llm` at a supported OpenAI-compatible LLM or vision-language model (VLM), including Omni. For a minimal GPU footprint, leave optional keys disabled (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims), [Answer generation](prerequisites-support-matrix.md#answer-generation), and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
+Refer to [Sidecar metadata in split topology](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#sidecar-metadata-in-split-topology).
+**Core NIMs for the default extraction pipeline:** `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:2.3.0`). These four are enabled and auto-wired into the retriever service by default. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, **Parakeet ASR**, and the **answer-generation LLM** (`answer_llm`, Super-49B defaults) are optional and disabled by default. When you opt in, Omni captioning and VL reranking auto-wire into `nim_endpoints`; Parakeet ASR still needs an explicit `audioGrpcEndpoint`. Enabling the Omni caption key does not enable `POST /v1/answer`. For `/v1/answer`, enable `nimOperator.answer_llm` or point `serviceConfig.llm` at a supported OpenAI-compatible LLM or vision-language model (VLM), including Omni. For a minimal GPU footprint, leave optional keys disabled (refer to [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#recommended-minimal-install-2608)). Refer to [Pre-Requisites & Support Matrix — Default NIMs](prerequisites-support-matrix.md#default-helm-nims), [Answer generation](prerequisites-support-matrix.md#answer-generation), and [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 
 For audio and video extraction in Kubernetes, refer to [Audio and video](audio-video.md).
 
 ### I want examples and notebooks
 
-1. [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md)
+1. [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md)
 
 ### I need API details and keys
 
@@ -82,23 +82,23 @@ Consider self-hosting when:
 - You run at large scale where dedicated capacity can cost less than hosted API usage.
 - You must meet latency or locality requirements that hosted regions cannot satisfy.
 
-**GPU sharing.** Combined core NIM VRAM fits on one A10G or better GPU, but the default Helm chart still requests four exclusive GPU slots. Time-slicing creates logical slots. It does not pin the four NIM pods onto one physical GPU. Refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
+**GPU sharing.** Combined core NIM VRAM fits on one A10G or better GPU, but the default Helm chart still requests four exclusive GPU slots. Time-slicing creates logical slots. It does not pin the four NIM pods onto one physical GPU. Refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
 
 ## Air-gapped and disconnected deployment { #air-gapped-deployment }
 
 The **default document extraction pipeline** (page elements, table structure, OCR, and VL embed) runs disconnected when you mirror images and models into a private registry and configure the [NIM Operator for air-gapped environments](https://docs.nvidia.com/nim-operator/latest/air-gap.html).
 
-On a staging host with internet access, pull from NGC, retag to your private registry, stage chart archives, then install in the enclave with registry overrides. Procedures, the chart image inventory, and Helm value patterns are in [Helm — Air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#air-gapped-deployment).
+On a staging host with internet access, pull from NGC, retag to your private registry, stage chart archives, then install in the enclave with registry overrides. Procedures, the chart image inventory, and Helm value patterns are in [Helm — Air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#air-gapped-deployment).
 
 !!! warning "Audio and video extraction"
 
-    Audio and video workflows require `ffmpeg` and `ffprobe` on `PATH`; runtime package installation is not suitable for air-gapped clusters. Refer to [Audio and video](audio-video.md) and the Helm chart [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#air-gapped-deployment) guide. Skip this if you do not use audio or video.
+    Audio and video workflows require `ffmpeg` and `ffprobe` on `PATH`; runtime package installation is not suitable for air-gapped clusters. Refer to [Audio and video](audio-video.md) and the Helm chart [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#air-gapped-deployment) guide. Skip this if you do not use audio or video.
 
 For offline image captioning, deploy the in-cluster [Nemotron 3 Nano Omni](prerequisites-support-matrix.md#image-captioning) NIM and point your pipeline caption endpoint at the in-cluster HTTP URL instead of `integrate.api.nvidia.com` or other hosted APIs.
 
 **Related**
 
-- [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) ([`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub) — [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#air-gapped-deployment)
+- [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md) ([`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm) on GitHub) — [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#air-gapped-deployment)
 - [About getting started](getting-started-about.md) (prerequisites through first deployment)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Audio and video](audio-video.md)

--- a/docs/docs/extraction/embedding.md
+++ b/docs/docs/extraction/embedding.md
@@ -2,7 +2,7 @@
 
 !!! note "Text-only NeMo Retriever embedding NIM"
 
-    You can still use the NeMo Retriever text embedding NIM (OpenAI-compatible embeddings for passage and query vectors) alongside or instead of the multimodal flows on this page. Product and deployment details are in the [NeMo Retriever Text Embedding NIM documentation](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html). In library and CLI pipelines, route embedding to that NIM with your configured embed endpoint and model name (refer to the [graph pipeline examples](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md) for environment-based remote inference).
+    You can still use the NeMo Retriever text embedding NIM (OpenAI-compatible embeddings for passage and query vectors) alongside or instead of the multimodal flows on this page. Product and deployment details are in the [NeMo Retriever Text Embedding NIM documentation](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html). In library and CLI pipelines, route embedding to that NIM with your configured embed endpoint and model name (refer to the [graph pipeline examples](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/README.md) for environment-based remote inference).
 
 This documentation describes how to use [NeMo Retriever Library](overview.md) 
 with the multimodal embedding model [Llama Nemotron Embed VL 1B v2](https://build.nvidia.com/nvidia/llama-nemotron-embed-vl-1b-v2).

--- a/docs/docs/extraction/embedding.md
+++ b/docs/docs/extraction/embedding.md
@@ -2,7 +2,7 @@
 
 !!! note "Text-only NeMo Retriever embedding NIM"
 
-    You can still use the NeMo Retriever text embedding NIM (OpenAI-compatible embeddings for passage and query vectors) alongside or instead of the multimodal flows on this page. Product and deployment details are in the [NeMo Retriever Text Embedding NIM documentation](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html). In library and CLI pipelines, route embedding to that NIM with your configured embed endpoint and model name (refer to the [graph pipeline examples](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/README.md) for environment-based remote inference).
+    You can still use the NeMo Retriever text embedding NIM (OpenAI-compatible embeddings for passage and query vectors) alongside or instead of the multimodal flows on this page. Product and deployment details are in the [NeMo Retriever Text Embedding NIM documentation](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html). In library and CLI pipelines, route embedding to that NIM with your configured embed endpoint and model name (refer to the [graph pipeline examples](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/README.md) for environment-based remote inference).
 
 This documentation describes how to use [NeMo Retriever Library](overview.md) 
 with the multimodal embedding model [Llama Nemotron Embed VL 1B v2](https://build.nvidia.com/nvidia/llama-nemotron-embed-vl-1b-v2).

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -34,9 +34,9 @@ for record in result.to_dict(orient="records"):
 
 Iterate the DataFrame, or convert it with `to_dict(orient="records")`, then send text, path, and metadata to your retriever.
 
-The public `retriever ingest` CLI runs extraction, embedding, and LanceDB indexing as one workflow. It does not return extraction-only rows. Use that command when you want a ready-to-query LanceDB table. For CLI usage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
+The public `retriever ingest` CLI runs extraction, embedding, and LanceDB indexing as one workflow. It does not return extraction-only rows. Use that command when you want a ready-to-query LanceDB table. For CLI usage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
 
-For Python ingest and indexing, refer to [Ingest documents into a searchable VDB collection](workflow-document-ingestion.md). After you have an index, the Jupyter notebooks [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb) and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb) show framework integration.
+For Python ingest and indexing, refer to [Ingest documents into a searchable VDB collection](workflow-document-ingestion.md). After you have an index, the Jupyter notebooks [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/llama_index_multimodal_rag.ipynb) and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/langchain_multimodal_rag.ipynb) show framework integration.
 
 ## Where does NeMo Retriever Library ingest to? { #where-does-nrl-ingest-to }
 
@@ -81,7 +81,7 @@ On a conventional cluster without GPU sharing, extra core NIM pods stay `Pending
 
 The chart keeps the same `NIMCache` name when you change a NIM image repository or tag. The NIM Operator marks `spec.source.ngc.modelPuller` immutable, so Kubernetes rejects the in-place update.
 
-Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Helm upgrade fails when changing a NIM image repository or tag](troubleshoot.md#helm-nimcache-modelpuller-immutable) and [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Helm upgrade fails when changing a NIM image repository or tag](troubleshoot.md#helm-nimcache-modelpuller-immutable) and [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 
 ## Why do NIMCache and NIMService still use ngc-secret after I rename ngcImagePullSecret.name? { #helm-nim-secret-rename }
 
@@ -91,7 +91,7 @@ A non-empty per-NIM override takes precedence. If you previously set those field
 
 `imagePullSecrets` applies only to Retriever Pods. It does not appear on NIMCache or NIMService.
 
-Refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [NIMCache or NIMService still uses ngc-secret after a global Secret rename](troubleshoot.md#helm-nim-secret-names).
+Refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [NIMCache or NIMService still uses ngc-secret after a global Secret rename](troubleshoot.md#helm-nim-secret-names).
 
 ## Why are the environment variables different between library mode and self-hosted mode? { #library-vs-self-hosted-env-vars }
 
@@ -106,7 +106,7 @@ For production environments, you should use the provided Helm charts. When you r
 
 For advanced scenarios, you might want to use library mode with self-hosted NIM instances. 
 You can set custom endpoints for each NIM. 
-For examples of `*_ENDPOINT` variables, refer to [Environment variables](environment-config.md) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
+For examples of `*_ENDPOINT` variables, refer to [Environment variables](environment-config.md) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md).
 
 When you explicitly configure remote NIM endpoints in Python library mode, graph ingestion raises a `GraphIngestionError` if a stage reports row-level connection or inference errors. This makes unreachable services visible to callers instead of returning a DataFrame that looks successful. To intentionally keep partial results with row-level error payloads, pass `error_policy="collect"` to `GraphIngestor` or `create_ingestor`. Refer to the [Python API error contract](nemo-retriever-api-reference.md#error-and-failure-contract) and [Python API error triage](troubleshoot.md#python-api-error-triage) for error signals, extraction-path mappings, and escalation criteria.
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -34,9 +34,9 @@ for record in result.to_dict(orient="records"):
 
 Iterate the DataFrame, or convert it with `to_dict(orient="records")`, then send text, path, and metadata to your retriever.
 
-The public `retriever ingest` CLI runs extraction, embedding, and LanceDB indexing as one workflow. It does not return extraction-only rows. Use that command when you want a ready-to-query LanceDB table. For CLI usage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
+The public `retriever ingest` CLI runs extraction, embedding, and LanceDB indexing as one workflow. It does not return extraction-only rows. Use that command when you want a ready-to-query LanceDB table. For CLI usage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli).
 
-For Python ingest and indexing, refer to [Ingest documents into a searchable VDB collection](workflow-document-ingestion.md). After you have an index, the Jupyter notebooks [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/llama_index_multimodal_rag.ipynb) and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/langchain_multimodal_rag.ipynb) show framework integration.
+For Python ingest and indexing, refer to [Ingest documents into a searchable VDB collection](workflow-document-ingestion.md). After you have an index, the Jupyter notebooks [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/llama_index_multimodal_rag.ipynb) and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/langchain_multimodal_rag.ipynb) show framework integration.
 
 ## Where does NeMo Retriever Library ingest to? { #where-does-nrl-ingest-to }
 
@@ -81,7 +81,7 @@ On a conventional cluster without GPU sharing, extra core NIM pods stay `Pending
 
 The chart keeps the same `NIMCache` name when you change a NIM image repository or tag. The NIM Operator marks `spec.source.ngc.modelPuller` immutable, so Kubernetes rejects the in-place update.
 
-Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Helm upgrade fails when changing a NIM image repository or tag](troubleshoot.md#helm-nimcache-modelpuller-immutable) and [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Helm upgrade fails when changing a NIM image repository or tag](troubleshoot.md#helm-nimcache-modelpuller-immutable) and [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 
 ## Why do NIMCache and NIMService still use ngc-secret after I rename ngcImagePullSecret.name? { #helm-nim-secret-rename }
 
@@ -91,7 +91,7 @@ A non-empty per-NIM override takes precedence. If you previously set those field
 
 `imagePullSecrets` applies only to Retriever Pods. It does not appear on NIMCache or NIMService.
 
-Refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [NIMCache or NIMService still uses ngc-secret after a global Secret rename](troubleshoot.md#helm-nim-secret-names).
+Refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [NIMCache or NIMService still uses ngc-secret after a global Secret rename](troubleshoot.md#helm-nim-secret-names).
 
 ## Why are the environment variables different between library mode and self-hosted mode? { #library-vs-self-hosted-env-vars }
 
@@ -106,7 +106,7 @@ For production environments, you should use the provided Helm charts. When you r
 
 For advanced scenarios, you might want to use library mode with self-hosted NIM instances. 
 You can set custom endpoints for each NIM. 
-For examples of `*_ENDPOINT` variables, refer to [Environment variables](environment-config.md) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md).
+For examples of `*_ENDPOINT` variables, refer to [Environment variables](environment-config.md) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md).
 
 When you explicitly configure remote NIM endpoints in Python library mode, graph ingestion raises a `GraphIngestionError` if a stage reports row-level connection or inference errors. This makes unreachable services visible to callers instead of returning a DataFrame that looks successful. To intentionally keep partial results with row-level error payloads, pass `error_policy="collect"` to `GraphIngestor` or `create_ingestor`. Refer to the [Python API error contract](nemo-retriever-api-reference.md#error-and-failure-contract) and [Python API error triage](troubleshoot.md#python-api-error-triage) for error signals, extraction-path mappings, and escalation criteria.
 

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -6,8 +6,8 @@ Typical order:
 
 1. [Get your API key](api-keys.md) (NGC / API access as required by your workflow).
 2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, software stack, and Kubernetes persistent storage and GPU scheduling if you use Helm. Local GPU inference requires Linux; remote NIM workflows can use the base package on Windows x64 and macOS Apple Silicon (arm64) as well. macOS Intel (x86_64) is not supported.
-3. Choose a path in [Deployment options](deployment-options.md). You can use the local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service. For Helm, complete the [persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite) and the [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) before `helm install`.
-4. Explore [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md) for end-to-end examples.
+3. Choose a path in [Deployment options](deployment-options.md). You can use the local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service. For Helm, complete the [persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite) and the [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) before `helm install`.
+4. Explore [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md) for end-to-end examples.
 
 The NeMo Retriever Library and its Helm chart are not supported under NVIDIA AI Enterprise (NVAIE). For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -6,8 +6,8 @@ Typical order:
 
 1. [Get your API key](api-keys.md) (NGC / API access as required by your workflow).
 2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, software stack, and Kubernetes persistent storage and GPU scheduling if you use Helm. Local GPU inference requires Linux; remote NIM workflows can use the base package on Windows x64 and macOS Apple Silicon (arm64) as well. macOS Intel (x86_64) is not supported.
-3. Choose a path in [Deployment options](deployment-options.md). You can use the local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service. For Helm, complete the [persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite) and the [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) before `helm install`.
-4. Explore [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md) for end-to-end examples.
+3. Choose a path in [Deployment options](deployment-options.md). You can use the local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service. For Helm, complete the [persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#persistent-storage-prerequisite) and the [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) before `helm install`.
+4. Explore [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md) for end-to-end examples.
 
 The NeMo Retriever Library and its Helm chart are not supported under NVIDIA AI Enterprise (NVAIE). For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -74,7 +74,7 @@ For natural-language infographic descriptions, optionally enable [image captioni
 
 Scanned PDFs and image-only pages rely on OCR and hybrid paths that combine native text extraction with OCR when needed. For extract methods such as `ocr` and `pdfium_hybrid`, refer to the [Python API reference](nemo-retriever-api-reference.md).
 
-When you run extraction locally with Hugging Face weights, the default OCR engine is **Nemotron OCR v2**, which operates in **multilingual** mode by default. For CLI flags and API parameters, refer to [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#ocr-language-mode). For Kubernetes image pins and overrides, refer to [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#ocr-nim-configuration). For hosted OCR endpoints and the NVCF language-mode limitation, refer to [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
+When you run extraction locally with Hugging Face weights, the default OCR engine is **Nemotron OCR v2**, which operates in **multilingual** mode by default. For CLI flags and API parameters, refer to [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docs/cli/README.md#ocr-language-mode). For Kubernetes image pins and overrides, refer to [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#ocr-nim-configuration). For hosted OCR endpoints and the NVCF language-mode limitation, refer to [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 
 **Related**
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -74,7 +74,7 @@ For natural-language infographic descriptions, optionally enable [image captioni
 
 Scanned PDFs and image-only pages rely on OCR and hybrid paths that combine native text extraction with OCR when needed. For extract methods such as `ocr` and `pdfium_hybrid`, refer to the [Python API reference](nemo-retriever-api-reference.md).
 
-When you run extraction locally with Hugging Face weights, the default OCR engine is **Nemotron OCR v2**, which operates in **multilingual** mode by default. For CLI flags and API parameters, refer to [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#ocr-language-mode). For Kubernetes image pins and overrides, refer to [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration). For hosted OCR endpoints and the NVCF language-mode limitation, refer to [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
+When you run extraction locally with Hugging Face weights, the default OCR engine is **Nemotron OCR v2**, which operates in **multilingual** mode by default. For CLI flags and API parameters, refer to [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#ocr-language-mode). For Kubernetes image pins and overrides, refer to [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#ocr-nim-configuration). For hosted OCR endpoints and the NVCF language-mode limitation, refer to [Default NVCF endpoints](prerequisites-support-matrix.md#default-nvcf-endpoints).
 
 **Related**
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -168,7 +168,7 @@ actions, and escalation criteria, refer to
 
 Large PDFs are split into page batches before Ray processing so extraction can run in parallel. This happens on the default ingest path; you do not need extra configuration for typical workloads.
 
-To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). Refer to [Local and batch ingest](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli#local-and-batch-ingest) in the CLI reference.
+To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). Refer to [Local and batch ingest](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli#local-and-batch-ingest) in the CLI reference.
 
 **Python client (`pdf_split_config`):** Only `create_ingestor(run_mode="service")` implements `.pdf_split_config(pages_per_chunk=...)`, which records page-chunking settings in the request pipeline spec for the remote gateway. Local graph ingest (`run_mode="inprocess"` or `"batch"`) raises `NotImplementedError` if you call this method; PDFs are split automatically on the default ingest path without client-side configuration.
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -168,7 +168,7 @@ actions, and escalation criteria, refer to
 
 Large PDFs are split into page batches before Ray processing so extraction can run in parallel. This happens on the default ingest path; you do not need extra configuration for typical workloads.
 
-To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). Refer to [Local and batch ingest](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli#local-and-batch-ingest) in the CLI reference.
+To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). Refer to [Local and batch ingest](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli#local-and-batch-ingest) in the CLI reference.
 
 **Python client (`pdf_split_config`):** Only `create_ingestor(run_mode="service")` implements `.pdf_split_config(pages_per_chunk=...)`, which records page-chunking settings in the request pipeline spec for the remote gateway. Local graph ingest (`run_mode="inprocess"` or `"batch"`) raises `NotImplementedError` if you call this method; PDFs are split automatically on the default ingest path without client-side configuration.
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -55,7 +55,7 @@ NeMo Retriever Library supports the following file types:
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Deployment options](deployment-options.md) — library, Helm, hosted vs self-hosted NIMs in one place
-- [Deploy on Kubernetes with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
-- [Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md)
+- [Deploy on Kubernetes with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
+- [Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md)
 - [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) — solution cards, enterprise RAG blueprints, and end-to-end patterns (including [Enterprise RAG — multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag))
-- For integration pathways, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md).
+- For integration pathways, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md).

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -55,7 +55,7 @@ NeMo Retriever Library supports the following file types:
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Deployment options](deployment-options.md) — library, Helm, hosted vs self-hosted NIMs in one place
-- [Deploy on Kubernetes with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
-- [Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md)
+- [Deploy on Kubernetes with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md)
+- [Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md)
 - [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) — solution cards, enterprise RAG blueprints, and end-to-end patterns (including [Enterprise RAG — multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag))
-- For integration pathways, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md).
+- For integration pathways, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md).

--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -66,7 +66,7 @@ chunks = (
 )
 ```
 
-Related batch-size, CPU, and GPU-per-actor flags are documented in the [CLI ingest options](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md).
+Related batch-size, CPU, and GPU-per-actor flags are documented in the [CLI ingest options](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docs/cli/README.md).
 
 Use the Ray dashboard to verify the available-resource snapshot and the planned worker allocation when you tune throughput.
 

--- a/docs/docs/extraction/performance_guide.md
+++ b/docs/docs/extraction/performance_guide.md
@@ -66,7 +66,7 @@ chunks = (
 )
 ```
 
-Related batch-size, CPU, and GPU-per-actor flags are documented in the [CLI ingest options](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md).
+Related batch-size, CPU, and GPU-per-actor flags are documented in the [CLI ingest options](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md).
 
 Use the Ray dashboard to verify the available-resource snapshot and the planned worker allocation when you tune throughput.
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -47,7 +47,7 @@ kubectl get pv
 
 If the cluster has no StorageClass and no compatible `Available` persistent volumes, stop and add a binding strategy before you install. `helm install` can report `STATUS: deployed` while every claim remains `Pending`, which leaves the retriever service, VectorDB, and core NIM workloads unschedulable.
 
-For claim names, Helm value paths, and example `--set` flags, refer to [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite) in the Helm chart README. For Helm success with Pending claims, refer to [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
+For claim names, Helm value paths, and example `--set` flags, refer to [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#persistent-storage-prerequisite) in the Helm chart README. For Helm success with Pending claims, refer to [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
 
 ## Kubernetes Helm GPU scheduling { #kubernetes-helm-gpu-scheduling }
 
@@ -66,7 +66,7 @@ Time-slicing creates logical GPU slots. It does not pin the four independently s
 
 The chart still renders `nvidia.com/gpu: 1` per NIMService unless a per-NIM `resources` block overrides it. Sharing is cluster configuration through the GPU Operator, not a Helm value. Applying `devicePlugin.config.default: "any"` is a cluster-administrator change that oversubscribes every eligible GPU Operator node and can affect unrelated GPU workloads. Time-slicing does not isolate GPU memory. Combined VRAM of the scheduled NIMs must still fit on the physical GPU. MIG is an advanced GPU Operator configuration outside this chart. The chart does not set a MIG strategy, MIG profile, or MIG resource requests.
 
-For the time-slicing ConfigMap, ClusterPolicy patch, node placement, and preflight commands, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) in the Helm chart README. For pods that stay `Pending` on `nvidia.com/gpu`, refer to [Core NIM pods stay Pending for GPU](troubleshoot.md#helm-pending-gpus).
+For the time-slicing ConfigMap, ClusterPolicy patch, node placement, and preflight commands, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) in the Helm chart README. For pods that stay `Pending` on `nvidia.com/gpu`, refer to [Core NIM pods stay Pending for GPU](troubleshoot.md#helm-pending-gpus).
 
 ## Hardware Requirements { #hardware-requirements }
 
@@ -122,7 +122,7 @@ Optional advanced features (audio and video transcription, Nemotron Parse, Omni 
 >
 > A NIM or model listed in the default and optional NIM rows in the table below might be supported under NVIDIA AI Enterprise (NVAIE) as an individual product. That support does **not** cover its use through NeMo Retriever Library or extend to the library, its container image, its Helm chart, or the end-to-end extraction workflow.
 
-The production Helm chart reconciles NIM microservices through `nimOperator.<key>.enabled`. Four core NIMs are **enabled by default** and auto-wired into the retriever service; optional NIMs reconcile only when you opt in. For chart keys, image overrides, and enablement, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#nim-operator-sub-stack) and [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#recommended-minimal-install-2608).
+The production Helm chart reconciles NIM microservices through `nimOperator.<key>.enabled`. Four core NIMs are **enabled by default** and auto-wired into the retriever service; optional NIMs reconcile only when you opt in. For chart keys, image overrides, and enablement, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#nim-operator-sub-stack) and [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#recommended-minimal-install-2608).
 
 | Helm flag | NIM | Default image (`repository:tag`) | Role | Enabled by default |
 |-----------|-----|----------------------------------|------|--------------------|
@@ -168,7 +168,7 @@ Setting `nimOperator.rerankqa.enabled=true` without `serviceConfig.nimEndpoints.
 
 ### Default NVCF endpoints { #default-nvcf-endpoints }
 
-When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-hosted-nims) from the Python library or CLI, these are the default remote endpoints the library uses when you do not set invoke URLs. Self-hosted Helm NIMs use in-cluster service URLs instead (refer to the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#nim-operator-sub-stack)).
+When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-hosted-nims) from the Python library or CLI, these are the default remote endpoints the library uses when you do not set invoke URLs. Self-hosted Helm NIMs use in-cluster service URLs instead (refer to the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#nim-operator-sub-stack)).
 
 | NIM | Default hosted endpoint | Notes |
 |-----|-------------------------|-------|
@@ -196,7 +196,7 @@ When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-host
 
     For model/endpoint mismatch symptoms, refer to [Nemotron Parse model and endpoint mismatch](troubleshoot.md#nemotron-parse-model-endpoint-mismatch).
 
-For local Hugging Face OCR language mode (`multi` vs `english`), Helm OCR image overrides, and local model install, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#ocr-nim-configuration), and [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#ocr-language-mode).
+For local Hugging Face OCR language mode (`multi` vs `english`), Helm OCR image overrides, and local model install, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#ocr-nim-configuration), and [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docs/cli/README.md#ocr-language-mode).
 
 ### Image captioning { #image-captioning }
 
@@ -235,7 +235,7 @@ The default Super-49B NIMService is **in addition to** the four core NIMs. It is
 
 The [model hardware requirements](#model-hardware-requirements) table lists GPU SKUs that can run that default Super-49B profile. A100 40GB, A10G, L40S, and RTX PRO 4500 Blackwell are not supported for the default BF16 TP2 profile. The [NVIDIA NIM for Large Language Models support matrix](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html) includes other Super-49B profiles with a different tensor-parallel size or precision. Those profiles require Helm `resources`, `modelProfile`, and `env` overrides. They are not the chart default.
 
-For enablement flags, Omni reuse, and image overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm) in the Helm chart README. For other Super-49B NIM profiles, refer to the [NVIDIA NIM for Large Language Models support matrix](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html).
+For enablement flags, Omni reuse, and image overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#answer-generation-llm) in the Helm chart README. For other Super-49B NIM profiles, refer to the [NVIDIA NIM for Large Language Models support matrix](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html).
 
 Omni hardware for answer generation matches the Omni caption rows in the table below. Size a dedicated Omni `answer_llm` deployment from those rows. Do not add a second Omni GPU or cache when you reuse an already running caption Omni endpoint.
 
@@ -291,9 +291,9 @@ and run only the embedder, reranker, and your vector database.
 - [Troubleshooting](troubleshoot.md)
 - [Release Notes](releasenotes.md)
 - [Deployment options](deployment-options.md) (local Python, hosted NIMs, and Kubernetes)
-- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
-- [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite)
-- [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite)
+- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md)
+- [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#persistent-storage-prerequisite)
+- [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite)
 - [NVIDIA NIM for Object Detection (supported hardware and memory footprint)](https://docs.nvidia.com/nim/ingestion/object-detection/latest/support-matrix.html#supported-hardware-and-memory-footprint)
 - [NVIDIA NIM for Image OCR (supported hardware and memory footprint)](https://docs.nvidia.com/nim/ingestion/image-ocr/latest/support-matrix.html#supported-hardware-and-memory-footprint)
 - [NVIDIA NeMo Retriever Embedding NIM (memory footprint)](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/support-matrix.html#memory-footprint)
@@ -301,4 +301,4 @@ and run only the embedder, reranker, and your vector database.
 - [NVIDIA NIM for Vision Language Models (support matrix)](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html)
 - [NVIDIA NIM for Large Language Models (support matrix)](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html)
 - [NVIDIA Speech NIM Microservices (support matrix)](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/index.html)
-- [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm)
+- [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#answer-generation-llm)

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -47,7 +47,7 @@ kubectl get pv
 
 If the cluster has no StorageClass and no compatible `Available` persistent volumes, stop and add a binding strategy before you install. `helm install` can report `STATUS: deployed` while every claim remains `Pending`, which leaves the retriever service, VectorDB, and core NIM workloads unschedulable.
 
-For claim names, Helm value paths, and example `--set` flags, refer to [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite) in the Helm chart README. For Helm success with Pending claims, refer to [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
+For claim names, Helm value paths, and example `--set` flags, refer to [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite) in the Helm chart README. For Helm success with Pending claims, refer to [Helm install succeeds but PersistentVolumeClaims stay Pending](troubleshoot.md#helm-pending-pvcs).
 
 ## Kubernetes Helm GPU scheduling { #kubernetes-helm-gpu-scheduling }
 
@@ -66,7 +66,7 @@ Time-slicing creates logical GPU slots. It does not pin the four independently s
 
 The chart still renders `nvidia.com/gpu: 1` per NIMService unless a per-NIM `resources` block overrides it. Sharing is cluster configuration through the GPU Operator, not a Helm value. Applying `devicePlugin.config.default: "any"` is a cluster-administrator change that oversubscribes every eligible GPU Operator node and can affect unrelated GPU workloads. Time-slicing does not isolate GPU memory. Combined VRAM of the scheduled NIMs must still fit on the physical GPU. MIG is an advanced GPU Operator configuration outside this chart. The chart does not set a MIG strategy, MIG profile, or MIG resource requests.
 
-For the time-slicing ConfigMap, ClusterPolicy patch, node placement, and preflight commands, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) in the Helm chart README. For pods that stay `Pending` on `nvidia.com/gpu`, refer to [Core NIM pods stay Pending for GPU](troubleshoot.md#helm-pending-gpus).
+For the time-slicing ConfigMap, ClusterPolicy patch, node placement, and preflight commands, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite) in the Helm chart README. For pods that stay `Pending` on `nvidia.com/gpu`, refer to [Core NIM pods stay Pending for GPU](troubleshoot.md#helm-pending-gpus).
 
 ## Hardware Requirements { #hardware-requirements }
 
@@ -122,7 +122,7 @@ Optional advanced features (audio and video transcription, Nemotron Parse, Omni 
 >
 > A NIM or model listed in the default and optional NIM rows in the table below might be supported under NVIDIA AI Enterprise (NVAIE) as an individual product. That support does **not** cover its use through NeMo Retriever Library or extend to the library, its container image, its Helm chart, or the end-to-end extraction workflow.
 
-The production Helm chart reconciles NIM microservices through `nimOperator.<key>.enabled`. Four core NIMs are **enabled by default** and auto-wired into the retriever service; optional NIMs reconcile only when you opt in. For chart keys, image overrides, and enablement, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack) and [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2608).
+The production Helm chart reconciles NIM microservices through `nimOperator.<key>.enabled`. Four core NIMs are **enabled by default** and auto-wired into the retriever service; optional NIMs reconcile only when you opt in. For chart keys, image overrides, and enablement, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#nim-operator-sub-stack) and [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#recommended-minimal-install-2608).
 
 | Helm flag | NIM | Default image (`repository:tag`) | Role | Enabled by default |
 |-----------|-----|----------------------------------|------|--------------------|
@@ -168,7 +168,7 @@ Setting `nimOperator.rerankqa.enabled=true` without `serviceConfig.nimEndpoints.
 
 ### Default NVCF endpoints { #default-nvcf-endpoints }
 
-When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-hosted-nims) from the Python library or CLI, these are the default remote endpoints the library uses when you do not set invoke URLs. Self-hosted Helm NIMs use in-cluster service URLs instead (refer to the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack)).
+When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-hosted-nims) from the Python library or CLI, these are the default remote endpoints the library uses when you do not set invoke URLs. Self-hosted Helm NIMs use in-cluster service URLs instead (refer to the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#nim-operator-sub-stack)).
 
 | NIM | Default hosted endpoint | Notes |
 |-----|-------------------------|-------|
@@ -196,7 +196,7 @@ When you call [NVIDIA-hosted NIMs](deployment-options.md#when-to-use-nvidia-host
 
     For model/endpoint mismatch symptoms, refer to [Nemotron Parse model and endpoint mismatch](troubleshoot.md#nemotron-parse-model-endpoint-mismatch).
 
-For local Hugging Face OCR language mode (`multi` vs `english`), Helm OCR image overrides, and local model install, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration), and [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#ocr-language-mode).
+For local Hugging Face OCR language mode (`multi` vs `english`), Helm OCR image overrides, and local model install, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#ocr-nim-configuration), and [CLI — OCR language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#ocr-language-mode).
 
 ### Image captioning { #image-captioning }
 
@@ -235,7 +235,7 @@ The default Super-49B NIMService is **in addition to** the four core NIMs. It is
 
 The [model hardware requirements](#model-hardware-requirements) table lists GPU SKUs that can run that default Super-49B profile. A100 40GB, A10G, L40S, and RTX PRO 4500 Blackwell are not supported for the default BF16 TP2 profile. The [NVIDIA NIM for Large Language Models support matrix](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html) includes other Super-49B profiles with a different tensor-parallel size or precision. Those profiles require Helm `resources`, `modelProfile`, and `env` overrides. They are not the chart default.
 
-For enablement flags, Omni reuse, and image overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#answer-generation-llm) in the Helm chart README. For other Super-49B NIM profiles, refer to the [NVIDIA NIM for Large Language Models support matrix](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html).
+For enablement flags, Omni reuse, and image overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm) in the Helm chart README. For other Super-49B NIM profiles, refer to the [NVIDIA NIM for Large Language Models support matrix](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html).
 
 Omni hardware for answer generation matches the Omni caption rows in the table below. Size a dedicated Omni `answer_llm` deployment from those rows. Do not add a second Omni GPU or cache when you reuse an already running caption Omni endpoint.
 
@@ -291,9 +291,9 @@ and run only the embedder, reranker, and your vector database.
 - [Troubleshooting](troubleshoot.md)
 - [Release Notes](releasenotes.md)
 - [Deployment options](deployment-options.md) (local Python, hosted NIMs, and Kubernetes)
-- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
-- [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite)
-- [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite)
+- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
+- [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite)
+- [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite)
 - [NVIDIA NIM for Object Detection (supported hardware and memory footprint)](https://docs.nvidia.com/nim/ingestion/object-detection/latest/support-matrix.html#supported-hardware-and-memory-footprint)
 - [NVIDIA NIM for Image OCR (supported hardware and memory footprint)](https://docs.nvidia.com/nim/ingestion/image-ocr/latest/support-matrix.html#supported-hardware-and-memory-footprint)
 - [NVIDIA NeMo Retriever Embedding NIM (memory footprint)](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/support-matrix.html#memory-footprint)
@@ -301,4 +301,4 @@ and run only the embedder, reranker, and your vector database.
 - [NVIDIA NIM for Vision Language Models (support matrix)](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html)
 - [NVIDIA NIM for Large Language Models (support matrix)](https://docs.nvidia.com/nim/large-language-models/latest/support-matrix.html)
 - [NVIDIA Speech NIM Microservices (support matrix)](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/index.html)
-- [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#answer-generation-llm)
+- [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm)

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -6,7 +6,7 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 NVIDIA® NeMo Retriever Library version 26.08 adds a shared text-generation task API, configurable large language model (LLM) settings, grounded answer-generation model paths, agentic retrieval, and updated Helm NIM defaults. It continues the 26.05 graph ingest, multimodal extraction, and Helm-first deployment foundation.
 
-To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
+To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md).
 
 The following sections summarize user-visible changes introduced in 26.08. Capabilities first documented in 26.05 that remain current are listed under [Continuing from 26.05](#continuing-from-2605).
 
@@ -20,7 +20,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - macOS Intel (x86_64) is no longer supported for package installs. Use Apple Silicon (arm64) macOS, Windows x64, or Linux. Refer to [Packaging and platform](#packaging-and-platform).
 - Legacy `nv-ingest` and compatibility pipeline CLI code paths are removed. Use `retriever ingest` and the graph stage registry.
 - Self-hosted Parakeet on Helm requires both `nimOperator.audio.enabled=true` and `serviceConfig.nimEndpoints.audioGrpcEndpoint=audio:50051`. Enabling the audio NIM alone does not wire the service ASR endpoint.
-- Changing a Helm NIM image repository or tag on an existing release cannot patch `NIMCache` `spec.source.ngc.modelPuller`. Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+- Changing a Helm NIM image repository or tag on an existing release cannot patch `NIMCache` `spec.source.ngc.modelPuller`. Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 - A document whose VectorDB write is not acknowledged now fails instead of reporting `completed` with a positive row count. Earlier builds failed only collection-managed writes and logged a legacy fixed-table failure as a warning. The worker acknowledgement timeout is configurable through `serviceConfig.vectordb.writeTimeoutSeconds` (rendered as `vectordb.write_timeout_s`) and defaults to 300 seconds. Refer to [Ingest fails with a VectorDB write error](troubleshoot.md#vectordb-write-not-acknowledged).
 - Retriever Service OpenAPI `info.version` no longer reports a stale `26.5.0` value. The service reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.
 
@@ -33,7 +33,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 ### Answer generation { #answer-generation }
 
 - `Retriever.answer()` and optional `POST /v1/answer` remain the grounded answer-generation path. The default LLM is `nvidia/llama-3.3-nemotron-super-49b-v1.5` (Helm `nimOperator.answer_llm` image `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5`). The generic slot also accepts another OpenAI-compatible LLM or vision-language model (VLM), including `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`.
-- Enabling the Omni caption Helm key does not enable `/v1/answer`. Use Omni as the answer backend by overriding the generic `answer_llm` slot or by pointing `serviceConfig.llm` at an Omni chat-completions endpoint. Refer to [Answer generation](prerequisites-support-matrix.md#answer-generation) and [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#answer-generation-llm).
+- Enabling the Omni caption Helm key does not enable `/v1/answer`. Use Omni as the answer backend by overriding the generic `answer_llm` slot or by pointing `serviceConfig.llm` at an Omni chat-completions endpoint. Refer to [Answer generation](prerequisites-support-matrix.md#answer-generation) and [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm).
 
 ### Agentic retrieval { #agentic-retrieval }
 
@@ -45,7 +45,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 
 ### Models, OCR, and NIM artifacts { #models-ocr-and-captioning }
 
-- Nemotron OCR v2 is unified across library, hosted, and Helm defaults. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration).
+- Nemotron OCR v2 is unified across library, hosted, and Helm defaults. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#ocr-nim-configuration).
 - Local OCR crop batching runs across page rows for throughput. Helm extraction NIMs (OCR and object detection) enable performance mode by default. The VL embed NIM does not.
 - 26.08 Helm default and optional NIM images that affect mirroring, allowlisting, and troubleshooting include the following:
     - Combined object detection for page elements and table structure: `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1`
@@ -56,7 +56,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - Optional Nemotron-3-Embed-1B is a released 26.08 embedding artifact. It is not enabled by default and is not a Helm NIM.
     - Optional NIM: `nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.2`
     - Optional Hugging Face checkpoint: `nvidia/Nemotron-3-Embed-1B-BF16` (revision `9e0b24858b1195815ecb1188ffa1b73bcea7b30a`)
-- The CLI lists `nvidia/Nemotron-3-Embed-1B-BF16` among tested official local checkpoints. For local Hugging Face inference, pass `--embed-model-name nvidia/Nemotron-3-Embed-1B-BF16`. For a self-hosted or hosted embedding NIM, pass `--embed-invoke-url` with `--embed-model-name`. Refer to [Dense Nemotron embedding checkpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#dense-nemotron-embedding-checkpoints) for local checkpoint usage. Refer to [Route ingest to hosted or self-hosted NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#route-ingest-to-hosted-or-self-hosted-nim-endpoints) and the text-only embedding NIM note in [Multimodal embeddings](embedding.md) for external endpoints.
+- The CLI lists `nvidia/Nemotron-3-Embed-1B-BF16` among tested official local checkpoints. For local Hugging Face inference, pass `--embed-model-name nvidia/Nemotron-3-Embed-1B-BF16`. For a self-hosted or hosted embedding NIM, pass `--embed-invoke-url` with `--embed-model-name`. Refer to [Dense Nemotron embedding checkpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#dense-nemotron-embedding-checkpoints) for local checkpoint usage. Refer to [Route ingest to hosted or self-hosted NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#route-ingest-to-hosted-or-self-hosted-nim-endpoints) and the text-only embedding NIM note in [Multimodal embeddings](embedding.md) for external endpoints.
 - The `page_elements` and `table_structure` services share the combined object-detection image and select distinct models. Pull that image once for air-gapped or allowlisted deployments.
 - Nemotron 3 Nano Omni is the canonical caption model. It is opt-in on Helm and has a larger GPU footprint than Nano caption profiles.
 - Nemotron Parse endpoint wiring is available in service extraction workers, with documented hosted versus self-hosted contract selection.
@@ -119,7 +119,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 
 - Published [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md) for CLI, service, REST, and MCP usage.
 - Published [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation) for `TextGenerationTask`, `GenericGenerationOperator`, `SummarizationOperator`, and `TextGenerationParams`.
-- Clarified Super-49B and Omni answer-generation paths on this page and in [Answer generation](prerequisites-support-matrix.md#answer-generation). For Helm enablement and slot overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#answer-generation-llm).
+- Clarified Super-49B and Omni answer-generation paths on this page and in [Answer generation](prerequisites-support-matrix.md#answer-generation). For Helm enablement and slot overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm).
 
 ### Continuing from 26.05 { #continuing-from-2605 }
 
@@ -146,7 +146,7 @@ The following capabilities shipped in 26.05 and remain current in 26.08. They ar
 - Evaluation includes a BEIR-centric overhaul and the experimental `retriever skill-eval` benchmark CLI.
 - Text-to-SQL agent graph and tabular tooling support structured data retrieval, including tabular data ingestion.
 - Optional install extras include `[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and slim remote or NIM-only installs on Mac and Windows.
-- Documentation is aligned to a Helm-first supported path and consolidates extraction concepts, ingest workflow, embeddings, audio and video guides, prerequisites and support matrix, and UDF or custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
+- Documentation is aligned to a Helm-first supported path and consolidates extraction concepts, ingest workflow, embeddings, audio and video guides, prerequisites and support matrix, and UDF or custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
 
 ## Release Notes for Previous Versions { #previous-versions }
 
@@ -169,4 +169,4 @@ Release notes for 24.12.1 and 24.12.0 are on the [25.3.0 archived release notes]
 - [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation)
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Deployment options](deployment-options.md)
-- [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
+- [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -6,7 +6,7 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 NVIDIA® NeMo Retriever Library version 26.08 adds a shared text-generation task API, configurable large language model (LLM) settings, grounded answer-generation model paths, agentic retrieval, and updated Helm NIM defaults. It continues the 26.05 graph ingest, multimodal extraction, and Helm-first deployment foundation.
 
-To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md).
+To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md).
 
 The following sections summarize user-visible changes introduced in 26.08. Capabilities first documented in 26.05 that remain current are listed under [Continuing from 26.05](#continuing-from-2605).
 
@@ -20,7 +20,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - macOS Intel (x86_64) is no longer supported for package installs. Use Apple Silicon (arm64) macOS, Windows x64, or Linux. Refer to [Packaging and platform](#packaging-and-platform).
 - Legacy `nv-ingest` and compatibility pipeline CLI code paths are removed. Use `retriever ingest` and the graph stage registry.
 - Self-hosted Parakeet on Helm requires both `nimOperator.audio.enabled=true` and `serviceConfig.nimEndpoints.audioGrpcEndpoint=audio:50051`. Enabling the audio NIM alone does not wire the service ASR endpoint.
-- Changing a Helm NIM image repository or tag on an existing release cannot patch `NIMCache` `spec.source.ngc.modelPuller`. Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+- Changing a Helm NIM image repository or tag on an existing release cannot patch `NIMCache` `spec.source.ngc.modelPuller`. Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 - A document whose VectorDB write is not acknowledged now fails instead of reporting `completed` with a positive row count. Earlier builds failed only collection-managed writes and logged a legacy fixed-table failure as a warning. The worker acknowledgement timeout is configurable through `serviceConfig.vectordb.writeTimeoutSeconds` (rendered as `vectordb.write_timeout_s`) and defaults to 300 seconds. Refer to [Ingest fails with a VectorDB write error](troubleshoot.md#vectordb-write-not-acknowledged).
 - Retriever Service OpenAPI `info.version` no longer reports a stale `26.5.0` value. The service reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.
 
@@ -33,7 +33,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 ### Answer generation { #answer-generation }
 
 - `Retriever.answer()` and optional `POST /v1/answer` remain the grounded answer-generation path. The default LLM is `nvidia/llama-3.3-nemotron-super-49b-v1.5` (Helm `nimOperator.answer_llm` image `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5`). The generic slot also accepts another OpenAI-compatible LLM or vision-language model (VLM), including `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`.
-- Enabling the Omni caption Helm key does not enable `/v1/answer`. Use Omni as the answer backend by overriding the generic `answer_llm` slot or by pointing `serviceConfig.llm` at an Omni chat-completions endpoint. Refer to [Answer generation](prerequisites-support-matrix.md#answer-generation) and [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm).
+- Enabling the Omni caption Helm key does not enable `/v1/answer`. Use Omni as the answer backend by overriding the generic `answer_llm` slot or by pointing `serviceConfig.llm` at an Omni chat-completions endpoint. Refer to [Answer generation](prerequisites-support-matrix.md#answer-generation) and [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#answer-generation-llm).
 
 ### Agentic retrieval { #agentic-retrieval }
 
@@ -45,7 +45,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 
 ### Models, OCR, and NIM artifacts { #models-ocr-and-captioning }
 
-- Nemotron OCR v2 is unified across library, hosted, and Helm defaults. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#ocr-nim-configuration).
+- Nemotron OCR v2 is unified across library, hosted, and Helm defaults. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#ocr-nim-configuration).
 - Local OCR crop batching runs across page rows for throughput. Helm extraction NIMs (OCR and object detection) enable performance mode by default. The VL embed NIM does not.
 - 26.08 Helm default and optional NIM images that affect mirroring, allowlisting, and troubleshooting include the following:
     - Combined object detection for page elements and table structure: `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1`
@@ -56,7 +56,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - Optional Nemotron-3-Embed-1B is a released 26.08 embedding artifact. It is not enabled by default and is not a Helm NIM.
     - Optional NIM: `nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.2`
     - Optional Hugging Face checkpoint: `nvidia/Nemotron-3-Embed-1B-BF16` (revision `9e0b24858b1195815ecb1188ffa1b73bcea7b30a`)
-- The CLI lists `nvidia/Nemotron-3-Embed-1B-BF16` among tested official local checkpoints. For local Hugging Face inference, pass `--embed-model-name nvidia/Nemotron-3-Embed-1B-BF16`. For a self-hosted or hosted embedding NIM, pass `--embed-invoke-url` with `--embed-model-name`. Refer to [Dense Nemotron embedding checkpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#dense-nemotron-embedding-checkpoints) for local checkpoint usage. Refer to [Route ingest to hosted or self-hosted NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#route-ingest-to-hosted-or-self-hosted-nim-endpoints) and the text-only embedding NIM note in [Multimodal embeddings](embedding.md) for external endpoints.
+- The CLI lists `nvidia/Nemotron-3-Embed-1B-BF16` among tested official local checkpoints. For local Hugging Face inference, pass `--embed-model-name nvidia/Nemotron-3-Embed-1B-BF16`. For a self-hosted or hosted embedding NIM, pass `--embed-invoke-url` with `--embed-model-name`. Refer to [Dense Nemotron embedding checkpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docs/cli/README.md#dense-nemotron-embedding-checkpoints) for local checkpoint usage. Refer to [Route ingest to hosted or self-hosted NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docs/cli/README.md#route-ingest-to-hosted-or-self-hosted-nim-endpoints) and the text-only embedding NIM note in [Multimodal embeddings](embedding.md) for external endpoints.
 - The `page_elements` and `table_structure` services share the combined object-detection image and select distinct models. Pull that image once for air-gapped or allowlisted deployments.
 - Nemotron 3 Nano Omni is the canonical caption model. It is opt-in on Helm and has a larger GPU footprint than Nano caption profiles.
 - Nemotron Parse endpoint wiring is available in service extraction workers, with documented hosted versus self-hosted contract selection.
@@ -119,7 +119,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 
 - Published [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md) for CLI, service, REST, and MCP usage.
 - Published [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation) for `TextGenerationTask`, `GenericGenerationOperator`, `SummarizationOperator`, and `TextGenerationParams`.
-- Clarified Super-49B and Omni answer-generation paths on this page and in [Answer generation](prerequisites-support-matrix.md#answer-generation). For Helm enablement and slot overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#answer-generation-llm).
+- Clarified Super-49B and Omni answer-generation paths on this page and in [Answer generation](prerequisites-support-matrix.md#answer-generation). For Helm enablement and slot overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#answer-generation-llm).
 
 ### Continuing from 26.05 { #continuing-from-2605 }
 
@@ -146,7 +146,7 @@ The following capabilities shipped in 26.05 and remain current in 26.08. They ar
 - Evaluation includes a BEIR-centric overhaul and the experimental `retriever skill-eval` benchmark CLI.
 - Text-to-SQL agent graph and tabular tooling support structured data retrieval, including tabular data ingestion.
 - Optional install extras include `[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and slim remote or NIM-only installs on Mac and Windows.
-- Documentation is aligned to a Helm-first supported path and consolidates extraction concepts, ingest workflow, embeddings, audio and video guides, prerequisites and support matrix, and UDF or custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
+- Documentation is aligned to a Helm-first supported path and consolidates extraction concepts, ingest workflow, embeddings, audio and video guides, prerequisites and support matrix, and UDF or custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
 
 ## Release Notes for Previous Versions { #previous-versions }
 
@@ -169,4 +169,4 @@ Release notes for 24.12.1 and 24.12.0 are on the [25.3.0 archived release notes]
 - [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation)
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Deployment options](deployment-options.md)
-- [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
+- [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md)

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -461,7 +461,7 @@ helm upgrade retriever ./nemo_retriever/helm \
   --set serviceConfig.vectordb.writeTimeoutSeconds=900
 ```
 
-For the rendered service key and sibling VectorDB values, refer to [Service configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#service-configuration-rendered-into-retriever-serviceyaml).
+For the rendered service key and sibling VectorDB values, refer to [Service configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#service-configuration-rendered-into-retriever-serviceyaml).
 
 
 ## Helm install succeeds but PersistentVolumeClaims stay Pending { #helm-pending-pvcs }
@@ -484,7 +484,7 @@ Complete the following checks:
 3. If you intended a named StorageClass, set the three chart-managed paths and the four per-NIM `nimOperator.<key>.storage.pvc.storageClass` paths. Do not set only `nimOperator.nimCache.pvc.storageClass`. That chart-level value is not applied to the core NIMCache resources.
 4. After you add a default StorageClass or compatible volumes, confirm the claims become `Bound`. If they remain `Pending`, uninstall and reinstall after the storage strategy is in place.
 
-For the default claim list, Helm value paths, and preflight commands, refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite).
+For the default claim list, Helm value paths, and preflight commands, refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#persistent-storage-prerequisite).
 
 ## Core NIM pods stay Pending for GPU { #helm-pending-gpus }
 
@@ -501,10 +501,10 @@ Complete the following checks:
 
 1. Run `kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu` and sum `GPU` across eligible nodes. A default core install needs four slots across the cluster. Four one-GPU nodes are enough. A single node needs four slots only when you pack all four core NIMs onto one physical GPU with sharing and placement constraints.
 2. Run `kubectl get pods --namespace <namespace>` and `kubectl describe pod <nim-pod>`. Confirm the Pending pods are the core NIMServices (`nemotron-page-elements-v3`, `nemotron-table-structure-v1`, `nemotron-ocr-v2`, and `llama-nemotron-embed-vl-1b-v2`).
-3. Either add GPU capacity so four slots are allocatable across the cluster, or configure GPU Operator time-slicing with at least four replicas before you reinstall. Time-slicing creates logical slots. MIG is an advanced GPU Operator configuration outside this chart. For one-GPU placement, cluster-wide oversubscription, and MIG constraints, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
+3. Either add GPU capacity so four slots are allocatable across the cluster, or configure GPU Operator time-slicing with at least four replicas before you reinstall. Time-slicing creates logical slots. MIG is an advanced GPU Operator configuration outside this chart. For one-GPU placement, cluster-wide oversubscription, and MIG constraints, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
 4. After sharing or extra GPUs are in place, confirm the four core NIM pods reach `Running`.
 
-For VRAM versus scheduling, the time-slicing ConfigMap, and ClusterPolicy patch, refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
+For VRAM versus scheduling, the time-slicing ConfigMap, and ClusterPolicy patch, refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
 
 ## Split topology Helm install or upgrade times out with Deployments not ready { #helm-split-topology-startup-deadlock }
 
@@ -541,7 +541,7 @@ kubectl patch service <release>-nemo-retriever-gateway --type=merge \
 ```
 
 Upgrade to a chart version that includes the startup Service so you do not need
-to repeat that patch after every reinstall. Refer to [Health probes](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#health-probes) and [Service networking](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#service-networking) in the Helm chart README.
+to repeat that patch after every reinstall. Refer to [Health probes](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#health-probes) and [Service networking](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#service-networking) in the Helm chart README.
 
 ## Helm upgrade fails when changing a NIM image repository or tag { #helm-nimcache-modelpuller-immutable }
 
@@ -568,7 +568,7 @@ The affected NIM is unavailable during re-cache. Repeat the sequence for every N
 
 Changing `service.image.repository` or `service.image.tag` does not use `NIMCache` and is not subject to this rule.
 
-For default cache names, PVC cleanup, and the full upgrade sequence, refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+For default cache names, PVC cleanup, and the full upgrade sequence, refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 
 ## NIMCache or NIMService still uses ngc-secret after a global Secret rename { #helm-nim-secret-names }
 
@@ -583,7 +583,7 @@ Complete the following checks:
 3. If a NIM still lists `ngc-secret` or `ngc-api` after you renamed the global Secret names, clear `nimOperator.<key>.image.pullSecrets` and `nimOperator.<key>.authSecret`, or set them to the new names. Empty values inherit the global names.
 4. Top-level `imagePullSecrets` applies only to Retriever Pods. It does not update NIM Operator custom resources.
 
-For value paths and a rename example, refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#secrets) in the Helm chart README.
+For value paths and a rename example, refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#secrets) in the Helm chart README.
 
 ## Agentic retrieval fails with auto tool choice HTTP 400 { #agentic-auto-tool-choice }
 
@@ -605,8 +605,8 @@ For the copy-paste Helm values and CLI command, refer to [Self-hosted Helm Super
 - [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements)
 - [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling)
 - [Deployment options](deployment-options.md)
-- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
-- [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag)
-- [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#use-externally-managed-secrets)
+- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md)
+- [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag)
+- [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#use-externally-managed-secrets)
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md#self-hosted-helm-super-49b)
 - [About getting started](getting-started-about.md) (prerequisites and deployment)

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -461,7 +461,7 @@ helm upgrade retriever ./nemo_retriever/helm \
   --set serviceConfig.vectordb.writeTimeoutSeconds=900
 ```
 
-For the rendered service key and sibling VectorDB values, refer to [Service configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#service-configuration-rendered-into-retriever-serviceyaml).
+For the rendered service key and sibling VectorDB values, refer to [Service configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#service-configuration-rendered-into-retriever-serviceyaml).
 
 
 ## Helm install succeeds but PersistentVolumeClaims stay Pending { #helm-pending-pvcs }
@@ -484,7 +484,7 @@ Complete the following checks:
 3. If you intended a named StorageClass, set the three chart-managed paths and the four per-NIM `nimOperator.<key>.storage.pvc.storageClass` paths. Do not set only `nimOperator.nimCache.pvc.storageClass`. That chart-level value is not applied to the core NIMCache resources.
 4. After you add a default StorageClass or compatible volumes, confirm the claims become `Bound`. If they remain `Pending`, uninstall and reinstall after the storage strategy is in place.
 
-For the default claim list, Helm value paths, and preflight commands, refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#persistent-storage-prerequisite).
+For the default claim list, Helm value paths, and preflight commands, refer to [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements) and [Persistent storage prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#persistent-storage-prerequisite).
 
 ## Core NIM pods stay Pending for GPU { #helm-pending-gpus }
 
@@ -501,10 +501,10 @@ Complete the following checks:
 
 1. Run `kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu` and sum `GPU` across eligible nodes. A default core install needs four slots across the cluster. Four one-GPU nodes are enough. A single node needs four slots only when you pack all four core NIMs onto one physical GPU with sharing and placement constraints.
 2. Run `kubectl get pods --namespace <namespace>` and `kubectl describe pod <nim-pod>`. Confirm the Pending pods are the core NIMServices (`nemotron-page-elements-v3`, `nemotron-table-structure-v1`, `nemotron-ocr-v2`, and `llama-nemotron-embed-vl-1b-v2`).
-3. Either add GPU capacity so four slots are allocatable across the cluster, or configure GPU Operator time-slicing with at least four replicas before you reinstall. Time-slicing creates logical slots. MIG is an advanced GPU Operator configuration outside this chart. For one-GPU placement, cluster-wide oversubscription, and MIG constraints, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
+3. Either add GPU capacity so four slots are allocatable across the cluster, or configure GPU Operator time-slicing with at least four replicas before you reinstall. Time-slicing creates logical slots. MIG is an advanced GPU Operator configuration outside this chart. For one-GPU placement, cluster-wide oversubscription, and MIG constraints, refer to [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
 4. After sharing or extra GPUs are in place, confirm the four core NIM pods reach `Running`.
 
-For VRAM versus scheduling, the time-slicing ConfigMap, and ClusterPolicy patch, refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
+For VRAM versus scheduling, the time-slicing ConfigMap, and ClusterPolicy patch, refer to [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling) and [GPU scheduling prerequisite](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#gpu-scheduling-prerequisite).
 
 ## Split topology Helm install or upgrade times out with Deployments not ready { #helm-split-topology-startup-deadlock }
 
@@ -541,7 +541,7 @@ kubectl patch service <release>-nemo-retriever-gateway --type=merge \
 ```
 
 Upgrade to a chart version that includes the startup Service so you do not need
-to repeat that patch after every reinstall. Refer to [Health probes](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#health-probes) and [Service networking](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#service-networking) in the Helm chart README.
+to repeat that patch after every reinstall. Refer to [Health probes](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#health-probes) and [Service networking](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#service-networking) in the Helm chart README.
 
 ## Helm upgrade fails when changing a NIM image repository or tag { #helm-nimcache-modelpuller-immutable }
 
@@ -568,7 +568,7 @@ The affected NIM is unavailable during re-cache. Repeat the sequence for every N
 
 Changing `service.image.repository` or `service.image.tag` does not use `NIMCache` and is not subject to this rule.
 
-For default cache names, PVC cleanup, and the full upgrade sequence, refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
+For default cache names, PVC cleanup, and the full upgrade sequence, refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 
 ## NIMCache or NIMService still uses ngc-secret after a global Secret rename { #helm-nim-secret-names }
 
@@ -583,7 +583,7 @@ Complete the following checks:
 3. If a NIM still lists `ngc-secret` or `ngc-api` after you renamed the global Secret names, clear `nimOperator.<key>.image.pullSecrets` and `nimOperator.<key>.authSecret`, or set them to the new names. Empty values inherit the global names.
 4. Top-level `imagePullSecrets` applies only to Retriever Pods. It does not update NIM Operator custom resources.
 
-For value paths and a rename example, refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#secrets) in the Helm chart README.
+For value paths and a rename example, refer to [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#use-externally-managed-secrets) and [Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#secrets) in the Helm chart README.
 
 ## Agentic retrieval fails with auto tool choice HTTP 400 { #agentic-auto-tool-choice }
 
@@ -605,8 +605,8 @@ For the copy-paste Helm values and CLI command, refer to [Self-hosted Helm Super
 - [Kubernetes Helm Storage Requirements](prerequisites-support-matrix.md#kubernetes-helm-storage-requirements)
 - [Kubernetes Helm GPU scheduling](prerequisites-support-matrix.md#kubernetes-helm-gpu-scheduling)
 - [Deployment options](deployment-options.md)
-- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
-- [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag)
-- [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#use-externally-managed-secrets)
+- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)
+- [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag)
+- [Use externally managed Secrets](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#use-externally-managed-secrets)
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md#self-hosted-helm-super-49b)
 - [About getting started](getting-started-about.md) (prerequisites and deployment)

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -37,7 +37,7 @@ NeMo Retriever Library supports uploading data through `.vdb_upload()` on `creat
 - **Local and batch CLI ingest** (`retriever ingest`, `retriever ingest local`, `retriever ingest batch`) persist embeddings to LanceDB (default URI `lancedb`, table `nemo-retriever`).
 - **Service CLI ingest** (`retriever ingest service`) writes to service-configured storage.
 
-For supported modes and target storage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
+For supported modes and target storage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli).
 
 `.vdb_upload()` does not generate embeddings. For dense SDK ingestion, include `.embed()` in the pipeline:
 
@@ -81,7 +81,7 @@ The following command runs local ingest into the default LanceDB table:
 retriever ingest ./data/multimodal_test.pdf
 ```
 
-Use `--lancedb-uri` and `--table-name` on the local and batch commands when you need a non-default LanceDB location. For modes and flags, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
+Use `--lancedb-uri` and `--table-name` on the local and batch commands when you need a non-default LanceDB location. For modes and flags, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli).
 
 ### Programmatic API (Python)
 
@@ -109,7 +109,7 @@ docs = vdb.retrieval(queries, top_k=10)
 
 Query ingested tables with `LanceDB.retrieval()` (precomputed vectors) or with [`Retriever.query`](nemo-retriever-api-reference.md) (embeds the query string for you). Optional `where` predicates and client-side filters are documented under [Metadata and filtering](#metadata-and-filtering).
 
-To use a custom operator, pass a `VDB` instance as `vdb` to `IngestVdbOperator` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/building_vdb_operator.ipynb)).
+To use a custom operator, pass a `VDB` instance as `vdb` to `IngestVdbOperator` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/building_vdb_operator.ipynb)).
 
 ## Semantic retrieval { #semantic-retrieval }
 
@@ -124,7 +124,7 @@ Semantic retrieval uses dense embeddings to find content that is similar in mean
 
 ## Metadata and filtering { #metadata-and-filtering }
 
-Refer to the [metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) for an end-to-end example of adding custom metadata fields to your documents and filtering retrieval results with that metadata.
+Refer to the [metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) for an end-to-end example of adding custom metadata fields to your documents and filtering retrieval results with that metadata.
 
 ## LanceDB deployment characteristics { #lancedb-deployment-characteristics }
 
@@ -150,19 +150,19 @@ NeMo Retriever Library integrates with vector databases used for RAG collections
 
 ### Backends with `VDB` implementations (retriever adapters) { #vdb-backends-implementations }
 
-NeMo Retriever graph operators [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py) and [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py) wrap concrete classes that implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface (`run` for ingest, `retrieval` for search). The library ships one first-party backend:
+NeMo Retriever graph operators [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/operators/vdb.py) and [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/operators/vdb.py) wrap concrete classes that implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface (`run` for ingest, `retrieval` for search). The library ships one first-party backend:
 
 | Backend | Project | Implementation |
 |---------|---------|----------------|
-| **LanceDB** | [LanceDB](https://lancedb.com/) · [documentation](https://lancedb.github.io/lancedb/) | [`lancedb.py`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py) — default `vdb_op` is `"lancedb"`. |
+| **LanceDB** | [LanceDB](https://lancedb.com/) · [documentation](https://lancedb.github.io/lancedb/) | [`lancedb.py`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py) — default `vdb_op` is `"lancedb"`. |
 
 `GraphIngestor.vdb_upload()` selects LanceDB when `vdb_op` is omitted. Refer to [Upload to LanceDB](#upload-to-lancedb).
 
-To integrate another vector database, subclass [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) and pass your operator instance as `vdb` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/building_vdb_operator.ipynb)).
+To integrate another vector database, subclass [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) and pass your operator instance as `vdb` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/building_vdb_operator.ipynb)).
 
 ### RAG Blueprint and partner vector stores { #rag-blueprint-and-partner-vector-stores }
 
-Some deployments use a different vector store than the default LanceDB path on this page—for example the [NVIDIA RAG Blueprint](https://docs.nvidia.com/rag/latest/index.html) (Docker Compose or Helm) or a partner package that subclasses the same [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface. Use the following public references when you wire those stacks to ingestion and retrieval:
+Some deployments use a different vector store than the default LanceDB path on this page—for example the [NVIDIA RAG Blueprint](https://docs.nvidia.com/rag/latest/index.html) (Docker Compose or Helm) or a partner package that subclasses the same [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface. Use the following public references when you wire those stacks to ingestion and retrieval:
 
 | Vector store | Where to configure or implement |
 |--------------|--------------------------------|
@@ -174,7 +174,7 @@ Testing and release cadence for these integrations follow the owning project (RA
 
 ### More information (embeddings & custom `VDB`) { #vector-database-partners-more-info }
 
-- [Metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) and the package [VDB README (metadata filtering)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/common/vdb#metadata-filtering)
+- [Metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) and the package [VDB README (metadata filtering)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb#metadata-filtering)
 - [Multimodal embeddings (VLM)](embedding.md)
 - [NeMo Retriever Text Embedding NIM](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html)
 - [NVIDIA NIM catalog](https://build.nvidia.com/) for embedding and retrieval-related NIMs
@@ -183,16 +183,16 @@ Testing and release cadence for these integrations follow the owning project (RA
 
     NVIDIA documents and validates the first-party LanceDB operator for this library. If you integrate a different vector store, you are responsible for testing and maintaining that integration.
 
-To implement a custom operator, follow the `VDB` abstract interface described in [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/building_vdb_operator.ipynb). For an overview of all customization paths (UDFs, graph pipelines, and embeddings), refer to [Customize & extend](customize-extend.md).
+To implement a custom operator, follow the `VDB` abstract interface described in [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/building_vdb_operator.ipynb). For an overview of all customization paths (UDFs, graph pipelines, and embeddings), refer to [Customize & extend](customize-extend.md).
 
 ## Related Topics { #related-topics }
 
 - [Metadata and filtering](#metadata-and-filtering)
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Customize & extend](customize-extend.md)
-- [Vector DB operators and LanceDB (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/common/vdb)
+- [Vector DB operators and LanceDB (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb)
 - [Use the NeMo Retriever Library Python API](nemo-retriever-api-reference.md)
-- [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli)
+- [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli)
 - [Store Extracted Images](nemo-retriever-api-reference.md)
 - [Environment Variables](environment-config.md)
 - [Troubleshoot NeMo Retriever Extraction](troubleshoot.md)

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -37,7 +37,7 @@ NeMo Retriever Library supports uploading data through `.vdb_upload()` on `creat
 - **Local and batch CLI ingest** (`retriever ingest`, `retriever ingest local`, `retriever ingest batch`) persist embeddings to LanceDB (default URI `lancedb`, table `nemo-retriever`).
 - **Service CLI ingest** (`retriever ingest service`) writes to service-configured storage.
 
-For supported modes and target storage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
+For supported modes and target storage, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
 
 `.vdb_upload()` does not generate embeddings. For dense SDK ingestion, include `.embed()` in the pipeline:
 
@@ -81,7 +81,7 @@ The following command runs local ingest into the default LanceDB table:
 retriever ingest ./data/multimodal_test.pdf
 ```
 
-Use `--lancedb-uri` and `--table-name` on the local and batch commands when you need a non-default LanceDB location. For modes and flags, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
+Use `--lancedb-uri` and `--table-name` on the local and batch commands when you need a non-default LanceDB location. For modes and flags, refer to the [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli).
 
 ### Programmatic API (Python)
 
@@ -109,7 +109,7 @@ docs = vdb.retrieval(queries, top_k=10)
 
 Query ingested tables with `LanceDB.retrieval()` (precomputed vectors) or with [`Retriever.query`](nemo-retriever-api-reference.md) (embeds the query string for you). Optional `where` predicates and client-side filters are documented under [Metadata and filtering](#metadata-and-filtering).
 
-To use a custom operator, pass a `VDB` instance as `vdb` to `IngestVdbOperator` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/building_vdb_operator.ipynb)).
+To use a custom operator, pass a `VDB` instance as `vdb` to `IngestVdbOperator` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/building_vdb_operator.ipynb)).
 
 ## Semantic retrieval { #semantic-retrieval }
 
@@ -124,7 +124,7 @@ Semantic retrieval uses dense embeddings to find content that is similar in mean
 
 ## Metadata and filtering { #metadata-and-filtering }
 
-Refer to the [metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) for an end-to-end example of adding custom metadata fields to your documents and filtering retrieval results with that metadata.
+Refer to the [metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) for an end-to-end example of adding custom metadata fields to your documents and filtering retrieval results with that metadata.
 
 ## LanceDB deployment characteristics { #lancedb-deployment-characteristics }
 
@@ -150,19 +150,19 @@ NeMo Retriever Library integrates with vector databases used for RAG collections
 
 ### Backends with `VDB` implementations (retriever adapters) { #vdb-backends-implementations }
 
-NeMo Retriever graph operators [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/operators/vdb.py) and [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/operators/vdb.py) wrap concrete classes that implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface (`run` for ingest, `retrieval` for search). The library ships one first-party backend:
+NeMo Retriever graph operators [`IngestVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py) and [`RetrieveVdbOperator`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/operators/vdb.py) wrap concrete classes that implement the [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface (`run` for ingest, `retrieval` for search). The library ships one first-party backend:
 
 | Backend | Project | Implementation |
 |---------|---------|----------------|
-| **LanceDB** | [LanceDB](https://lancedb.com/) · [documentation](https://lancedb.github.io/lancedb/) | [`lancedb.py`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py) — default `vdb_op` is `"lancedb"`. |
+| **LanceDB** | [LanceDB](https://lancedb.com/) · [documentation](https://lancedb.github.io/lancedb/) | [`lancedb.py`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py) — default `vdb_op` is `"lancedb"`. |
 
 `GraphIngestor.vdb_upload()` selects LanceDB when `vdb_op` is omitted. Refer to [Upload to LanceDB](#upload-to-lancedb).
 
-To integrate another vector database, subclass [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) and pass your operator instance as `vdb` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/building_vdb_operator.ipynb)).
+To integrate another vector database, subclass [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) and pass your operator instance as `vdb` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/building_vdb_operator.ipynb)).
 
 ### RAG Blueprint and partner vector stores { #rag-blueprint-and-partner-vector-stores }
 
-Some deployments use a different vector store than the default LanceDB path on this page—for example the [NVIDIA RAG Blueprint](https://docs.nvidia.com/rag/latest/index.html) (Docker Compose or Helm) or a partner package that subclasses the same [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface. Use the following public references when you wire those stacks to ingestion and retrieval:
+Some deployments use a different vector store than the default LanceDB path on this page—for example the [NVIDIA RAG Blueprint](https://docs.nvidia.com/rag/latest/index.html) (Docker Compose or Helm) or a partner package that subclasses the same [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py) interface. Use the following public references when you wire those stacks to ingestion and retrieval:
 
 | Vector store | Where to configure or implement |
 |--------------|--------------------------------|
@@ -174,7 +174,7 @@ Testing and release cadence for these integrations follow the owning project (RA
 
 ### More information (embeddings & custom `VDB`) { #vector-database-partners-more-info }
 
-- [Metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) and the package [VDB README (metadata filtering)](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/common/vdb#metadata-filtering)
+- [Metadata filtering notebook](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) and the package [VDB README (metadata filtering)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/common/vdb#metadata-filtering)
 - [Multimodal embeddings (VLM)](embedding.md)
 - [NeMo Retriever Text Embedding NIM](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html)
 - [NVIDIA NIM catalog](https://build.nvidia.com/) for embedding and retrieval-related NIMs
@@ -183,16 +183,16 @@ Testing and release cadence for these integrations follow the owning project (RA
 
     NVIDIA documents and validates the first-party LanceDB operator for this library. If you integrate a different vector store, you are responsible for testing and maintaining that integration.
 
-To implement a custom operator, follow the `VDB` abstract interface described in [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/building_vdb_operator.ipynb). For an overview of all customization paths (UDFs, graph pipelines, and embeddings), refer to [Customize & extend](customize-extend.md).
+To implement a custom operator, follow the `VDB` abstract interface described in [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/building_vdb_operator.ipynb). For an overview of all customization paths (UDFs, graph pipelines, and embeddings), refer to [Customize & extend](customize-extend.md).
 
 ## Related Topics { #related-topics }
 
 - [Metadata and filtering](#metadata-and-filtering)
 - [Workflow: Agentic retrieval](workflow-agentic-retrieval.md)
 - [Customize & extend](customize-extend.md)
-- [Vector DB operators and LanceDB (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/common/vdb)
+- [Vector DB operators and LanceDB (source)](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/src/nemo_retriever/common/vdb)
 - [Use the NeMo Retriever Library Python API](nemo-retriever-api-reference.md)
-- [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli)
+- [Retriever CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli)
 - [Store Extracted Images](nemo-retriever-api-reference.md)
 - [Environment Variables](environment-config.md)
 - [Troubleshoot NeMo Retriever Extraction](troubleshoot.md)

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -60,7 +60,7 @@ This self-hosted NIM configuration gap does not apply to NVIDIA-hosted Build end
 
 ### CLI options { #cli-options }
 
-The following options apply only with `--agentic`. For the full flag list, refer to [Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#agentic-retrieval) in the CLI reference.
+The following options apply only with `--agentic`. For the full flag list, refer to [Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#agentic-retrieval) in the CLI reference.
 
 | Option | Default | Notes |
 |---|---|---|
@@ -150,7 +150,7 @@ If you register MCP retrieval tools, set `serviceConfig.mcp.queryMethods` to `ag
 
 For other self-hosted OpenAI-compatible NIMs, enable automatic tool choice and the parser that model requires. The `llama3_json` parser is the verified Super-49B setting.
 
-For chart keys, refer to [Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#agentic-retrieval-llm) in the Helm chart README.
+For chart keys, refer to [Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#agentic-retrieval-llm) in the Helm chart README.
 
 ## Enable agentic retrieval in the service { #enable-agentic-retrieval-in-the-service }
 
@@ -173,7 +173,7 @@ agentic:
 
 Agentic service requests use the configured remote embedding endpoint for retrieval. The result-selection graph does not require a local embedding model or Hugging Face cache.
 
-On Kubernetes, the Helm chart maps the same knobs under `serviceConfig.agentic`. Enabling `nimOperator.answer_llm` does not populate this block. Refer to [Self-hosted Helm Super-49B](#self-hosted-helm-super-49b) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#agentic-retrieval-llm).
+On Kubernetes, the Helm chart maps the same knobs under `serviceConfig.agentic`. Enabling `nimOperator.answer_llm` does not populate this block. Refer to [Self-hosted Helm Super-49B](#self-hosted-helm-super-49b) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#agentic-retrieval-llm).
 
 The VectorDB service runs up to four non-agentic queries concurrently by default.
 Set `--max-concurrent-queries` when starting `nemo_retriever.service.vectordb_app`
@@ -267,6 +267,6 @@ Agentic runs use a dedicated worker pool in the VectorDB process so they cannot 
 - [Metadata and filtering](vdbs.md#metadata-and-filtering)
 - [Evaluate on your data](evaluate-on-your-data.md)
 - [Authentication and API keys](api-keys.md)
-- [CLI reference: Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#agentic-retrieval)
-- [Helm chart README: Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#agentic-retrieval-llm)
+- [CLI reference: Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#agentic-retrieval)
+- [Helm chart README: Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#agentic-retrieval-llm)
 - [Release notes](releasenotes.md#retrieval-and-rag)

--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -60,7 +60,7 @@ This self-hosted NIM configuration gap does not apply to NVIDIA-hosted Build end
 
 ### CLI options { #cli-options }
 
-The following options apply only with `--agentic`. For the full flag list, refer to [Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#agentic-retrieval) in the CLI reference.
+The following options apply only with `--agentic`. For the full flag list, refer to [Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docs/cli/README.md#agentic-retrieval) in the CLI reference.
 
 | Option | Default | Notes |
 |---|---|---|
@@ -150,7 +150,7 @@ If you register MCP retrieval tools, set `serviceConfig.mcp.queryMethods` to `ag
 
 For other self-hosted OpenAI-compatible NIMs, enable automatic tool choice and the parser that model requires. The `llama3_json` parser is the verified Super-49B setting.
 
-For chart keys, refer to [Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#agentic-retrieval-llm) in the Helm chart README.
+For chart keys, refer to [Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#agentic-retrieval-llm) in the Helm chart README.
 
 ## Enable agentic retrieval in the service { #enable-agentic-retrieval-in-the-service }
 
@@ -173,7 +173,7 @@ agentic:
 
 Agentic service requests use the configured remote embedding endpoint for retrieval. The result-selection graph does not require a local embedding model or Hugging Face cache.
 
-On Kubernetes, the Helm chart maps the same knobs under `serviceConfig.agentic`. Enabling `nimOperator.answer_llm` does not populate this block. Refer to [Self-hosted Helm Super-49B](#self-hosted-helm-super-49b) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#agentic-retrieval-llm).
+On Kubernetes, the Helm chart maps the same knobs under `serviceConfig.agentic`. Enabling `nimOperator.answer_llm` does not populate this block. Refer to [Self-hosted Helm Super-49B](#self-hosted-helm-super-49b) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#agentic-retrieval-llm).
 
 The VectorDB service runs up to four non-agentic queries concurrently by default.
 Set `--max-concurrent-queries` when starting `nemo_retriever.service.vectordb_app`
@@ -267,6 +267,6 @@ Agentic runs use a dedicated worker pool in the VectorDB process so they cannot 
 - [Metadata and filtering](vdbs.md#metadata-and-filtering)
 - [Evaluate on your data](evaluate-on-your-data.md)
 - [Authentication and API keys](api-keys.md)
-- [CLI reference: Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docs/cli/README.md#agentic-retrieval)
-- [Helm chart README: Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md#agentic-retrieval-llm)
+- [CLI reference: Agentic retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docs/cli/README.md#agentic-retrieval)
+- [Helm chart README: Agentic retrieval (self-hosted Super-49B)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md#agentic-retrieval-llm)
 - [Release notes](releasenotes.md#retrieval-and-rag)

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -8,7 +8,7 @@ Document ingestion is the step where NeMo Retriever Library reads your files (PD
 
 Follow these steps:
 
-1. **Choose how you call the library.** Use the [Python API](nemo-retriever-api-reference.md) or [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli) from application code, or run a deployment (for example [NeMo Retriever Library on GitHub](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever), [Deployment options](deployment-options.md), or [Quickstart: Kubernetes (Helm)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)) and send jobs over the network. Runnable examples appear in [Choose how you call the library](#choose-how-you-call-the-library) below.
+1. **Choose how you call the library.** Use the [Python API](nemo-retriever-api-reference.md) or [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli) from application code, or run a deployment (for example [NeMo Retriever Library on GitHub](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever), [Deployment options](deployment-options.md), or [Quickstart: Kubernetes (Helm)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)) and send jobs over the network. Runnable examples appear in [Choose how you call the library](#choose-how-you-call-the-library) below.
 2. **Use parallel PDF handling.** The default ingest path splits large PDFs before Ray processing; refer to [API guide — PDF pre-splitting](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest).
 3. **Tune extraction for your content.** Refer to [Multimodal extraction](multimodal-extraction.md) for formats, [text and layout](multimodal-extraction.md#text-and-layout-extraction), [tables](multimodal-extraction.md#tables), [OCR](multimodal-extraction.md#ocr-and-scanned-documents), and related subsections on that page.
 
@@ -18,11 +18,11 @@ Pipeline concepts and stage overview appear in [Key concepts](concepts.md). Defa
 
 ## Choose how you call the library { #choose-how-you-call-the-library }
 
-The following examples match the [NeMo Retriever Library README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md). They assume a checkout of the [NeMo Retriever](https://github.com/NVIDIA/NeMo-Retriever) repository and the `batch` run mode with local GPU inference unless you configure remote NIMs.
+The following examples match the [NeMo Retriever Library README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/README.md). They assume a checkout of the [NeMo Retriever](https://github.com/NVIDIA/NeMo-Retriever) repository and the `batch` run mode with local GPU inference unless you configure remote NIMs.
 
 ### Ingest a test PDF (Python)
 
-The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/main/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only so you can inspect embedded chunks before indexing. To upload in the same run, append `.vdb_upload(...)` before `.ingest()` (parameter details in the [Python API guide](nemo-retriever-api-reference.md)).
+The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only so you can inspect embedded chunks before indexing. To upload in the same run, append `.vdb_upload(...)` before `.ingest()` (parameter details in the [Python API guide](nemo-retriever-api-reference.md)).
 
 ```python
 from nemo_retriever import create_ingestor

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -8,7 +8,7 @@ Document ingestion is the step where NeMo Retriever Library reads your files (PD
 
 Follow these steps:
 
-1. **Choose how you call the library.** Use the [Python API](nemo-retriever-api-reference.md) or [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli) from application code, or run a deployment (for example [NeMo Retriever Library on GitHub](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever), [Deployment options](deployment-options.md), or [Quickstart: Kubernetes (Helm)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/README.md)) and send jobs over the network. Runnable examples appear in [Choose how you call the library](#choose-how-you-call-the-library) below.
+1. **Choose how you call the library.** Use the [Python API](nemo-retriever-api-reference.md) or [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli) from application code, or run a deployment (for example [NeMo Retriever Library on GitHub](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever), [Deployment options](deployment-options.md), or [Quickstart: Kubernetes (Helm)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/README.md)) and send jobs over the network. Runnable examples appear in [Choose how you call the library](#choose-how-you-call-the-library) below.
 2. **Use parallel PDF handling.** The default ingest path splits large PDFs before Ray processing; refer to [API guide — PDF pre-splitting](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest).
 3. **Tune extraction for your content.** Refer to [Multimodal extraction](multimodal-extraction.md) for formats, [text and layout](multimodal-extraction.md#text-and-layout-extraction), [tables](multimodal-extraction.md#tables), [OCR](multimodal-extraction.md#ocr-and-scanned-documents), and related subsections on that page.
 
@@ -18,11 +18,11 @@ Pipeline concepts and stage overview appear in [Key concepts](concepts.md). Defa
 
 ## Choose how you call the library { #choose-how-you-call-the-library }
 
-The following examples match the [NeMo Retriever Library README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/README.md). They assume a checkout of the [NeMo Retriever](https://github.com/NVIDIA/NeMo-Retriever) repository and the `batch` run mode with local GPU inference unless you configure remote NIMs.
+The following examples match the [NeMo Retriever Library README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/README.md). They assume a checkout of the [NeMo Retriever](https://github.com/NVIDIA/NeMo-Retriever) repository and the `batch` run mode with local GPU inference unless you configure remote NIMs.
 
 ### Ingest a test PDF (Python)
 
-The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only so you can inspect embedded chunks before indexing. To upload in the same run, append `.vdb_upload(...)` before `.ingest()` (parameter details in the [Python API guide](nemo-retriever-api-reference.md)).
+The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only so you can inspect embedded chunks before indexing. To upload in the same run, append `.vdb_upload(...)` before `.ingest()` (parameter details in the [Python API guide](nemo-retriever-api-reference.md)).
 
 ```python
 from nemo_retriever import create_ingestor

--- a/docs/docs/extraction/workflow-e2e-blueprints.md
+++ b/docs/docs/extraction/workflow-e2e-blueprints.md
@@ -5,4 +5,4 @@ Use these external resources for end-to-end RAG implementations with NeMo Retrie
 - [Enterprise RAG - multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)
 - [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover)
 
-For framework-specific integration patterns, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md).
+For framework-specific integration patterns, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md).

--- a/docs/docs/extraction/workflow-e2e-blueprints.md
+++ b/docs/docs/extraction/workflow-e2e-blueprints.md
@@ -5,4 +5,4 @@ Use these external resources for end-to-end RAG implementations with NeMo Retrie
 - [Enterprise RAG - multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)
 - [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover)
 
-For framework-specific integration patterns, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md).
+For framework-specific integration patterns, refer to [Starter kits](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -81,13 +81,13 @@ nav:
   - "2. Get started":
       - About this section: extraction/getting-started-about.md
       - "Pre-Requisites & Support Matrix": extraction/prerequisites-support-matrix.md
-      - "Quickstart: NeMo Retriever Library": https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever
+      - "Quickstart: NeMo Retriever Library": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever
       - "Authentication and API keys": extraction/api-keys.md
   - "3. Deployment options":
       - "Compare deployment options": extraction/deployment-options.md
-      - "OpenShift deployment (Helm)": https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/openshift.md
-      - "Helm chart (Kubernetes)": https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm
-      - "Docker service image": https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md
+      - "OpenShift deployment (Helm)": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/openshift.md
+      - "Helm chart (Kubernetes)": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm
+      - "Docker service image": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docker.md
   - "4. Core workflows":
       - "Workflow: Ingest documents into a searchable VDB collection": extraction/workflow-document-ingestion.md
       - "Workflow: Audio & video ingestion": extraction/audio-video.md
@@ -104,13 +104,13 @@ nav:
   - "8. Customize & extend":
       - "Customize & extend": extraction/customize-extend.md
   - "9. Integrations & ecosystem":
-      - "Starter kits": https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md
+      - "Starter kits": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
   - "10. Evaluation & benchmarks":
       - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
   - "11. Reference":
       - "API guide": extraction/nemo-retriever-api-reference.md
       # TODO: after nv-ingest code removal, update this link when CLI docs are relocated.
-      - "CLI reference": https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli
+      - "CLI reference": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli
       - "Quickstart: retriever CLI": reference/retriever-cli-quickstart.md
       - "Collection management Python API": reference/collection-management-api.md
       - Environment variables: extraction/environment-config.md
@@ -153,19 +153,19 @@ plugins:
         index.md: extraction/overview.md
         extraction/index.md: extraction/overview.md
         # TODO: after nv-ingest code removal, update this link when CLI docs are relocated.
-        extraction/nv-ingest_cli.md: https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli
+        extraction/nv-ingest_cli.md: https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli
         extraction/helm.md: extraction/deployment-options.md
-        extraction/quickstart-guide.md: https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm
+        extraction/quickstart-guide.md: https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm
         extraction/choose-your-path.md: extraction/deployment-options.md
         extraction/hosted-nims-when-to-use.md: extraction/deployment-options.md
         extraction/releasenotes-nv-ingest.md: extraction/releasenotes.md
         extraction/ngc-api-key.md: extraction/api-keys.md
-        extraction/notebooks/index.md: https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md
-        extraction/notebooks.md: https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md
-        extraction/starter-kits.md: https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md
+        extraction/notebooks/index.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
+        extraction/notebooks.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
+        extraction/starter-kits.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
         extraction/data-store.md: extraction/vdbs.md
         extraction/custom-metadata.md: extraction/vdbs.md#metadata-and-filtering
-        extraction/integrations-langchain-llamaindex-haystack.md: https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md
+        extraction/integrations-langchain-llamaindex-haystack.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
         extraction/nemoretriever-parse.md: extraction/multimodal-extraction.md#text-and-layout-extraction
         extraction/supported-file-types.md: extraction/multimodal-extraction.md#supported-file-types-and-formats
         extraction/text-layout-extraction.md: extraction/multimodal-extraction.md#text-and-layout-extraction
@@ -192,7 +192,7 @@ plugins:
         extraction/user-defined-functions/index.md: extraction/customize-extend.md#user-defined-functions-udfs
         extraction/user-defined-functions.md: extraction/customize-extend.md#user-defined-functions-udfs
         extraction/customize-and-extend.md: extraction/customize-extend.md
-        extraction/nimclient.md: https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints
+        extraction/nimclient.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints
   - site-urls
 
 markdown_extensions:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -81,13 +81,13 @@ nav:
   - "2. Get started":
       - About this section: extraction/getting-started-about.md
       - "Pre-Requisites & Support Matrix": extraction/prerequisites-support-matrix.md
-      - "Quickstart: NeMo Retriever Library": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever
+      - "Quickstart: NeMo Retriever Library": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever
       - "Authentication and API keys": extraction/api-keys.md
   - "3. Deployment options":
       - "Compare deployment options": extraction/deployment-options.md
-      - "OpenShift deployment (Helm)": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/helm/openshift.md
-      - "Helm chart (Kubernetes)": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm
-      - "Docker service image": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/docker.md
+      - "OpenShift deployment (Helm)": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/helm/openshift.md
+      - "Helm chart (Kubernetes)": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/helm
+      - "Docker service image": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/docker.md
   - "4. Core workflows":
       - "Workflow: Ingest documents into a searchable VDB collection": extraction/workflow-document-ingestion.md
       - "Workflow: Audio & video ingestion": extraction/audio-video.md
@@ -104,13 +104,13 @@ nav:
   - "8. Customize & extend":
       - "Customize & extend": extraction/customize-extend.md
   - "9. Integrations & ecosystem":
-      - "Starter kits": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
+      - "Starter kits": https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md
   - "10. Evaluation & benchmarks":
       - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
   - "11. Reference":
       - "API guide": extraction/nemo-retriever-api-reference.md
       # TODO: after nv-ingest code removal, update this link when CLI docs are relocated.
-      - "CLI reference": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli
+      - "CLI reference": https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli
       - "Quickstart: retriever CLI": reference/retriever-cli-quickstart.md
       - "Collection management Python API": reference/collection-management-api.md
       - Environment variables: extraction/environment-config.md
@@ -153,19 +153,19 @@ plugins:
         index.md: extraction/overview.md
         extraction/index.md: extraction/overview.md
         # TODO: after nv-ingest code removal, update this link when CLI docs are relocated.
-        extraction/nv-ingest_cli.md: https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/docs/cli
+        extraction/nv-ingest_cli.md: https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/docs/cli
         extraction/helm.md: extraction/deployment-options.md
-        extraction/quickstart-guide.md: https://github.com/NVIDIA/NeMo-Retriever/tree/26.08/nemo_retriever/helm
+        extraction/quickstart-guide.md: https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1/nemo_retriever/helm
         extraction/choose-your-path.md: extraction/deployment-options.md
         extraction/hosted-nims-when-to-use.md: extraction/deployment-options.md
         extraction/releasenotes-nv-ingest.md: extraction/releasenotes.md
         extraction/ngc-api-key.md: extraction/api-keys.md
-        extraction/notebooks/index.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
-        extraction/notebooks.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
-        extraction/starter-kits.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
+        extraction/notebooks/index.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md
+        extraction/notebooks.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md
+        extraction/starter-kits.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md
         extraction/data-store.md: extraction/vdbs.md
         extraction/custom-metadata.md: extraction/vdbs.md#metadata-and-filtering
-        extraction/integrations-langchain-llamaindex-haystack.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/examples/README.md
+        extraction/integrations-langchain-llamaindex-haystack.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/examples/README.md
         extraction/nemoretriever-parse.md: extraction/multimodal-extraction.md#text-and-layout-extraction
         extraction/supported-file-types.md: extraction/multimodal-extraction.md#supported-file-types-and-formats
         extraction/text-layout-extraction.md: extraction/multimodal-extraction.md#text-and-layout-extraction
@@ -192,7 +192,7 @@ plugins:
         extraction/user-defined-functions/index.md: extraction/customize-extend.md#user-defined-functions-udfs
         extraction/user-defined-functions.md: extraction/customize-extend.md#user-defined-functions-udfs
         extraction/customize-and-extend.md: extraction/customize-extend.md
-        extraction/nimclient.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints
+        extraction/nimclient.md: https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/developer_docs/nimclient.md#nimclient-and-custom-nim-endpoints
   - site-urls
 
 markdown_extensions:


### PR DESCRIPTION
Closed per https://github.com/NVIDIA/NeMo-Retriever/pull/2593 
## Summary
- Pin release-specific `blob/main` and `tree/main` GitHub links in versioned 26.08.1 extraction docs to the immutable `26.08.1` tag (Helm README/values, CLI, examples, source, nav, and redirects).
- Leave contribution-policy links on `main` (`contributing.md` â†’ `CONTRIBUTING.md`).
- Fixes NVBug 6628516: after `main` advances, 26.08.1 readers no longer follow newer Helm keys, defaults, examples, or source.

## Why this is on `main`
There is no `26.08.1` maintenance branch. Tag `26.08.1` currently matches `upstream/main`. This pin is for the 26.08.1 versioned docs snapshot.

After `main` diverges for the next train, restore `/blob/main/` and `/tree/main/` on `main` (or keep this pin only on a `26.08.1` branch) so latest docs stay evergreen.

## Intentional leftovers
- `docs/docs/extraction/contributing.md` still points at `blob/main/CONTRIBUTING.md` (evergreen, per bug expected result).
- `docs/docs/license.md` still has four `blob/main` links (outside the extraction audit scope).
- In-repo Helm/CLI markdown still contains `blob/main` self-links; this PR only changes published extraction docs and `docs/mkdocs.yml`.

## Test plan
- [x] `git grep` for `github.com/NVIDIA/NeMo-Retriever/(blob|tree)/main` under `docs/docs/extraction` â€” only `contributing.md` remains
- [x] Sample `26.08.1` tag URLs resolve
- [ ] Click Helm README, values.yaml, CLI, and example links from 26.08.1 release notes and deployment docs after publish
- [ ] Confirm contribution links still open `CONTRIBUTING.md` on `main`

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** 21 extraction markdown pages and docs/mkdocs.yml (GitHub blob/tree pins to tag 26.08.1)

| Check | Result |
|-------|--------|
| Leakage (page roles + see [ CTAs) | PASS — no see [ CTAs in changed markdown; faq/overview/multimodal-extraction have no nimOperator/nvcr.io/nim/installFfmpeg |
| Allowed paths | PASS — 22 documentation files (extraction/*.md + mkdocs.yml) |
| mkdocs --strict | PASS for this change — exit 1 from untracked leftover pages (custom-metadata.md, user-defined-stages.md), not this diff |
| ::a audit | PASS — pins target tag 26.08.1 (1992e3f09); Helm README and CLI README exist at that tag; contributing.md remains blob/main/CONTRIBUTING.md |
| ::p polish | none needed — mechanical URL retarget from 26.08 to 26.08.1 |
| ::r style | 95% — no blocking issues; no prose rewrite |

**Code drift (not in this docs PR):** none for this pin.

**PR:** https://github.com/NVIDIA/NeMo-Retriever/pull/2579
