### PR TITLE
update references to 26.08.1

### DIFF
--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -14,10 +14,10 @@
 #   index.html, versions.json, latest/, <version>/ (e.g. 26.8.1/)
 #
 # Manual publish only (workflow_dispatch). Do not re-enable push/tag auto-publish
-# while docs.nvidia.com 26.8.1 / latest are frozen to the 26.08.1 release docs.
+# while docs.nvidia.com 26.8.1 / latest are frozen to the 26.08 release docs.
 #
 # Operator steps when ready to publish:
-#   1. Merge doc changes to the 26.08.1 branch (content source for the build).
+#   1. Merge doc changes to the 26.08 branch (content source for the build).
 #   2. Keep docs/publish/versions.json on main accurate (version picker + latest alias).
 #   3. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
 #        dry-run: false
@@ -116,16 +116,16 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the doc pages from the 26.08.1 release branch, not main. main keeps
+      # Publish the doc pages from the 26.08 release branch, not main. main keeps
       # moving toward the next release, so its docs must not be published under the
-      # 26.8.1 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.08.1.
-      - name: Checkout 26.08.1 docs content
+      # 26.8.1 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.08.
+      - name: Checkout 26.08 docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: "26.08.1"
+          ref: "26.08"
 
       # versions.json (the version picker + "latest" alias) is canonical on main and
-      # does not exist on 26.08.1, so fetch just that file from main into a side path.
+      # does not exist on 26.08, so fetch just that file from main into a side path.
       - name: Checkout version-picker metadata from main
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -11,17 +11,17 @@
 #   Variables (optional): DOCS_AWS_REGION, NRL_DOCS_PUBLISH_VERSION, DOCS_RELEASE_EMAILS
 #
 # S3 layout written under developer/docs/nemo/retriever/:
-#   index.html, versions.json, latest/, <version>/ (e.g. 26.5.0/)
+#   index.html, versions.json, latest/, <version>/ (e.g. 26.8.1/)
 #
 # Manual publish only (workflow_dispatch). Do not re-enable push/tag auto-publish
-# while docs.nvidia.com 26.5.0 / latest are frozen to the 26.05 release docs.
+# while docs.nvidia.com 26.8.1 / latest are frozen to the 26.08.1 release docs.
 #
 # Operator steps when ready to publish:
-#   1. Merge doc changes to the 26.05 branch (content source for the build).
+#   1. Merge doc changes to the 26.08.1 branch (content source for the build).
 #   2. Keep docs/publish/versions.json on main accurate (version picker + latest alias).
 #   3. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
 #        dry-run: false
-#        docs-version-override: 26.5.0 (or leave empty to use NRL_DOCS_PUBLISH_VERSION / default)
+#        docs-version-override: 26.8.1 (or leave empty to use NRL_DOCS_PUBLISH_VERSION / default)
 #        publish-as-latest: true only when intentionally refreshing latest/
 # Backports: publish-as-latest: false; do not move the "latest" alias in versions.json.
 name: NRL documentation — docs.nvidia.com publish
@@ -35,7 +35,7 @@ on:
         type: boolean
         default: true
       docs-version-override:
-        description: Version folder to publish (e.g. 26.5.0). Empty uses NRL_DOCS_PUBLISH_VERSION, or 26.5.0.
+        description: Version folder to publish (e.g. 26.8.1). Empty uses NRL_DOCS_PUBLISH_VERSION, or 26.8.1.
         required: false
         type: string
         default: ""
@@ -93,7 +93,7 @@ jobs:
             VERSION="${NRL_DOCS_PUBLISH_VERSION_VAR}"
           fi
           if [[ -z "${VERSION}" ]]; then
-            VERSION="26.5.0"
+            VERSION="26.8.1"
           fi
           echo "docs_version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "site_url=${{ env.DOCS_SITE_URL_BASE }}/${VERSION}/" >> "$GITHUB_OUTPUT"
@@ -116,16 +116,16 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the doc pages from the 26.05 release branch, not main. main keeps
+      # Publish the doc pages from the 26.08.1 release branch, not main. main keeps
       # moving toward the next release, so its docs must not be published under the
-      # 26.5.0 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.05.
-      - name: Checkout 26.05 docs content
+      # 26.8.1 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.08.1.
+      - name: Checkout 26.08.1 docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: "26.05"
+          ref: "26.08.1"
 
       # versions.json (the version picker + "latest" alias) is canonical on main and
-      # does not exist on 26.05, so fetch just that file from main into a side path.
+      # does not exist on 26.08.1, so fetch just that file from main into a side path.
       - name: Checkout version-picker metadata from main
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -5,12 +5,12 @@ on:
   workflow_dispatch:
     inputs:
       source-branch:
-        description: 'Git ref to build from (e.g. `26.05`). When empty, RC versions like `26.05-RC8` build from `26.05`; otherwise uses the branch selected in "Run workflow".'
+        description: 'Git ref to build from (e.g. `26.08.1`). When empty, prerelease versions build from `26.08.1`; otherwise uses the branch selected in "Run workflow".'
         required: false
         type: string
         default: ''
       version:
-        description: 'Release version for artifacts and git tag (e.g. `26.05-RC8`). Does not need to exist before the run.'
+        description: 'Release version for artifacts and git tag (e.g. `26.08.1`). Does not need to exist before the run.'
         required: false
         type: string
         default: ''

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       source-branch:
-        description: 'Git ref to build from (e.g. `26.08.1`). When empty, prerelease versions build from `26.08.1`; otherwise uses the branch selected in "Run workflow".'
+        description: 'Git ref to build from (e.g. `26.08`). When empty, prerelease and patch releases build from the corresponding release branch; otherwise uses the branch selected in "Run workflow".'
         required: false
         type: string
         default: ''
@@ -59,6 +59,9 @@ jobs:
           elif [ -n "$VERSION_INPUT" ] && [[ "$VERSION_INPUT" =~ ^(.+)-RC[0-9]+$ ]]; then
             SOURCE_REF="${BASH_REMATCH[1]}"
             echo "RC version $VERSION_INPUT: building from integration branch $SOURCE_REF"
+          elif [ -n "$VERSION_INPUT" ] && [[ "$VERSION_INPUT" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
+            SOURCE_REF="${BASH_REMATCH[1]}"
+            echo "Patch release $VERSION_INPUT: building from release branch $SOURCE_REF"
           elif [ -n "$VERSION_INPUT" ]; then
             SOURCE_REF="$VERSION_INPUT"
           else

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Chart version (e.g. 26.5.0)'
+        description: 'Chart version (e.g. 26.8.1)'
         required: true
         type: string
       source-ref:

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ FROM install AS service
 
 # Optional release metadata for OpenAPI ``info.version`` and package version helpers.
 # Release builds should pass matching values, for example:
-#   --build-arg RETRIEVER_VERSION=26.08-RC4 --build-arg RETRIEVER_RELEASE_TYPE=release
+#   --build-arg RETRIEVER_VERSION=26.08.1 --build-arg RETRIEVER_RELEASE_TYPE=release
 ARG RETRIEVER_VERSION=
 ARG RETRIEVER_RELEASE_TYPE=dev
 ENV RETRIEVER_VERSION=${RETRIEVER_VERSION}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **Important: The default branch is main, which tracks active development and may be ahead of the latest supported release.**
 
-For the latest supported release, use the [26.05 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05) (GA PyPI and Helm chart version `26.5.0`). The previous stable line is [26.03](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
+For the latest supported release, use the [26.08.1 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1) (GA PyPI and Helm chart version `26.8.1`). The previous stable line is [26.03](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
 
 See the corresponding [NeMo Retriever Library documentation](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **Important: The default branch is main, which tracks active development and may be ahead of the latest supported release.**
 
-For the latest supported release, use the [26.08.1 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08.1) (GA PyPI and Helm chart version `26.8.1`). The previous stable line is [26.03](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
+For the latest supported release, use the [26.08 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.08) (GA PyPI and Helm chart version `26.8.1`). The previous stable line is [26.03](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
 
 See the corresponding [NeMo Retriever Library documentation](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/).
 

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -2,19 +2,19 @@
 
 This documentation contains the release notes for [NeMo Retriever Library](overview.md).
 
-## 26.08 Release Notes (26.8.0) { #release-2608 }
+## 26.08.1 Release Notes (26.8.1) { #release-26081 }
 
-NVIDIA® NeMo Retriever Library version 26.08 adds a shared text-generation task API, configurable large language model (LLM) settings, grounded answer-generation model paths, agentic retrieval, and updated Helm NIM defaults. It continues the 26.05 graph ingest, multimodal extraction, and Helm-first deployment foundation.
+NVIDIA® NeMo Retriever Library version 26.08.1 includes a shared text-generation task API, configurable large language model (LLM) settings, grounded answer-generation model paths, agentic retrieval, and updated Helm NIM defaults. It builds on the graph ingest, multimodal extraction, and Helm-first deployment foundation.
 
 To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
 
-The following sections summarize user-visible changes introduced in 26.08. Capabilities first documented in 26.05 that remain current are listed under [Continuing from 26.05](#continuing-from-2605).
+The following sections summarize user-visible changes included in 26.08.1 and foundational capabilities that remain current.
 
 ### Upgrade notes { #upgrade-notes }
 
-- Nemotron OCR v2 is now the default OCR engine for local Hugging Face, hosted CPU actors, and Helm NIM deployments. 26.05 kept Helm on OCR v1. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`.
+- Nemotron OCR v2 is now the default OCR engine for local Hugging Face, hosted CPU actors, and Helm NIM deployments. The previous release kept Helm on OCR v1. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`.
 - Helm replaces separate page-elements and table-structure NIMs with the combined `nemotron-object-detection:2.0.1` image. Development Compose uses the same combined object-detection image and OCR v2, but still defaults to `2.0.0` tags unless you override `NIM_*_TAG`.
-- Helm default VL embed and VL rerank NIM images bump to `2.3.0`. 26.05 used `1.12.0` and `1.11.0`. Development Compose still defaults to `1.12.0` and `1.11.0` unless you override `NIM_EMBED_TAG` and `NIM_RERANK_TAG`.
+- Helm default VL embed and VL rerank NIM images bump to `2.3.0`. The previous release used `1.12.0` and `1.11.0`. Development Compose still defaults to `1.12.0` and `1.11.0` unless you override `NIM_EMBED_TAG` and `NIM_RERANK_TAG`.
 - Default VLM image captioning is Nemotron 3 Nano Omni for local and hosted paths. Chart-classified PDF regions remain on the layout and OCR path.
 - Hosted Nemotron Parse and self-hosted Nemotron Parse use distinct HTTP contracts. Select the matching client path for your endpoint.
 - macOS Intel (x86_64) is no longer supported for package installs. Use Apple Silicon (arm64) macOS, Windows x64, or Linux. Refer to [Packaging and platform](#packaging-and-platform).
@@ -22,11 +22,11 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - Self-hosted Parakeet on Helm requires both `nimOperator.audio.enabled=true` and `serviceConfig.nimEndpoints.audioGrpcEndpoint=audio:50051`. Enabling the audio NIM alone does not wire the service ASR endpoint.
 - Changing a Helm NIM image repository or tag on an existing release cannot patch `NIMCache` `spec.source.ngc.modelPuller`. Delete the `NIMCache` and its PVC, then upgrade. The affected NIM is unavailable while the operator re-caches weights. Refer to [Changing a NIM image repository or tag](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#changing-nim-image-repository-or-tag).
 - A document whose VectorDB write is not acknowledged now fails instead of reporting `completed` with a positive row count. Earlier builds failed only collection-managed writes and logged a legacy fixed-table failure as a warning. The worker acknowledgement timeout is configurable through `serviceConfig.vectordb.writeTimeoutSeconds` (rendered as `vectordb.write_timeout_s`) and defaults to 300 seconds. Refer to [Ingest fails with a VectorDB write error](troubleshoot.md#vectordb-write-not-acknowledged).
-- Retriever Service OpenAPI `info.version` no longer reports a stale `26.5.0` value. The service reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.
+- Retriever Service OpenAPI `info.version` no longer reports a stale package-version value. The service reports the package version, and Helm sets `RETRIEVER_SERVICE_VERSION` from the running service image tag so `/openapi.json` matches the deployed release.
 
 ### Text generation and LLM configuration { #text-generation-and-llm-configuration }
 
-- 26.08 introduces a shared one-request-per-row text-generation abstraction: `TextGenerationTask` plus `TextGenerationOperator`. `GenericGenerationOperator` accepts a validated custom prompt. Refer to [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation).
+- 26.08.1 includes a shared one-request-per-row text-generation abstraction: `TextGenerationTask` plus `TextGenerationOperator`. `GenericGenerationOperator` accepts a validated custom prompt. Refer to [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation).
 - `SummarizeTask` inherits from `TextGenerationTask`. `SummarizationOperator` provides the built-in summarization behavior with the default prompt or a custom prompt.
 - Configure those operators with `TextGenerationParams.from_kwargs(...)`. Supported fields include `model`, `api_base`, `api_key`, `temperature`, `top_p`, `max_tokens`, `extra_params`, `num_retries`, `timeout`, `prompt`, `system_prompt`, `rag_system_prompt`, `rag_system_prompt_prefix`, `reasoning_enabled`, and `max_workers`. Refer to [TextGenerationParams configuration](nemo-retriever-api-reference.md#textgenerationparams-configuration).
 
@@ -37,7 +37,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 
 ### Agentic retrieval { #agentic-retrieval }
 
-- Agentic retrieval is a 26.08 user-facing feature. An LLM agent issues multiple searches, fuses candidates, and returns a document-level ranking. The CLI, Python query workflow, REST, and MCP surfaces share this path. Refer to [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
+- Agentic retrieval is available in 26.08.1. An LLM agent issues multiple searches, fuses candidates, and returns a document-level ranking. The CLI, Python query workflow, REST, and MCP surfaces share this path. Refer to [Agentic retrieval (concept)](agentic-retrieval-concept.md) and [Workflow: Agentic retrieval](workflow-agentic-retrieval.md).
 - `retriever query --agentic` runs that ReAct loop over the same LanceDB table as one-pass retrieval. Local CLI and harness runs default to in-process vLLM (`nemotron-8b`). Remote OpenAI-compatible NIM or NVIDIA-hosted endpoints use `--agentic-invoke-url`.
 - Retriever Service exposes agentic retrieval on `POST /v1/query` with `agentic=true` and an `agentic_query` MCP tool when `agentic.enabled` is true. Service mode requires a remote OpenAI-compatible LLM endpoint. Agentic remains opt-in through `serviceConfig.agentic.enabled`.
 - The Helm `answer_llm` Super-49B NIM auto-wires `/v1/answer` only. Self-hosted agentic retrieval against that NIM requires `--enable-auto-tool-choice --tool-call-parser llama3_json` on `NIM_PASSTHROUGH_ARGS` and explicit `serviceConfig.agentic` wiring. Refer to [Self-hosted Helm Super-49B](workflow-agentic-retrieval.md#self-hosted-helm-super-49b).
@@ -47,13 +47,13 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 
 - Nemotron OCR v2 is unified across library, hosted, and Helm defaults. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration).
 - Local OCR crop batching runs across page rows for throughput. Helm extraction NIMs (OCR and object detection) enable performance mode by default. The VL embed NIM does not.
-- 26.08 Helm default and optional NIM images that affect mirroring, allowlisting, and troubleshooting include the following:
+- 26.08.1 Helm default and optional NIM images that affect mirroring, allowlisting, and troubleshooting include the following:
     - Combined object detection for page elements and table structure: `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1`
     - VL embedding: `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0`
     - VL reranking (optional): `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0`
     - Optional Omni caption and configurable answer VLM: `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant`
     - Optional answer-generation LLM: `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:2.0.5`
-- Optional Nemotron-3-Embed-1B is a released 26.08 embedding artifact. It is not enabled by default and is not a Helm NIM.
+- Optional Nemotron-3-Embed-1B is available in 26.08.1. It is not enabled by default and is not a Helm NIM.
     - Optional NIM: `nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.2`
     - Optional Hugging Face checkpoint: `nvidia/Nemotron-3-Embed-1B-BF16` (revision `9e0b24858b1195815ecb1188ffa1b73bcea7b30a`)
 - The CLI lists `nvidia/Nemotron-3-Embed-1B-BF16` among tested official local checkpoints. For local Hugging Face inference, pass `--embed-model-name nvidia/Nemotron-3-Embed-1B-BF16`. For a self-hosted or hosted embedding NIM, pass `--embed-invoke-url` with `--embed-model-name`. Refer to [Dense Nemotron embedding checkpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#dense-nemotron-embedding-checkpoints) for local checkpoint usage. Refer to [Route ingest to hosted or self-hosted NIM endpoints](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#route-ingest-to-hosted-or-self-hosted-nim-endpoints) and the text-only embedding NIM note in [Multimodal embeddings](embedding.md) for external endpoints.
@@ -109,7 +109,7 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 ### Packaging and platform { #packaging-and-platform }
 
 - Public nightlies are published to PyPI while local install extras remain stable.
-- Ray is raised to `>=2.56.1` for CVE remediation. 26.05 used `>=2.49.0`. Ray no longer publishes wheels for macOS Intel (x86_64), so `pip` and `uv` installs fail on Intel Macs, including in-process library mode. Apple Silicon (arm64) macOS remains supported for slim remote or NIM-only installs, alongside Windows x64.
+- Ray is raised to `>=2.56.1` for CVE remediation. The previous release used `>=2.49.0`. Ray no longer publishes wheels for macOS Intel (x86_64), so `pip` and `uv` installs fail on Intel Macs, including in-process library mode. Apple Silicon (arm64) macOS remains supported for slim remote or NIM-only installs, alongside Windows x64.
 
 ### Helm chart { #helm-chart }
 
@@ -121,9 +121,9 @@ The following sections summarize user-visible changes introduced in 26.08. Capab
 - Published [One-shot text generation](nemo-retriever-api-reference.md#one-shot-text-generation) for `TextGenerationTask`, `GenericGenerationOperator`, `SummarizationOperator`, and `TextGenerationParams`.
 - Clarified Super-49B and Omni answer-generation paths on this page and in [Answer generation](prerequisites-support-matrix.md#answer-generation). For Helm enablement and slot overrides, refer to [Answer generation (operator-managed LLM)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#answer-generation-llm).
 
-### Continuing from 26.05 { #continuing-from-2605 }
+### Current foundational capabilities { #current-foundational-capabilities }
 
-The following capabilities shipped in 26.05 and remain current in 26.08. They are not new 26.08 highlights. For the original 26.05 wording, refer to the [26.05 Release Notes](https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/releasenotes-nv-ingest/).
+The following foundational capabilities remain current. They are not new 26.08.1 highlights.
 
 - Text splitting for graph and library ingest uses `.extract(split_config=...)` instead of standalone `.split()` on the graph ingest path. The service ingestor API can still expose `.split()` separately.
 - Direct `Retriever(...)` construction uses `vdb_kwargs`, `embed_kwargs`, and `rerank` instead of flat `lancedb_uri`, `lancedb_table`, `embedder`, `embedding_endpoint`, `local_query_embed_backend`, and `reranker` arguments.
@@ -150,7 +150,7 @@ The following capabilities shipped in 26.05 and remain current in 26.08. They ar
 
 ## Release Notes for Previous Versions { #previous-versions }
 
-- [26.05](https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/releasenotes-nv-ingest/) (GA on docs.nvidia.com at time of 26.08 RC)
+- [26.05](https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/releasenotes-nv-ingest/)
 - [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
 - [26.1.2](https://archive.docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes-nv-ingest/)
 - [26.1.1](https://archive.docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes-nv-ingest/)

--- a/docs/publish/versions.json
+++ b/docs/publish/versions.json
@@ -1,7 +1,7 @@
 [
   {
-    "version": "26.5.0",
-    "title": "26.5.0",
+    "version": "26.8.1",
+    "title": "26.8.1",
     "aliases": ["latest"]
   },
   {

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -55,7 +55,7 @@ try prerelease/nightly Nemotron packages from PyPI within the same supported
 major-version windows, opt in with `--pre`:
 
 ```bash
-uv pip install --pre "nemo-retriever[local]==26.08-RC1"
+uv pip install --pre "nemo-retriever[local]==26.08.1"
 ```
 
 **Remote NIM (no local GPU)**

--- a/nemo_retriever/docker.md
+++ b/nemo_retriever/docker.md
@@ -20,9 +20,9 @@ For a release-tagged image whose OpenAPI document should report a specific versi
 docker build \
   -f Dockerfile \
   --target service \
-  --build-arg RETRIEVER_VERSION=26.08-RC4 \
+  --build-arg RETRIEVER_VERSION=26.08.1 \
   --build-arg RETRIEVER_RELEASE_TYPE=release \
-  -t nemo-retriever-service:26.08-RC4 \
+  -t nemo-retriever-service:26.08.1 \
   .
 ```
 

--- a/nemo_retriever/harness/examples/managed-helm-nrl-26.08.1.yaml
+++ b/nemo_retriever/harness/examples/managed-helm-nrl-26.08.1.yaml
@@ -1,4 +1,4 @@
-# Historical managed NRL Helm service configuration for the 26.05 perf sweep.
+# Historical managed NRL Helm service configuration for the 26.08.1 perf sweep.
 #
 # This body preserves the retired nested harness schema for release reference;
 # it is not accepted by the current managed-Helm runner. For current runs, use
@@ -11,9 +11,9 @@
 #   - ngc-api: opaque secret with the NGC API key entries required by the NIM operator
 # Keep credentials out of this file and out of command history.
 
-# Use the official 26.5.0 NGC chart. The chart defaults to the matching
-# nvcr.io/nvidia/nemo-microservices/nrl-service:26.5.0 service image.
-x-nrl-chart-version: &nrl_chart_version "26.5.0"
+# Use the official 26.8.1 NGC chart. The chart defaults to the matching
+# nvcr.io/nvidia/nemo-microservices/nrl-service:26.8.1 service image.
+x-nrl-chart-version: &nrl_chart_version "26.8.1"
 
 active:
   dataset: bo767

--- a/nemo_retriever/helm/Chart.yaml
+++ b/nemo_retriever/helm/Chart.yaml
@@ -18,8 +18,8 @@ description: |
   work and status history.
 
 type: application
-version: "26.5.0"
-appVersion: "26.5.0"
+version: "26.8.1"
+appVersion: "26.8.1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/NVIDIA/NeMo-Retriever
 sources:

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -452,7 +452,7 @@ helm install retriever ./nemo_retriever/helm \
   --set ngcApiSecret.password=$NGC_API_KEY
 ```
 
-### Recommended minimal install (26.08) { #recommended-minimal-install-2608 }
+### Recommended minimal install (26.08.1) { #recommended-minimal-install-26081 }
 
 Complete the [persistent storage prerequisite](#persistent-storage-prerequisite)
 and the [GPU scheduling prerequisite](#gpu-scheduling-prerequisite)
@@ -466,7 +466,7 @@ helm install retriever ./nemo_retriever/helm \
   --set ngcImagePullSecret.password=$NGC_API_KEY \
   --set ngcApiSecret.create=true \
   --set ngcApiSecret.password=$NGC_API_KEY \
-  --set service.image.tag=26.8.0
+  --set service.image.tag=26.8.1
 ```
 
 > The VL reranker (`rerankqa`), Nemotron Parse, the Nemotron 3 Nano Omni 30B caption NIM, the generic answer-generation LLM (`answer_llm`, Super-49B defaults), and the Parakeet `audio` ASR NIM are **all off by default** — they only reconcile when you explicitly opt in. Opt-in flags:

--- a/nemo_retriever/helm/openshift.md
+++ b/nemo_retriever/helm/openshift.md
@@ -192,7 +192,7 @@ helm install retriever ./nemo_retriever/helm -n nemo-retriever \
   --set persistence.enabled=false \
   --set retrieverResults.enabled=false \
   --set service.image.repository=nvcr.io/nvidia/nemo-microservices/nrl-service \
-  --set service.image.tag=26.8.0
+  --set service.image.tag=26.8.1
 ```
 
 Verify pods:
@@ -214,7 +214,7 @@ helm install retriever ./nemo_retriever/helm -n nemo-retriever \
   --set ngcImagePullSecret.create=false \
   --set ngcApiSecret.create=false \
   --set service.image.repository=nvcr.io/nvidia/nemo-microservices/nrl-service \
-  --set service.image.tag=26.8.0
+  --set service.image.tag=26.8.1
 ```
 
 After install, confirm workloads reach Ready before you run ingest:

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -71,7 +71,7 @@ service:
     #   docker build -f Dockerfile --target service \
     #       -t <your-registry>/nemo-retriever-service:<tag> .
     repository: nvcr.io/nvidia/nemo-microservices/nrl-service
-    tag: "26.5.0"
+    tag: "26.8.1"
     pullPolicy: IfNotPresent
 
   # Optional image for in-pod Hugging Face models (service-gpu Docker target).
@@ -1041,7 +1041,7 @@ nimOperator:
   # ---------------------------------------------------------------------------
   # Two enablement tiers, matching the docs' "core vs optional" contract
   # (see docs/extraction/deployment-options.md "Core NIMs for the default
-  # extraction pipeline (26.05)"):
+  # extraction pipeline (26.08.1)"):
   #
   #   Core (enabled: true by default, auto-wired into the service config):
   #     - page_elements
@@ -1065,11 +1065,11 @@ nimOperator:
   #   * `nimOperator.<key>.enabled: true` — per-NIM toggle below.
   #
   # The optional NIMs sit behind their per-NIM toggles to honor the
-  # "optional and disabled by default" contract in 26.05 — turning them
+  # "optional and disabled by default" contract in 26.08.1 — turning them
   # on alongside the core stack at install time would silently pull tens
   # of gigabytes of model weights (Omni 30B ≈ 62 GiB BF16) and consume
   # an additional dedicated GPU per NIM with no opt-in from the operator.
-  # See helm/README.md "Recommended minimal install (26.05)" for the
+  # See helm/README.md "Recommended minimal install (26.08.1)" for the
   # opt-in flags and "Image tag conventions" for what the
   # ``1.7.0-variant`` Parse and ``2.0.4-variant`` Omni tags mean.
   # ---------------------------------------------------------------------------
@@ -1390,7 +1390,7 @@ nimOperator:
 
   # Llama Nemotron rerank VL 1B v2 — multimodal reranking NIM.
   #
-  # Disabled by default per the 26.05 "optional and disabled by default"
+  # Disabled by default per the 26.08.1 "optional and disabled by default"
   # contract (see docs/extraction/deployment-options.md L21 and
   # docs/extraction/prerequisites-support-matrix.md L92 / L128). Opt in
   # only when the retrieval pipeline calls a reranker — enabling this NIM
@@ -1402,7 +1402,7 @@ nimOperator:
   # `serviceConfig.nimEndpoints.rerankInvokeUrl` /
   # `rerankModelName` when pointing at an external ranking endpoint.
   #
-  # IMPORTANT — VL vs text-only: 26.05 documents the **VL** reranker
+  # IMPORTANT — VL vs text-only: 26.08.1 documents the **VL** reranker
   # (``llama-nemotron-rerank-vl-1b-v2``) as the supported NIM so the
   # ingest pipeline can score image + text passages together. The
   # text-only ``llama-nemotron-rerank-1b-v2`` is a different SKU that
@@ -1454,14 +1454,14 @@ nimOperator:
 
   # Nemotron Parse v1.2. Optional structured document parser.
   #
-  # Disabled by default per the 26.05 "optional and disabled by default"
+  # Disabled by default per the 26.08.1 "optional and disabled by default"
   # contract (see docs/extraction/deployment-options.md). Opt in only when
   # the pipeline runs `extract_method="nemotron_parse"`; enabling this
   # NIM consumes one GPU and ~3.5 GiB of GPU memory at runtime, plus
   # ~16 GB of on-disk NIM model cache (see prerequisites-support-matrix).
   #
   # The default image tag (`1.7.0-variant`) is the Nemotron Parse v1.2
-  # NIM SKU shipped alongside the 26.05 release; the `-variant` suffix
+  # NIM SKU shipped alongside the 26.08.1 release; the `-variant` suffix
   # marks it as the build that ships with the per-GPU TensorRT engine
   # variants required by NIM Operator profile reconciliation, matching
   # `nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant` and the row
@@ -1515,7 +1515,7 @@ nimOperator:
   # Nemotron 3 Nano Omni 30B A3B Reasoning. Multimodal reasoning VLM
   # used by the image-captioning stage.
   #
-  # Disabled by default per the 26.05 "optional and disabled by default"
+  # Disabled by default per the 26.08.1 "optional and disabled by default"
   # contract (see docs/extraction/deployment-options.md). This is the
   # canonical caption NIM — once enabled the chart auto-wires
   # `nim_endpoints.caption_invoke_url` + `caption_model_name` into the
@@ -1528,7 +1528,7 @@ nimOperator:
   # nimservice` if necessary).
   #
   # The default image tag (`2.0.4-variant`) is the Omni NIM SKU shipped
-  # alongside the 26.05 release; the `-variant` suffix marks it as the
+  # alongside the 26.08.1 release; the `-variant` suffix marks it as the
   # build that ships with the per-GPU TensorRT engine variants required
   # by NIM Operator profile reconciliation, matching the row for the
   # Omni caption NIM in

--- a/nemo_retriever/src/nemo_retriever/service/client.py
+++ b/nemo_retriever/src/nemo_retriever/service/client.py
@@ -139,7 +139,7 @@ class RetrieverServiceCompatibilityError(RuntimeError):
     nrl-service is older than this SDK build.  Raising a dedicated
     error type lets callers surface a single, actionable message
     instead of the previous silent "no document_complete event"
-    failure mode that 26.05-RC2 customers reported.
+    failure mode that 26.08.1 customers reported.
     """
 
 
@@ -168,9 +168,9 @@ def _compat_error_message(
         "This signals an SDK/service version mismatch: this Python "
         "SDK targets the job-scoped ingest API "
         "(POST /v1/ingest/job + POST /v1/ingest/job/{job_id}/document "
-        "+ GET /v1/ingest/job/{job_id}/events) introduced in 26.05, "
+        "+ GET /v1/ingest/job/{job_id}/events) introduced in 26.08.1, "
         "but the deployed nrl-service does not advertise that route. "
-        "Upgrade the chart/image to a 26.05+ build, or downgrade the "
+        "Upgrade the chart/image to a 26.08.1+ build, or downgrade the "
         "Python SDK to match the deployed service version. Server "
         f"response body: {body_clip}"
     )
@@ -643,7 +643,7 @@ class RetrieverServiceClient:
         # A 404/410 here means the deployed service does not advertise
         # the job-scoped ingest API.  Surface a dedicated compatibility
         # error instead of a generic HTTPStatusError so callers see one
-        # actionable message — see the 26.05-RC2 release-integration
+        # actionable message — see the 26.08.1 release-integration
         # regression report.
         if _is_api_mismatch_status(resp.status_code):
             raise RetrieverServiceCompatibilityError(

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -2192,7 +2192,7 @@ async def job_callback(request: Request) -> JSONResponse:
 # ------------------------------------------------------------------
 
 
-_LEGACY_REMOVED_VERSION = "26.05"
+_LEGACY_REMOVED_VERSION = "26.08.1"
 
 _LEGACY_INGEST_DETAIL = (
     "POST /v1/ingest was removed in retriever-service "
@@ -2223,7 +2223,7 @@ async def _legacy_ingest_upload_removed() -> None:
     Older SDK builds (pre-v2 client) upload through ``POST /v1/ingest``.
     Without this stub FastAPI returns a body-less 404 and the SDK
     surfaces "no documents completed" with no indication of why — the
-    customer-visible regression captured in the 26.05-RC2 release notes.
+    customer-visible regression captured in the 26.08.1 release notes.
     """
     raise HTTPException(status_code=410, detail=_LEGACY_INGEST_DETAIL)
 

--- a/nemo_retriever/tests/test_helm_caption_endpoint.py
+++ b/nemo_retriever/tests/test_helm_caption_endpoint.py
@@ -4,7 +4,7 @@
 
 """Regression tests for the Omni 30B caption-endpoint auto-wiring.
 
-In 26.05 RC2 the chart could deploy the Nemotron 3 Nano Omni VLM as a
+In 26.08.1 the chart could deploy the Nemotron 3 Nano Omni VLM as a
 NIMService, but the retriever-service ConfigMap rendered no
 ``caption_invoke_url`` / ``caption_model_name``.  The downstream service
 deriving ``caption_enabled`` from

--- a/nemo_retriever/tests/test_helm_nimcache_model_profile.py
+++ b/nemo_retriever/tests/test_helm_nimcache_model_profile.py
@@ -6,7 +6,7 @@
 
 The NIM Operator's NIMCache CRD supports an optional
 ``spec.source.ngc.model`` block that restricts which model profiles a
-cache job downloads (by GPU SKU or by profile UUID).  Through 26.05 RC2
+cache job downloads (by GPU SKU or by profile UUID).  Through 26.08.1
 the chart's NIMCache templates omitted the field entirely and
 ``values.yaml`` exposed no corresponding knob — even
 ``--set nimOperator.<key>.gpus[0].ids[0]=26B5`` could not move the
@@ -135,7 +135,7 @@ def _iter_nimcache_docs(rendered: str) -> list[dict]:
 
 
 class NimCacheModelProfileTests(TestCase):
-    """26.05 contract: every NIMCache exposes spec.source.ngc.model."""
+    """26.08.1 contract: every NIMCache exposes spec.source.ngc.model."""
 
     # ------------------------------------------------------------------
     # values.yaml — source-level invariants

--- a/nemo_retriever/tests/test_helm_optional_nims_disabled_by_default.py
+++ b/nemo_retriever/tests/test_helm_optional_nims_disabled_by_default.py
@@ -2,12 +2,12 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression tests for the 26.05 "optional and disabled by default" contract.
+"""Regression tests for the 26.08.1 "optional and disabled by default" contract.
 
-The 26.05 docs at ``docs/extraction/deployment-options.md`` mark the
+The 26.08.1 docs at ``docs/extraction/deployment-options.md`` mark the
 **VL reranker** (``llama-nemotron-rerank-vl-1b-v2``), **Nemotron Parse**,
 and the **Nemotron 3 Nano Omni 30B** caption NIM as optional and not
-auto-wired into the retriever-service.  Through 26.05 RC2 the Helm
+auto-wired into the retriever-service.  Through 26.08.1 the Helm
 chart did the opposite — all three NIMs were ``enabled: true`` in
 ``values.yaml`` — so a plain ``helm install`` (matching the documented
 quick-start) silently pulled tens of GiB of model weights and claimed a
@@ -30,7 +30,7 @@ These tests pin the chart-side fix:
   ``--set nimOperator.<key>.enabled=true`` workflow keeps working.
 * The README and ``values.yaml`` document the ``1.7.0-variant`` tag
   used by Parse + Omni so air-gapped mirror pipelines and
-  reproducibility audits can map it to the 26.05 release.
+  reproducibility audits can map it to the 26.08.1 release.
 
 The integration tests shell out to ``helm template`` when ``helm`` is
 on ``$PATH``; otherwise they skip cleanly.
@@ -68,7 +68,7 @@ _RERANK_TEXT_SERVICE_NAME = "name: llama-nemotron-rerank-1b-v2"
 _PARSE_SERVICE_NAME = "name: nemotron-parse"
 _OMNI_SERVICE_NAME = "name: nemotron-3-nano-omni-30b-a3b-reasoning"
 
-# Image tags the chart pins for Parse and Omni in 26.05. Documenting it on
+# Image tags the chart pins for Parse and Omni in 26.08.1. Documenting it on
 # both ends (values.yaml comments + README) keeps air-gapped mirror
 # pipelines pointed at the right NGC tag.
 _PARSE_VARIANT_TAG = "1.7.0-variant"
@@ -76,7 +76,7 @@ _OMNI_VARIANT_TAG = "2.0.4-variant"
 
 # Repositories the rerank NIM may be pinned to. The chart MUST point at
 # the VL SKU — the text-only SKU silently degrades multimodal
-# reranking, which is the bug surfaced in the 26.05 report.
+# reranking, which is the bug surfaced in the 26.08.1 report.
 _RERANK_VL_REPOSITORY = "nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2"
 _RERANK_TEXT_REPOSITORY = "nvcr.io/nim/nvidia/llama-nemotron-rerank-1b-v2"
 
@@ -146,7 +146,7 @@ def _assert_helm_ok(self: TestCase, proc: subprocess.CompletedProcess[str]) -> N
 
 
 class OptionalNimsDefaultDisabledTests(TestCase):
-    """26.05 contract: Parse and Omni are off until the user opts in."""
+    """26.08.1 contract: Parse and Omni are off until the user opts in."""
 
     # ------------------------------------------------------------------
     # values.yaml — source-level invariants
@@ -177,7 +177,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
         Omni 30B is the heaviest NIM in the chart (~62 GiB BF16 weights,
         ~80 GB on-disk NIM cache, requires its own ≥ 80 GiB GPU). It must
         not deploy on a "default" install — that contradicts the docs and
-        the README's [Recommended minimal install (26.08)] guidance.
+        the README's [Recommended minimal install (26.08.1)] guidance.
         """
         values = _read_required_file(_VALUES_YAML)
         value = _enabled_value_for_block(values, _OMNI_BLOCK)
@@ -193,7 +193,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
     def test_values_rerankqa_enabled_defaults_to_false(self) -> None:
         """``nimOperator.rerankqa.enabled`` must default to ``false``.
 
-        Through 26.05 RC2 this defaulted to ``true``, so a plain
+        Through 26.08.1 this defaulted to ``true``, so a plain
         ``helm install`` provisioned an extra ≈ 3.1 GiB GPU NIM with no
         opt-in. The docs explicitly mark the VL reranker as optional
         and disabled by default (``docs/extraction/deployment-options.md``
@@ -215,7 +215,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
 
         ``docs/extraction/prerequisites-support-matrix.md`` L92 / L128
         documents ``llama-nemotron-rerank-vl-1b-v2`` as the supported
-        reranker NIM for 26.05. Through RC2 the chart shipped the
+        reranker NIM for 26.08.1. Through RC2 the chart shipped the
         text-only ``llama-nemotron-rerank-1b-v2`` — that SKU silently
         degrades multimodal reranking and is not the documented POR.
         """
@@ -235,7 +235,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
             values,
             "values.yaml must not pin the text-only rerank SKU "
             f"`{_RERANK_TEXT_REPOSITORY}` — that silently degrades "
-            "multimodal reranking and contradicts the 26.05 docs. Use "
+            "multimodal reranking and contradicts the 26.08.1 docs. Use "
             "the VL build instead.",
         )
 
@@ -298,7 +298,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
             self.assertRegex(
                 readme,
                 rf"`{path}`.*\|\s*`false`",
-                f"README per-NIM defaults table must show `{path}` defaulting " "to `false` after the 26.05 fix.",
+                f"README per-NIM defaults table must show `{path}` defaulting " "to `false` after the 26.08.1 fix.",
             )
 
     def test_readme_image_table_pins_vl_rerank_sku(self) -> None:
@@ -370,12 +370,12 @@ class OptionalNimsDefaultDisabledTests(TestCase):
         # Find the heredoc-style minimal install command. The recipe
         # ends with `audio.enabled=false`; the block above that is what
         # we inspect.
-        marker = "Recommended minimal install (26.08)"
+        marker = "Recommended minimal install (26.08.1)"
         idx = readme.find(marker)
         self.assertNotEqual(
             idx,
             -1,
-            "README must keep a `Recommended minimal install (26.08)` "
+            "README must keep a `Recommended minimal install (26.08.1)` "
             "section even after the defaults flip — it documents the "
             "two flags that are still needed (`rerankqa` + `audio`).",
         )
@@ -400,7 +400,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
             window,
             "Minimal-install recipe must not set "
             "`nimOperator.rerankqa.enabled=false` — that's the default "
-            "in 26.05 now and listing it implies the chart still "
+            "in 26.08.1 now and listing it implies the chart still "
             "provisions the VL reranker on a plain install.",
         )
 
@@ -429,14 +429,14 @@ class OptionalNimsDefaultDisabledTests(TestCase):
             proc.stdout,
             "Default helm template render must not contain a "
             "`name: nemotron-parse` resource — Parse is optional and "
-            "disabled by default in 26.05.",
+            "disabled by default in 26.08.1.",
         )
         self.assertNotIn(
             _OMNI_SERVICE_NAME,
             proc.stdout,
             "Default helm template render must not contain a "
             "`name: nemotron-3-nano-omni-30b-a3b-reasoning` resource — "
-            "Omni 30B is optional and disabled by default in 26.05.",
+            "Omni 30B is optional and disabled by default in 26.08.1.",
         )
         # Caption auto-wiring must stay off too, otherwise the service
         # would call a non-existent NIM Service.
@@ -464,7 +464,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
                 proc.stdout,
                 "Default helm template render must not contain a "
                 f"`{name}` resource — the VL reranker is optional and "
-                "disabled by default in 26.05 (the text-only SKU must "
+                "disabled by default in 26.08.1 (the text-only SKU must "
                 "never appear at all).",
             )
 
@@ -546,7 +546,7 @@ class OptionalNimsDefaultDisabledTests(TestCase):
             f"{_RERANK_TEXT_REPOSITORY}:",
             proc.stdout,
             "Rendered manifest must not reference the text-only rerank "
-            "repository — that is the bug the 26.05 fix exists to "
+            "repository — that is the bug the 26.08.1 fix exists to "
             "prevent.",
         )
         self.assertIn(

--- a/nemo_retriever/tests/test_helm_rerank_endpoint.py
+++ b/nemo_retriever/tests/test_helm_rerank_endpoint.py
@@ -4,7 +4,7 @@
 
 """Regression tests for VL reranker endpoint auto-wiring.
 
-In 26.08 RC2 the chart could deploy the VL reranker as a NIMService and
+In 26.08.1 the chart could deploy the VL reranker as a NIMService and
 accept ``serviceConfig.nimEndpoints.rerankInvokeUrl`` /
 ``rerankModelName``, but ``templates/configmap.yaml`` never rendered
 ``nim_endpoints.rerank_invoke_url`` / ``rerank_model_name``. Split-mode

--- a/nemo_retriever/tests/test_helm_service_openapi_version.py
+++ b/nemo_retriever/tests/test_helm_service_openapi_version.py
@@ -68,7 +68,7 @@ class TestHelmServiceOpenApiVersion(TestCase):
                 "--set",
                 "topology.mode=standalone",
                 "--set",
-                "service.image.tag=26.08-RC4",
+                "service.image.tag=26.08.1",
             )
         )
         self.assertEqual(
@@ -79,7 +79,7 @@ class TestHelmServiceOpenApiVersion(TestCase):
         docs = list(yaml.safe_load_all(proc.stdout))
         containers = _nemo_retriever_containers(docs)
         self.assertEqual(len(containers), 1)
-        self.assertEqual(_env_value(containers[0], "RETRIEVER_SERVICE_VERSION"), "26.08-RC4")
+        self.assertEqual(_env_value(containers[0], "RETRIEVER_SERVICE_VERSION"), "26.08.1")
 
     def test_split_injects_image_tag_on_gateway_and_workers(self) -> None:
         proc = _helm_template(
@@ -87,7 +87,7 @@ class TestHelmServiceOpenApiVersion(TestCase):
                 "--set",
                 "topology.mode=split",
                 "--set",
-                "service.image.tag=26.08-RC4",
+                "service.image.tag=26.08.1",
             )
         )
         self.assertEqual(
@@ -99,7 +99,7 @@ class TestHelmServiceOpenApiVersion(TestCase):
         containers = _nemo_retriever_containers(docs)
         self.assertGreaterEqual(len(containers), 2)
         for container in containers:
-            self.assertEqual(_env_value(container, "RETRIEVER_SERVICE_VERSION"), "26.08-RC4")
+            self.assertEqual(_env_value(container, "RETRIEVER_SERVICE_VERSION"), "26.08.1")
 
 
 if __name__ == "__main__":

--- a/nemo_retriever/tests/test_pipeline_image_caption_concurrency.py
+++ b/nemo_retriever/tests/test_pipeline_image_caption_concurrency.py
@@ -4,7 +4,7 @@
 
 """Regression tests pinning the ``image_caption`` stage's concurrency.
 
-Customer-reported head-of-line block (26.05):
+Customer-reported head-of-line block (26.08.1):
 
     Client A ingests a small text-only PDF (``--task=extract:{...}``,
     no caption work).  On its own A finishes in ~0.45 s.

--- a/nemo_retriever/tests/test_service_client_compat.py
+++ b/nemo_retriever/tests/test_service_client_compat.py
@@ -4,7 +4,7 @@
 
 """Regression tests for SDK/service version-mismatch handling.
 
-These tests pin the customer-facing failure mode reported in 26.05-RC2:
+These tests pin the customer-facing failure mode reported in 26.08.1:
 a Python SDK wheel whose ``RetrieverServiceClient`` targets the new
 job-scoped ingest API (``POST /v1/ingest/job`` +
 ``POST /v1/ingest/job/{job_id}/document`` +
@@ -140,7 +140,7 @@ def test_compat_error_message_clips_long_body() -> None:
 def test_create_job_raises_compat_error_for_404_and_410(status: int) -> None:
     """The very first SDK call ⇒ clear compat error, not silent empty result.
 
-    Reproduces the 26.05-RC2 customer scenario: ``POST /v1/ingest/job``
+    Reproduces the 26.08.1 customer scenario: ``POST /v1/ingest/job``
     on a service image that does not advertise that route. Before this
     fix the client surfaced a generic ``httpx.HTTPStatusError`` (which
     callers often catch+log+continue), so the documented service-mode
@@ -154,7 +154,7 @@ def test_create_job_raises_compat_error_for_404_and_410(status: int) -> None:
         if status == 410:
             return httpx.Response(
                 410,
-                json={"detail": "POST /v1/ingest was removed in 26.05"},
+                json={"detail": "POST /v1/ingest was removed in 26.08.1"},
             )
         return httpx.Response(404)
 
@@ -402,7 +402,7 @@ def test_upload_one_410_surfaces_replacement_routes(tmp_path: Path) -> None:
     def _handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             410,
-            json={"detail": "POST /v1/ingest was removed in 26.05"},
+            json={"detail": "POST /v1/ingest was removed in 26.08.1"},
         )
 
     rc = RetrieverServiceClient(base_url="http://nrl:7670")

--- a/nemo_retriever/tests/test_service_ingestor_compat.py
+++ b/nemo_retriever/tests/test_service_ingestor_compat.py
@@ -2,11 +2,11 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""End-to-end regression test for the 26.05-RC2 version-mismatch bug.
+"""End-to-end regression test for the 26.08.1 version-mismatch bug.
 
 The customer-reported failure mode:
 
-    The published 26.05-RC2 Python SDK calls legacy ``/v1/ingest`` /
+    The published 26.08.1 Python SDK calls legacy ``/v1/ingest`` /
     ``/v1/ingest/events`` routes against an nrl-service image that
     expects the newer job-scoped API. The documented service-mode flow
     appears to run but returns an empty result with no successful
@@ -72,7 +72,7 @@ def _install_mock_transport(monkeypatch: pytest.MonkeyPatch, handler) -> None:
 def test_service_ingestor_ingest_surfaces_compat_error_on_404(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """Customer entry point: ``ServiceIngestor.ingest()`` must raise, not return empty.
 
-    This pins the exact end-to-end behavior that 26.05-RC2 customers
+    This pins the exact end-to-end behavior that 26.08.1 customers
     expected.  Before the fix the documented flow produced an empty
     :class:`ServiceIngestResult` with ``len(result) == 0`` and no
     actionable error.  After the fix:
@@ -112,7 +112,7 @@ def test_service_ingestor_ingest_surfaces_compat_error_on_404(monkeypatch: pytes
 def test_service_ingestor_ingest_surfaces_compat_error_on_410(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """An explicit ``410 Gone`` from a new service raises the same error.
 
-    The mirror-image case: the SDK is the older 26.05-RC2 build, but
+    The mirror-image case: the SDK is the older 26.08.1 build, but
     the deployed service ships the 410 stub that explains the legacy
     route is gone.  Our new SDK targets the new route, so the 410 is
     delivered to the new client too — and it must still produce the
@@ -124,7 +124,7 @@ def test_service_ingestor_ingest_surfaces_compat_error_on_410(monkeypatch: pytes
         return httpx.Response(
             410,
             json={
-                "detail": ("POST /v1/ingest was removed in retriever-service 26.05"),
+                "detail": ("POST /v1/ingest was removed in retriever-service 26.08.1"),
             },
         )
 

--- a/nemo_retriever/tests/test_service_openapi_version.py
+++ b/nemo_retriever/tests/test_service_openapi_version.py
@@ -21,17 +21,17 @@ def test_openapi_version_matches_service_api_version() -> None:
         schema = client.get("/openapi.json").json()
 
     assert schema["info"]["version"] == get_service_api_version()
-    assert schema["info"]["version"] != "26.5.0"
+    assert schema["info"]["version"] != "26.8.1"
 
 
 def test_openapi_version_respects_service_version_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("RETRIEVER_SERVICE_VERSION", "26.08-RC4")
+    monkeypatch.setenv("RETRIEVER_SERVICE_VERSION", "26.08.1")
     app = create_app(ServiceConfig(mode="gateway"))
 
     with TestClient(app) as client:
         schema = client.get("/openapi.json").json()
 
-    assert schema["info"]["version"] == "26.08-RC4"
-    assert get_service_api_version() == "26.08-RC4"
+    assert schema["info"]["version"] == "26.08.1"
+    assert get_service_api_version() == "26.08.1"

--- a/nemo_retriever/tests/test_service_sse.py
+++ b/nemo_retriever/tests/test_service_sse.py
@@ -124,7 +124,7 @@ def test_legacy_ingest_upload_route_returns_410_with_migration_body(
     Older SDK builds upload through this path.  Without an explicit
     handler FastAPI returns a body-less 404 and the SDK surfaces an
     empty result — the customer-facing regression captured in the
-    26.05-RC2 release-integration report.  The 410 body must name the
+    26.08.1 release-integration report.  The 410 body must name the
     replacement pair (``/v1/ingest/job`` + ``/v1/ingest/job/{job_id}/document``).
     """
     # Body is intentionally empty — the route should reject the request


### PR DESCRIPTION
## Description
Completed the PR #2574-equivalent release update for 26.08.1.

  - Updated active release references to 26.08.1; Helm Chart.yaml and service.image.tag use the prior format: 26.8.1.
  - Renamed the managed Helm example to managed-helm-nrl-26.08.1.yaml.
  - Retained the single 26.05 reference only as the intentional historical link to the prior release notes.
  - Validation passed: 88 targeted tests, Helm lint, Ruff, whitespace check, and all pre-commit hooks.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
