### PR TITLE
ci(docs): publish 26.8.1 docs.nvidia.com from main

### DIFF
--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -14,8 +14,9 @@
 #   index.html, versions.json, latest/, <version>/ (e.g. 26.8.1/)
 #
 # 26.08.1 current-docs model:
-#   - Build content from main (docs + library used by mkdocstrings).
-#   - Publish folder label is 26.8.1; versions.json on main owns the "latest" alias.
+#   - Build content from the workflow commit (dispatch from main after this
+#     merges, or from this branch for a one-shot cutover).
+#   - Publish folder label is 26.8.1; versions.json on that commit owns latest.
 #
 # Manual publish only (workflow_dispatch). Do not re-enable push/tag auto-publish
 # until that is an explicit operator decision.
@@ -130,11 +131,13 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the current 26.08.1 docs from main under the 26.8.1 label.
-      - name: Checkout main docs content
+      # Publish the triggering commit under the 26.8.1 label. Use github.sha so a
+      # delayed run cannot publish a newer tip, and a dispatch from this branch
+      # includes the versions.json picker on the same commit.
+      - name: Checkout docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Resolve publish inputs
         id: publish
         env:
+          EVENT_NAME: ${{ github.event_name }}
           DISPATCH_DRY_RUN: ${{ inputs.dry-run }}
           VERSION_INPUT: ${{ inputs.docs-version-override }}
           PUBLISH_LATEST_INPUT: ${{ inputs.publish-as-latest }}
@@ -89,8 +90,17 @@ jobs:
           NRL_DOCS_PUBLISH_VERSION_VAR: ${{ vars.NRL_DOCS_PUBLISH_VERSION }}
           DOCS_RELEASE_EMAILS_VAR: ${{ vars.DOCS_RELEASE_EMAILS }}
         run: |
-          echo "dry_run=${DISPATCH_DRY_RUN}" >> "$GITHUB_OUTPUT"
-          echo "publish_latest=${PUBLISH_LATEST_INPUT}" >> "$GITHUB_OUTPUT"
+          # Fail closed: if a push/tag trigger is re-added, do not write S3/latest.
+          # Aug 19 26.08 leaked because a push event forced dry_run=false and
+          # publish_latest=true with no operator confirmation.
+          if [[ "${EVENT_NAME}" != "workflow_dispatch" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "publish_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Non-dispatch event ${EVENT_NAME}; forcing dry-run and not moving latest/."
+          else
+            echo "dry_run=${DISPATCH_DRY_RUN}" >> "$GITHUB_OUTPUT"
+            echo "publish_latest=${PUBLISH_LATEST_INPUT}" >> "$GITHUB_OUTPUT"
+          fi
 
           VERSION="${VERSION_INPUT}"
           if [[ -z "${VERSION}" ]]; then

--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -13,11 +13,15 @@
 # S3 layout written under developer/docs/nemo/retriever/:
 #   index.html, versions.json, latest/, <version>/ (e.g. 26.8.1/)
 #
+# 26.08.1 current-docs model:
+#   - Build content from main (docs + library used by mkdocstrings).
+#   - Publish folder label is 26.8.1; versions.json on main owns the "latest" alias.
+#
 # Manual publish only (workflow_dispatch). Do not re-enable push/tag auto-publish
-# while docs.nvidia.com 26.8.1 / latest are frozen to the 26.08.1 release docs.
+# until that is an explicit operator decision.
 #
 # Operator steps when ready to publish:
-#   1. Merge doc changes to the 26.08.1 branch (content source for the build).
+#   1. Merge doc changes to main (content source for the build).
 #   2. Keep docs/publish/versions.json on main accurate (version picker + latest alias).
 #   3. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
 #        dry-run: false
@@ -116,23 +120,11 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the doc pages from the 26.08.1 release branch, not main. main keeps
-      # moving toward the next release, so its docs must not be published under the
-      # 26.8.1 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.08.1.
-      - name: Checkout 26.08.1 docs content
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: "26.08.1"
-
-      # versions.json (the version picker + "latest" alias) is canonical on main and
-      # does not exist on 26.08.1, so fetch just that file from main into a side path.
-      - name: Checkout version-picker metadata from main
+      # Publish the current 26.08.1 docs from main under the 26.8.1 label.
+      - name: Checkout main docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
-          path: .docs-main-meta
-          sparse-checkout: docs/publish/versions.json
-          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -156,9 +148,9 @@ jobs:
 
       # MkDocs does not emit versions.json. publish-docs uploads the artifact copy to S3
       # (it does not merge with the live S3 file). versions.json is canonical on main.
-      - name: Stage version picker metadata for publish-docs
+      - name: Copy versions.json into site artifact
         run: |
-          cp .docs-main-meta/docs/publish/versions.json docs/site/versions.json
+          cp docs/publish/versions.json docs/site/versions.json
 
       - name: Upload docs.nvidia.com site artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -14,10 +14,10 @@
 #   index.html, versions.json, latest/, <version>/ (e.g. 26.8.1/)
 #
 # Manual publish only (workflow_dispatch). Do not re-enable push/tag auto-publish
-# while docs.nvidia.com 26.8.1 / latest are frozen to the 26.08 release docs.
+# while docs.nvidia.com 26.8.1 / latest are frozen to the 26.08.1 release docs.
 #
 # Operator steps when ready to publish:
-#   1. Merge doc changes to the 26.08 branch (content source for the build).
+#   1. Merge doc changes to the 26.08.1 branch (content source for the build).
 #   2. Keep docs/publish/versions.json on main accurate (version picker + latest alias).
 #   3. Actions → "NRL documentation — docs.nvidia.com publish" → Run workflow:
 #        dry-run: false
@@ -116,16 +116,16 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      # Publish the doc pages from the 26.08 release branch, not main. main keeps
+      # Publish the doc pages from the 26.08.1 release branch, not main. main keeps
       # moving toward the next release, so its docs must not be published under the
-      # 26.8.1 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.08.
-      - name: Checkout 26.08 docs content
+      # 26.8.1 label. mkdocs.yml, requirements.txt, and docs/docs/** come from 26.08.1.
+      - name: Checkout 26.08.1 docs content
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: "26.08"
+          ref: "26.08.1"
 
       # versions.json (the version picker + "latest" alias) is canonical on main and
-      # does not exist on 26.08, so fetch just that file from main into a side path.
+      # does not exist on 26.08.1, so fetch just that file from main into a side path.
       - name: Checkout version-picker metadata from main
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/docs/publish/versions.json
+++ b/docs/publish/versions.json
@@ -5,6 +5,11 @@
     "aliases": ["latest"]
   },
   {
+    "version": "26.5.0",
+    "title": "26.5.0",
+    "aliases": []
+  },
+  {
     "version": "26.3.0",
     "title": "26.3.0",
     "aliases": []


### PR DESCRIPTION
## Summary
- Build docs.nvidia.com content from `main` and publish as `26.8.1` / `latest`.
- Fail closed: non-`workflow_dispatch` events cannot write S3 or move `latest/` (the Aug 19 leak).
- Keep `26.5.0` and `26.3.0` in the version picker.

## Test plan
- [x] PR checks green
- [ ] Merge this PR before the live publish (`main` still checks out tag `26.08`)
- [ ] Dry-run, then live `workflow_dispatch` with version `26.8.1` and `publish-as-latest: true`