### PR TITLE
service deploys vdb

### DIFF
--- a/nemo_retriever/docker.md
+++ b/nemo_retriever/docker.md
@@ -64,6 +64,37 @@ docker run --rm \
 
 Use Kubernetes Secrets, Helm values, or container environment variables for credentials. Do not bake API keys into derived images.
 
+## Run A Local VectorDB With The Service
+
+For a local development deployment, start the service with `--launch-vectordb`. It starts a VectorDB child process on `127.0.0.1:7671`, waits for `/v1/health`, and stops the child when the service exits.
+
+The VectorDB child uses `nim_endpoints.embed_invoke_url` when configured. If that endpoint is unset, it uses local Hugging Face embedding when both `local_models.enabled` and `local_models.embed.enabled` are `true`.
+
+For a fully local deployment, use a CUDA-capable host and install the service and local extras:
+
+```bash
+pip install "nemo-retriever[service,local]"
+```
+
+Install the `multimedia` extra when you ingest audio or video. From a source checkout, start the included local configuration with:
+
+```bash
+scripts/launch_local_service_with_vectordb.sh \
+  nemo_retriever/examples/retriever-service.local.yaml
+```
+
+The example leaves all NIM endpoints unset and uses local Hugging Face models for service ingestion and VectorDB query embeddings. The launcher validates `/v1/health` on both components, then keeps the deployment running until you stop it with `Ctrl+C`.
+
+To use remote embedding instead, configure `nim_endpoints.embed_invoke_url` and run:
+
+```bash
+retriever service start --config my-retriever-service.yaml --launch-vectordb
+```
+
+The launcher is limited to loopback VectorDB URLs. Omit the flag for an existing VectorDB. Helm deployments continue to run VectorDB in a separate pod.
+
+
+
 ## Audio And Video
 
 The service image omits `ffmpeg` and `ffprobe` by default. For audio or video extraction on a development machine with package-repository network access, set `INSTALL_FFMPEG=true`:

--- a/nemo_retriever/docker.md
+++ b/nemo_retriever/docker.md
@@ -70,6 +70,8 @@ For a local development deployment, start the service with `--launch-vectordb`. 
 
 The VectorDB child uses `nim_endpoints.embed_invoke_url` when configured. If that endpoint is unset, it uses local Hugging Face embedding when both `local_models.enabled` and `local_models.embed.enabled` are `true`.
 
+The child inherits credentials from the service environment. Set `NVIDIA_API_KEY` or `NGC_API_KEY` for a remote embedding endpoint. Set `NRL_INTERNAL_VDB_TOKEN` or `NRL_INTERNAL_VDB_TOKEN_FILE` for the VectorDB internal credential. Do not place credentials in the service YAML.
+
 For a fully local deployment, use a CUDA-capable host and install the service and local extras:
 
 ```bash
@@ -92,6 +94,8 @@ retriever service start --config my-retriever-service.yaml --launch-vectordb
 ```
 
 The launcher is limited to loopback VectorDB URLs. Omit the flag for an existing VectorDB. Helm deployments continue to run VectorDB in a separate pod.
+
+If VectorDB exits during startup or does not become ready, read the VectorDB output in the terminal that started the service. Verify the VectorDB configuration, embedding model setup and credentials, writable LanceDB directory, and that port `7671` is available.
 
 
 

--- a/nemo_retriever/docker.md
+++ b/nemo_retriever/docker.md
@@ -66,7 +66,7 @@ Use Kubernetes Secrets, Helm values, or container environment variables for cred
 
 ## Run A Local VectorDB With The Service
 
-For a local development deployment, start the service with `--launch-vectordb`. It starts a VectorDB child process on `127.0.0.1:7671`, waits for `/v1/health`, and stops the child when the service exits.
+For a local development deployment, start the service with `--launch-vectordb`. It starts a VectorDB child process on `127.0.0.1:7671`, waits for `/v1/health`, and terminates the child when the service exits. If the child does not exit promptly, the service forcefully stops it.
 
 The VectorDB child uses `nim_endpoints.embed_invoke_url` when configured. If that endpoint is unset, it uses local Hugging Face embedding when both `local_models.enabled` and `local_models.embed.enabled` are `true`.
 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -122,7 +122,9 @@ retriever query service "What is in this corpus?" \
 
 ### Start a local service with VectorDB
 
-Use `retriever service start --launch-vectordb` to run a local service with a supervised VectorDB child on `127.0.0.1:7671`. The child uses `nim_endpoints.embed_invoke_url` when configured. Otherwise, it uses local Hugging Face embedding when `local_models.enabled` and `local_models.embed.enabled` are both `true`. The command waits for VectorDB readiness and stops it when the service exits.
+Use `retriever service start --launch-vectordb` to run a local service with a supervised VectorDB child on `127.0.0.1:7671`. The child uses `nim_endpoints.embed_invoke_url` when configured. Otherwise, it uses local Hugging Face embedding when `local_models.enabled` and `local_models.embed.enabled` are both `true`. The command waits for VectorDB readiness and stops it when the service exits. You can set the same behavior in YAML with `vectordb.launch_on_start: true` and a loopback `vectordb.vectordb_url`.
+
+The child inherits credentials from the service environment. Set `NVIDIA_API_KEY` or `NGC_API_KEY` for remote embedding, and set `NRL_INTERNAL_VDB_TOKEN` or `NRL_INTERNAL_VDB_TOKEN_FILE` for the VectorDB internal credential. Do not place credentials in the service YAML.
 
 For a fully local deployment, use a CUDA-capable host and install the service and local extras. Install the `multimedia` extra when you ingest audio or video.
 
@@ -139,6 +141,8 @@ retriever service start --config my-retriever-service.yaml --launch-vectordb
 ```
 
 Use the command above when `nim_endpoints.embed_invoke_url` is configured. Omit the flag to use an existing VectorDB. Helm continues to deploy VectorDB as a separate pod.
+
+If VectorDB exits during startup or does not become ready, inspect the VectorDB output in the terminal that started the service. Verify the VectorDB configuration, embedding model setup and credentials, writable LanceDB directory, and that port `7671` is available.
 
 ### Route ingest to hosted or self-hosted NIM endpoints
 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -122,7 +122,7 @@ retriever query service "What is in this corpus?" \
 
 ### Start a local service with VectorDB
 
-Use `retriever service start --launch-vectordb` to run a local service with a supervised VectorDB child on `127.0.0.1:7671`. The child uses `nim_endpoints.embed_invoke_url` when configured. Otherwise, it uses local Hugging Face embedding when `local_models.enabled` and `local_models.embed.enabled` are both `true`. The command waits for VectorDB readiness and stops it when the service exits. You can set the same behavior in YAML with `vectordb.launch_on_start: true` and a loopback `vectordb.vectordb_url`.
+Use `retriever service start --launch-vectordb` to run a local service with a supervised VectorDB child on `127.0.0.1:7671`. The child uses `nim_endpoints.embed_invoke_url` when configured. Otherwise, it uses local Hugging Face embedding when `local_models.enabled` and `local_models.embed.enabled` are both `true`. The command waits for VectorDB readiness and terminates the child when the service exits. If the child does not exit promptly, the service forcefully stops it. You can set the same behavior in YAML with `vectordb.launch_on_start: true` and a loopback `vectordb.vectordb_url`.
 
 The child inherits credentials from the service environment. Set `NVIDIA_API_KEY` or `NGC_API_KEY` for remote embedding, and set `NRL_INTERNAL_VDB_TOKEN` or `NRL_INTERNAL_VDB_TOKEN_FILE` for the VectorDB internal credential. Do not place credentials in the service YAML.
 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -119,6 +119,27 @@ retriever query service "What is in this corpus?" \
   --service-url http://localhost:7670
 ```
 
+
+### Start a local service with VectorDB
+
+Use `retriever service start --launch-vectordb` to run a local service with a supervised VectorDB child on `127.0.0.1:7671`. The child uses `nim_endpoints.embed_invoke_url` when configured. Otherwise, it uses local Hugging Face embedding when `local_models.enabled` and `local_models.embed.enabled` are both `true`. The command waits for VectorDB readiness and stops it when the service exits.
+
+For a fully local deployment, use a CUDA-capable host and install the service and local extras. Install the `multimedia` extra when you ingest audio or video.
+
+```bash
+pip install "nemo-retriever[service,local]"
+scripts/launch_local_service_with_vectordb.sh \
+  nemo_retriever/examples/retriever-service.local.yaml
+```
+
+The example configuration leaves NIM endpoints unset and uses local Hugging Face models. The launcher validates `/v1/health` on the service and VectorDB, then keeps both processes running until you stop it with `Ctrl+C`.
+
+```bash
+retriever service start --config my-retriever-service.yaml --launch-vectordb
+```
+
+Use the command above when `nim_endpoints.embed_invoke_url` is configured. Omit the flag to use an existing VectorDB. Helm continues to deploy VectorDB as a separate pod.
+
 ### Route ingest to hosted or self-hosted NIM endpoints
 
 ```bash

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -45,8 +45,8 @@ def _start_local_vectordb(cfg):
     local_embed = cfg.local_models.enabled and cfg.local_models.embed.enabled and not cfg.nim_endpoints.embed_invoke_url
     if not cfg.nim_endpoints.embed_invoke_url and not local_embed:
         raise typer.BadParameter(
-            "vectordb.launch_on_start requires nim_endpoints.embed_invoke_url or enabled local_models.embed." +
-            "Configure one, then retry."
+            "vectordb.launch_on_start requires nim_endpoints.embed_invoke_url or enabled local_models.embed."
+            + "Configure one, then retry."
         )
     port = parsed.port or 7671
     child_env = os.environ.copy()

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -22,6 +22,21 @@ import typer
 app = typer.Typer(help="Operate the Retriever service. Use `retriever ingest service` to submit documents.")
 
 
+def _stop_local_vectordb(process, *, timeout_s: float = 10) -> None:
+    """Stop a supervised VectorDB child without masking the caller error."""
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+            process.wait(timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+
 def _start_local_vectordb(cfg):
     vdb = cfg.vectordb
     parsed = urlparse(vdb.vectordb_url)
@@ -74,8 +89,7 @@ def _start_local_vectordb(cfg):
                     return process
         except URLError:
             time.sleep(0.2)
-    process.terminate()
-    process.wait(timeout=5)
+    _stop_local_vectordb(process, timeout_s=5)
     raise RuntimeError(
         f"VectorDB did not become ready at {health_url} within 30 seconds. "
         "Inspect the VectorDB logs above and verify the embedding configuration, "
@@ -209,9 +223,8 @@ def start(
             log_level=cfg.logging.level.lower(),
         )
     finally:
-        if vectordb_process is not None and vectordb_process.poll() is None:
-            vectordb_process.terminate()
-            vectordb_process.wait(timeout=10)
+        if vectordb_process is not None:
+            _stop_local_vectordb(vectordb_process)
 
 
 @app.command("mcp-stdio")

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -42,18 +42,31 @@ def _start_local_vectordb(cfg):
     parsed = urlparse(vdb.vectordb_url)
     if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
         raise typer.BadParameter("vectordb.vectordb_url must use localhost when vectordb.launch_on_start is enabled.")
-    local_embed = (
-        cfg.local_models.enabled
-        and cfg.local_models.embed.enabled
-        and not cfg.nim_endpoints.embed_invoke_url
-    )
+    local_embed = cfg.local_models.enabled and cfg.local_models.embed.enabled and not cfg.nim_endpoints.embed_invoke_url
     if not cfg.nim_endpoints.embed_invoke_url and not local_embed:
         raise typer.BadParameter(
-            "vectordb.launch_on_start requires nim_endpoints.embed_invoke_url or enabled local_models.embed. Configure one, then retry."
+            "vectordb.launch_on_start requires nim_endpoints.embed_invoke_url or enabled local_models.embed." +
+            "Configure one, then retry."
         )
     port = parsed.port or 7671
     child_env = os.environ.copy()
-    command = [sys.executable, "-m", "nemo_retriever.service.vectordb_app", "--host", parsed.hostname, "--port", str(port), "--lancedb-uri", vdb.lancedb_uri, "--table-name", vdb.table_name, "--index-mode", vdb.index_mode, "--embed-model", vdb.embed_model]
+    command = [
+        sys.executable,
+        "-m",
+        "nemo_retriever.service.vectordb_app",
+        "--host",
+        parsed.hostname,
+        "--port",
+        str(port),
+        "--lancedb-uri",
+        vdb.lancedb_uri,
+        "--table-name",
+        vdb.table_name,
+        "--index-mode",
+        vdb.index_mode,
+        "--embed-model",
+        vdb.embed_model,
+    ]
     if local_embed:
         command += ["--local-embed", "--local-embed-backend", cfg.local_models.embed.local_ingest_embed_backend]
         if cfg.local_models.hf_cache_dir:
@@ -73,7 +86,25 @@ def _start_local_vectordb(cfg):
         command += ["--disable-expiration-cleanup"]
     command += ["--reconciliation-interval-seconds", str(vdb.reconciliation_interval_seconds)]
     if cfg.agentic.enabled:
-        command += ["--agentic", "--agentic-llm-model", cfg.agentic.llm_model or "", "--agentic-invoke-url", cfg.agentic.invoke_url or "", "--agentic-reasoning-effort", cfg.agentic.reasoning_effort or "", "--agentic-backend-top-k", str(cfg.agentic.backend_top_k), "--agentic-react-max-steps", str(cfg.agentic.react_max_steps), "--agentic-text-truncation", str(cfg.agentic.text_truncation), "--agentic-temperature", str(cfg.agentic.temperature), "--agentic-request-timeout", str(cfg.agentic.request_timeout_s)]
+        command += [
+            "--agentic",
+            "--agentic-llm-model",
+            cfg.agentic.llm_model or "",
+            "--agentic-invoke-url",
+            cfg.agentic.invoke_url or "",
+            "--agentic-reasoning-effort",
+            cfg.agentic.reasoning_effort or "",
+            "--agentic-backend-top-k",
+            str(cfg.agentic.backend_top_k),
+            "--agentic-react-max-steps",
+            str(cfg.agentic.react_max_steps),
+            "--agentic-text-truncation",
+            str(cfg.agentic.text_truncation),
+            "--agentic-temperature",
+            str(cfg.agentic.temperature),
+            "--agentic-request-timeout",
+            str(cfg.agentic.request_timeout_s),
+        ]
     process = subprocess.Popen(command, env=child_env)
     health_url = f"http://{parsed.hostname}:{port}/v1/health"
     for _ in range(150):
@@ -95,6 +126,7 @@ def _start_local_vectordb(cfg):
         "Inspect the VectorDB logs above and verify the embedding configuration, "
         "LanceDB path, and port 7671 availability."
     )
+
 
 @app.command("start")
 def start(
@@ -120,7 +152,9 @@ def start(
     gpu_devices: Optional[str] = typer.Option(
         None, "--gpu-devices", help="Comma-separated GPU device IDs (overrides YAML)."
     ),
-    launch_vectordb: bool = typer.Option(False, "--launch-vectordb", help="Start and supervise a local VectorDB process on 127.0.0.1:7671."),
+    launch_vectordb: bool = typer.Option(
+        False, "--launch-vectordb", help="Start and supervise a local VectorDB process on 127.0.0.1:7671."
+    ),
     local_models: Optional[bool] = typer.Option(
         None,
         "--local-models/--no-local-models",

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -7,12 +7,69 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
+import sys
+import time
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import urlopen
 from typing import Optional
 
 import typer
 
 app = typer.Typer(help="Operate the Retriever service. Use `retriever ingest service` to submit documents.")
 
+
+def _start_local_vectordb(cfg):
+    vdb = cfg.vectordb
+    parsed = urlparse(vdb.vectordb_url)
+    if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        raise typer.BadParameter("vectordb.vectordb_url must use localhost when vectordb.launch_on_start is enabled.")
+    local_embed = (
+        cfg.local_models.enabled
+        and cfg.local_models.embed.enabled
+        and not cfg.nim_endpoints.embed_invoke_url
+    )
+    if not cfg.nim_endpoints.embed_invoke_url and not local_embed:
+        raise typer.BadParameter(
+            "vectordb.launch_on_start requires nim_endpoints.embed_invoke_url or local_models.embed."
+        )
+    port = parsed.port or 7671
+    command = [sys.executable, "-m", "nemo_retriever.service.vectordb_app", "--host", parsed.hostname, "--port", str(port), "--lancedb-uri", vdb.lancedb_uri, "--table-name", vdb.table_name, "--index-mode", vdb.index_mode, "--embed-model", vdb.embed_model]
+    if local_embed:
+        command += ["--local-embed", "--local-embed-backend", cfg.local_models.embed.local_ingest_embed_backend]
+        if cfg.local_models.hf_cache_dir:
+            command += ["--hf-cache-dir", cfg.local_models.hf_cache_dir]
+        if cfg.local_models.device:
+            command += ["--device", cfg.local_models.device]
+        command += ["--gpu-memory-utilization", str(cfg.local_models.embed.gpu_memory_utilization)]
+    else:
+        command += ["--embed-endpoint", cfg.nim_endpoints.embed_invoke_url]
+    if cfg.nim_endpoints.api_key and not local_embed:
+        command += ["--embed-api-key", cfg.nim_endpoints.api_key]
+    if vdb.embed_model_provider_prefix:
+        command += ["--embed-model-provider-prefix", vdb.embed_model_provider_prefix]
+    if vdb.internal_api_token:
+        command += ["--internal-api-token", vdb.internal_api_token]
+    if not vdb.expiration_cleanup_enabled:
+        command += ["--disable-expiration-cleanup"]
+    command += ["--reconciliation-interval-seconds", str(vdb.reconciliation_interval_seconds)]
+    if cfg.agentic.enabled:
+        command += ["--agentic", "--agentic-llm-model", cfg.agentic.llm_model or "", "--agentic-invoke-url", cfg.agentic.invoke_url or "", "--agentic-reasoning-effort", cfg.agentic.reasoning_effort or "", "--agentic-backend-top-k", str(cfg.agentic.backend_top_k), "--agentic-react-max-steps", str(cfg.agentic.react_max_steps), "--agentic-text-truncation", str(cfg.agentic.text_truncation), "--agentic-temperature", str(cfg.agentic.temperature), "--agentic-request-timeout", str(cfg.agentic.request_timeout_s)]
+    process = subprocess.Popen(command)
+    health_url = f"http://{parsed.hostname}:{port}/v1/health"
+    for _ in range(150):
+        if process.poll() is not None:
+            raise RuntimeError(f"VectorDB exited during startup with status {process.returncode}.")
+        try:
+            with urlopen(health_url, timeout=1) as response:
+                if response.status == 200:
+                    return process
+        except URLError:
+            time.sleep(0.2)
+    process.terminate()
+    process.wait(timeout=5)
+    raise RuntimeError(f"VectorDB did not become ready at {health_url} within 30 seconds.")
 
 @app.command("start")
 def start(
@@ -38,6 +95,7 @@ def start(
     gpu_devices: Optional[str] = typer.Option(
         None, "--gpu-devices", help="Comma-separated GPU device IDs (overrides YAML)."
     ),
+    launch_vectordb: bool = typer.Option(False, "--launch-vectordb", help="Start and supervise a local VectorDB process on 127.0.0.1:7671."),
     local_models: Optional[bool] = typer.Option(
         None,
         "--local-models/--no-local-models",
@@ -99,6 +157,10 @@ def start(
         overrides["llm.api_key"] = llm_api_key
     if gpu_devices is not None:
         overrides["resources.gpu_devices"] = [d.strip() for d in gpu_devices.split(",") if d.strip()]
+    if launch_vectordb:
+        overrides["vectordb.enabled"] = True
+        overrides["vectordb.launch_on_start"] = True
+        overrides["vectordb.vectordb_url"] = "http://127.0.0.1:7671"
     if local_models is not None:
         overrides["local_models.enabled"] = local_models
     if local_embed_backend is not None:
@@ -118,6 +180,7 @@ def start(
 
     from nemo_retriever.service.app import create_app
 
+    vectordb_process = _start_local_vectordb(cfg) if cfg.vectordb.launch_on_start else None
     application = create_app(cfg)
 
     try:
@@ -127,12 +190,17 @@ def start(
     except ImportError:
         pass
 
-    uvicorn.run(
-        application,
-        host=cfg.server.host,
-        port=cfg.server.port,
-        log_level=cfg.logging.level.lower(),
-    )
+    try:
+        uvicorn.run(
+            application,
+            host=cfg.server.host,
+            port=cfg.server.port,
+            log_level=cfg.logging.level.lower(),
+        )
+    finally:
+        if vectordb_process is not None and vectordb_process.poll() is None:
+            vectordb_process.terminate()
+            vectordb_process.wait(timeout=10)
 
 
 @app.command("mcp-stdio")

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import os
+
 from pathlib import Path
 import subprocess
 import sys
@@ -32,9 +34,10 @@ def _start_local_vectordb(cfg):
     )
     if not cfg.nim_endpoints.embed_invoke_url and not local_embed:
         raise typer.BadParameter(
-            "vectordb.launch_on_start requires nim_endpoints.embed_invoke_url or local_models.embed."
+            "vectordb.launch_on_start requires nim_endpoints.embed_invoke_url or enabled local_models.embed. Configure one, then retry."
         )
     port = parsed.port or 7671
+    child_env = os.environ.copy()
     command = [sys.executable, "-m", "nemo_retriever.service.vectordb_app", "--host", parsed.hostname, "--port", str(port), "--lancedb-uri", vdb.lancedb_uri, "--table-name", vdb.table_name, "--index-mode", vdb.index_mode, "--embed-model", vdb.embed_model]
     if local_embed:
         command += ["--local-embed", "--local-embed-backend", cfg.local_models.embed.local_ingest_embed_backend]
@@ -46,21 +49,25 @@ def _start_local_vectordb(cfg):
     else:
         command += ["--embed-endpoint", cfg.nim_endpoints.embed_invoke_url]
     if cfg.nim_endpoints.api_key and not local_embed:
-        command += ["--embed-api-key", cfg.nim_endpoints.api_key]
+        child_env["NVIDIA_API_KEY"] = cfg.nim_endpoints.api_key
     if vdb.embed_model_provider_prefix:
         command += ["--embed-model-provider-prefix", vdb.embed_model_provider_prefix]
     if vdb.internal_api_token:
-        command += ["--internal-api-token", vdb.internal_api_token]
+        child_env["NRL_INTERNAL_VDB_TOKEN"] = vdb.internal_api_token
     if not vdb.expiration_cleanup_enabled:
         command += ["--disable-expiration-cleanup"]
     command += ["--reconciliation-interval-seconds", str(vdb.reconciliation_interval_seconds)]
     if cfg.agentic.enabled:
         command += ["--agentic", "--agentic-llm-model", cfg.agentic.llm_model or "", "--agentic-invoke-url", cfg.agentic.invoke_url or "", "--agentic-reasoning-effort", cfg.agentic.reasoning_effort or "", "--agentic-backend-top-k", str(cfg.agentic.backend_top_k), "--agentic-react-max-steps", str(cfg.agentic.react_max_steps), "--agentic-text-truncation", str(cfg.agentic.text_truncation), "--agentic-temperature", str(cfg.agentic.temperature), "--agentic-request-timeout", str(cfg.agentic.request_timeout_s)]
-    process = subprocess.Popen(command)
+    process = subprocess.Popen(command, env=child_env)
     health_url = f"http://{parsed.hostname}:{port}/v1/health"
     for _ in range(150):
         if process.poll() is not None:
-            raise RuntimeError(f"VectorDB exited during startup with status {process.returncode}.")
+            raise RuntimeError(
+                f"VectorDB exited during startup with status {process.returncode}. "
+                "Inspect the VectorDB logs above and verify the embedding configuration, "
+                "LanceDB path, and port 7671 availability."
+            )
         try:
             with urlopen(health_url, timeout=1) as response:
                 if response.status == 200:
@@ -69,7 +76,11 @@ def _start_local_vectordb(cfg):
             time.sleep(0.2)
     process.terminate()
     process.wait(timeout=5)
-    raise RuntimeError(f"VectorDB did not become ready at {health_url} within 30 seconds.")
+    raise RuntimeError(
+        f"VectorDB did not become ready at {health_url} within 30 seconds. "
+        "Inspect the VectorDB logs above and verify the embedding configuration, "
+        "LanceDB path, and port 7671 availability."
+    )
 
 @app.command("start")
 def start(
@@ -181,16 +192,16 @@ def start(
     from nemo_retriever.service.app import create_app
 
     vectordb_process = _start_local_vectordb(cfg) if cfg.vectordb.launch_on_start else None
-    application = create_app(cfg)
-
     try:
-        import setproctitle
+        application = create_app(cfg)
 
-        setproctitle.setproctitle("nemo-retriever-server")
-    except ImportError:
-        pass
+        try:
+            import setproctitle
 
-    try:
+            setproctitle.setproctitle("nemo-retriever-server")
+        except ImportError:
+            pass
+
         uvicorn.run(
             application,
             host=cfg.server.host,

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -437,6 +437,7 @@ class VectorDbConfig(RichModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = False
+    launch_on_start: bool = False
     lancedb_uri: str = "/data/vectordb"
     table_name: str = "nemo_retriever"
     index_mode: Literal["dense", "hybrid"] = "hybrid"

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -437,7 +437,13 @@ class VectorDbConfig(RichModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = False
-    launch_on_start: bool = False
+    launch_on_start: bool = Field(
+        default=False,
+        description=(
+            "Start and supervise a loopback VectorDB child when retriever service starts. "
+            "The configured vectordb_url must use localhost or 127.0.0.1."
+        ),
+    )
     lancedb_uri: str = "/data/vectordb"
     table_name: str = "nemo_retriever"
     index_mode: Literal["dense", "hybrid"] = "hybrid"

--- a/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
+++ b/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
@@ -156,6 +156,9 @@ work_queue:
 # Workers POST embedding rows to vectordb_url; the gateway proxies queries.
 vectordb:
   enabled: false
+  # Start and supervise a local VectorDB process from `retriever service start`.
+  # This must use a loopback vectordb_url.
+  launch_on_start: false
   lancedb_uri: "/data/vectordb"
   table_name: "nemo_retriever"
   embed_model: "nvidia/llama-nemotron-embed-vl-1b-v2"

--- a/nemo_retriever/tests/test_service_answer_generation.py
+++ b/nemo_retriever/tests/test_service_answer_generation.py
@@ -707,8 +707,12 @@ def test_local_vectordb_uses_configured_local_embedding(monkeypatch: pytest.Monk
 
     assert cli._start_local_vectordb(cfg) is process
     assert "--local-embed" in command
-    assert ["--local-embed-backend", "hf"] == command[command.index("--local-embed-backend") : command.index("--local-embed-backend") + 2]
-    assert ["--hf-cache-dir", "/models/cache"] == command[command.index("--hf-cache-dir") : command.index("--hf-cache-dir") + 2]
+    assert ["--local-embed-backend", "hf"] == command[
+        command.index("--local-embed-backend") : command.index("--local-embed-backend") + 2
+    ]
+    assert ["--hf-cache-dir", "/models/cache"] == command[
+        command.index("--hf-cache-dir") : command.index("--hf-cache-dir") + 2
+    ]
     assert ["--device", "cuda:1"] == command[command.index("--device") : command.index("--device") + 2]
     assert "--embed-endpoint" not in command
 
@@ -796,7 +800,9 @@ def test_vectordb_launch_setting_has_schema_description() -> None:
     assert VectorDbConfig.model_fields["launch_on_start"].description
 
 
-def test_service_start_force_kills_vectordb_without_masking_app_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_service_start_force_kills_vectordb_without_masking_app_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     from typer.testing import CliRunner
 
     from nemo_retriever.service.cli import app as service_cli_app

--- a/nemo_retriever/tests/test_service_answer_generation.py
+++ b/nemo_retriever/tests/test_service_answer_generation.py
@@ -697,7 +697,7 @@ def test_local_vectordb_uses_configured_local_embedding(monkeypatch: pytest.Monk
 
     process = _FakeProcess()
 
-    def _fake_popen(args: list[str]) -> _FakeProcess:
+    def _fake_popen(args: list[str], **kwargs) -> _FakeProcess:
         command.extend(args)
         return process
 
@@ -710,3 +710,86 @@ def test_local_vectordb_uses_configured_local_embedding(monkeypatch: pytest.Monk
     assert ["--hf-cache-dir", "/models/cache"] == command[command.index("--hf-cache-dir") : command.index("--hf-cache-dir") + 2]
     assert ["--device", "cuda:1"] == command[command.index("--device") : command.index("--device") + 2]
     assert "--embed-endpoint" not in command
+
+
+def test_local_vectordb_passes_secrets_through_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_retriever.service import cli
+
+    cfg = ServiceConfig(
+        nim_endpoints={"embed_invoke_url": "http://embed-nim:8000/v1", "api_key": "embed-secret"},
+        vectordb=VectorDbConfig(
+            vectordb_url="http://127.0.0.1:7671",
+            internal_api_token="internal-secret",
+        ),
+    )
+    captured: dict[str, Any] = {}
+
+    class _FakeProcess:
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    process = _FakeProcess()
+    monkeypatch.setattr(
+        cli.subprocess,
+        "Popen",
+        lambda command, *, env: captured.update(command=command, env=env) or process,
+    )
+    monkeypatch.setattr(cli, "urlopen", lambda *args, **kwargs: _Response())
+
+    assert cli._start_local_vectordb(cfg) is process
+    assert "embed-secret" not in captured["command"]
+    assert "internal-secret" not in captured["command"]
+    assert captured["env"]["NVIDIA_API_KEY"] == "embed-secret"
+    assert captured["env"]["NRL_INTERNAL_VDB_TOKEN"] == "internal-secret"
+
+
+def test_service_start_cleans_up_vectordb_when_app_creation_fails(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from typer.testing import CliRunner
+
+    from nemo_retriever.service.cli import app as service_cli_app
+
+    config_path = tmp_path / "retriever-service.yaml"
+    config_path.write_text(
+        "mode: standalone\n" "nim_endpoints:\n" "  embed_invoke_url: http://embed-nim:8000/v1\n",
+        encoding="utf-8",
+    )
+
+    class _FakeProcess:
+        terminated = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def wait(self, *, timeout: int) -> None:
+            return None
+
+    process = _FakeProcess()
+    monkeypatch.setattr("nemo_retriever.service.cli._start_local_vectordb", lambda config: process)
+    monkeypatch.setattr(
+        "nemo_retriever.service.app.create_app",
+        lambda config: (_ for _ in ()).throw(RuntimeError("create_app failed")),
+    )
+
+    result = CliRunner().invoke(service_cli_app, ["start", "--config", str(config_path), "--launch-vectordb"])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, RuntimeError)
+    assert process.terminated is True
+
+
+def test_vectordb_launch_setting_has_schema_description() -> None:
+    assert VectorDbConfig.model_fields["launch_on_start"].description

--- a/nemo_retriever/tests/test_service_answer_generation.py
+++ b/nemo_retriever/tests/test_service_answer_generation.py
@@ -615,3 +615,98 @@ def test_service_start_reads_llm_api_key_from_env(monkeypatch: pytest.MonkeyPatc
     assert result.exit_code == 0, result.output
     assert captured["config"].llm.api_key == "secret-from-env"
     assert captured["uvicorn"]["app"] is application
+
+
+def test_service_start_launches_and_supervises_local_vectordb(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from typer.testing import CliRunner
+
+    from nemo_retriever.service.cli import app as service_cli_app
+
+    config_path = tmp_path / "retriever-service.yaml"
+    config_path.write_text(
+        "mode: standalone\n" "nim_endpoints:\n" "  embed_invoke_url: http://embed-nim:8000/v1\n",
+        encoding="utf-8",
+    )
+    captured: dict[str, Any] = {}
+    application = object()
+
+    class _FakeProcess:
+        terminated = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def wait(self, *, timeout: int) -> None:
+            captured["wait_timeout"] = timeout
+
+    process = _FakeProcess()
+
+    def _fake_start_vectordb(config: ServiceConfig) -> _FakeProcess:
+        captured["config"] = config
+        return process
+
+    monkeypatch.setattr("nemo_retriever.service.cli._start_local_vectordb", _fake_start_vectordb)
+    monkeypatch.setattr("nemo_retriever.service.app.create_app", lambda config: application)
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
+
+    result = CliRunner().invoke(service_cli_app, ["start", "--config", str(config_path), "--launch-vectordb"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["config"].vectordb.enabled is True
+    assert captured["config"].vectordb.launch_on_start is True
+    assert captured["config"].vectordb.vectordb_url == "http://127.0.0.1:7671"
+    assert process.terminated is True
+    assert captured["wait_timeout"] == 10
+
+
+def test_local_vectordb_uses_configured_local_embedding(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nemo_retriever.service import cli
+
+    cfg = ServiceConfig(
+        local_models={
+            "enabled": True,
+            "hf_cache_dir": "/models/cache",
+            "device": "cuda:1",
+            "embed": {
+                "enabled": True,
+                "local_ingest_embed_backend": "hf",
+                "gpu_memory_utilization": 0.5,
+            },
+        },
+        vectordb=VectorDbConfig(vectordb_url="http://127.0.0.1:7671"),
+    )
+    command: list[str] = []
+
+    class _FakeProcess:
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    process = _FakeProcess()
+
+    def _fake_popen(args: list[str]) -> _FakeProcess:
+        command.extend(args)
+        return process
+
+    monkeypatch.setattr(cli.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(cli, "urlopen", lambda *args, **kwargs: _Response())
+
+    assert cli._start_local_vectordb(cfg) is process
+    assert "--local-embed" in command
+    assert ["--local-embed-backend", "hf"] == command[command.index("--local-embed-backend") : command.index("--local-embed-backend") + 2]
+    assert ["--hf-cache-dir", "/models/cache"] == command[command.index("--hf-cache-dir") : command.index("--hf-cache-dir") + 2]
+    assert ["--device", "cuda:1"] == command[command.index("--device") : command.index("--device") + 2]
+    assert "--embed-endpoint" not in command

--- a/nemo_retriever/tests/test_service_answer_generation.py
+++ b/nemo_retriever/tests/test_service_answer_generation.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -793,3 +794,50 @@ def test_service_start_cleans_up_vectordb_when_app_creation_fails(monkeypatch: p
 
 def test_vectordb_launch_setting_has_schema_description() -> None:
     assert VectorDbConfig.model_fields["launch_on_start"].description
+
+
+def test_service_start_force_kills_vectordb_without_masking_app_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from typer.testing import CliRunner
+
+    from nemo_retriever.service.cli import app as service_cli_app
+
+    config_path = tmp_path / "retriever-service.yaml"
+    config_path.write_text(
+        "mode: standalone\n" "nim_endpoints:\n" "  embed_invoke_url: http://embed-nim:8000/v1\n",
+        encoding="utf-8",
+    )
+
+    class _FakeProcess:
+        terminated = False
+        killed = False
+        wait_calls = 0
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def wait(self, *, timeout: int | float) -> None:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired("vectordb", timeout)
+
+    process = _FakeProcess()
+    monkeypatch.setattr("nemo_retriever.service.cli._start_local_vectordb", lambda config: process)
+    monkeypatch.setattr(
+        "nemo_retriever.service.app.create_app",
+        lambda config: (_ for _ in ()).throw(RuntimeError("create_app failed")),
+    )
+
+    result = CliRunner().invoke(service_cli_app, ["start", "--config", str(config_path), "--launch-vectordb"])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, RuntimeError)
+    assert str(result.exception) == "create_app failed"
+    assert process.terminated is True
+    assert process.killed is True
+    assert process.wait_calls == 2

--- a/scripts/launch_local_service_with_vectordb.sh
+++ b/scripts/launch_local_service_with_vectordb.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+config=${1:?usage: launch_local_service_with_vectordb.sh CONFIG [SERVICE_PORT]}
+service_port=${2:-7670}
+retriever service start --config "$config" --port "$service_port" --launch-vectordb &
+service_pid=$!
+cleanup() { kill "$service_pid" 2>/dev/null || true; wait "$service_pid" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+for _ in $(seq 1 150); do
+  if ! kill -0 "$service_pid" 2>/dev/null; then
+    echo "Retriever Service exited before readiness checks completed." >&2
+    wait "$service_pid"
+  fi
+  if curl --fail --silent --show-error "http://127.0.0.1:7671/v1/health" >/dev/null \
+    && curl --fail --silent --show-error "http://127.0.0.1:${service_port}/v1/health" >/dev/null; then
+    echo "Retriever Service and local VectorDB are healthy and ready for requests."
+    wait "$service_pid"
+    exit 0
+  fi
+  sleep 0.2
+done
+echo "Timed out waiting for Retriever Service and VectorDB readiness." >&2
+exit 1


### PR DESCRIPTION
## Description

  Add opt-in local VectorDB lifecycle management to Retriever Service.

  retriever service start can now launch and supervise a local VectorDB child process using --launch-vectordb or vectordb.launch_on_start: true in service configuration. The child starts on 127.0.0.1:7671, is checked through /v1/health before the service starts, and is terminated
  when the service exits.

  Local VectorDB startup supports both remote embedding endpoints and fully local embedding. When no nim_endpoints.embed_invoke_url is configured and local_models.enabled plus local_models.embed.enabled are set, VectorDB uses the configured local Hugging Face embedding model,
  backend, cache directory, device, and GPU memory setting. Configured remote embedding endpoints continue to take precedence.

  Add:

  - scripts/launch_local_service_with_vectordb.sh to start a local full deployment and wait for service and VectorDB readiness.
  - nemo_retriever/examples/retriever-service.local.yaml for a CUDA-based, fully local service and VectorDB deployment.
  - Focused tests for CLI lifecycle behavior and local VectorDB command construction.
  - Documentation for remote and local startup paths, prerequisites, health checks, and unchanged Helm behavior.

  ## Validation

  - Focused service tests: 3 passed.
  - Ruff checks passed.
  - New YAML loads successfully against the updated source configuration.
  - Launcher shell syntax and diff whitespace checks passed.
  - Strict MkDocs build was not run because mkdocs is unavailable in the environment.
  - 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
