### PR TITLE
Warn on query embedding model mismatch

### DIFF
--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -102,6 +102,7 @@ The following sections summarize user-visible changes included in 26.08.1 and fo
 
 - True LanceDB hybrid retrieval.
 - LanceDB retrieval-mode autodetection and persisted embedding identity for automatic local queries.
+- Local queries warn when an explicit embedding model differs from the model recorded on the LanceDB table. The query continues with the explicit override so intentional model overrides remain available.
 - Dense image-only VDB records are retained where applicable.
 - Scope-isolated collection and document lifecycle APIs (`/v1/collections`) support create, ingest, replace, query, and cleanup without exposing LanceDB table names.
 - Fixed an issue where concurrent ingests into one VectorDB pod could report success minutes before the rows were durable or queryable. Each write now commits its rows independently, and index maintenance runs in a separate serialized phase where concurrent writers share one coalesced rebuild. An index-readiness wait that expires logs a warning and leaves the committed rows queryable instead of failing the write. Refer to [LanceDB index creation fails during concurrent Helm ingestion](troubleshoot.md#lancedb-concurrent-index-creation).

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -203,9 +203,13 @@ retrieval, preserving retriever ranking order and truncating the final output to
 `--top-k`. Local and batch ingest record the canonical embedding model on the
 LanceDB table, and non-service query uses that model automatically. Use
 `--embed-model-name` only as an explicit override or when querying a legacy or
-third-party table without model metadata. Endpoint URLs and provider prefixes
-remain runtime configuration, so continue to pass `--embed-invoke-url` and
-`--embed-model-provider-prefix` when the selected model must be routed remotely.
+third-party table without model metadata. If the explicit model differs from
+the model recorded on the table, the query logs a warning that names both
+models and continues with the explicit override. Confirm that the models use a
+compatible vector space before you trust the relevance results. Endpoint URLs
+and provider prefixes remain runtime configuration, so continue to pass
+`--embed-invoke-url` and `--embed-model-provider-prefix` when the selected model
+must be routed remotely.
 For example, a table can store the canonical model
 `nvidia/llama-nemotron-embed-vl-1b-v2` while a LiteLLM-routed request uses
 `nvidia/nvidia/llama-nemotron-embed-vl-1b-v2`. The endpoint and routing prefix

--- a/nemo_retriever/src/nemo_retriever/graph/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/graph/retriever.py
@@ -451,10 +451,22 @@ class Retriever:
         explicit_model = self._embedding_model_from_kwargs(embed_kwargs) or self._embedding_model_from_kwargs(
             self.embed_kwargs
         )
-        if self.graph is None and explicit_model is None:
+        if self.graph is None:
             metadata_reader = RetrieveVdbOperator(**_coerce_vdb_init(self.vdb_kwargs))
             index_model = metadata_reader.get_index_metadata("embedding_model_name", **vdb_call_kwargs)
             index_revision = metadata_reader.get_index_metadata("embedding_model_revision", **vdb_call_kwargs)
+            if explicit_model and index_model:
+                resolved_explicit_model = resolve_embed_model(explicit_model)
+                resolved_index_model = resolve_embed_model(index_model)
+                if resolved_explicit_model != resolved_index_model:
+                    logger.warning(
+                        "The explicitly configured query embedding model %r differs from the model %r "
+                        "recorded on the index. Results may be unreliable because different embedding "
+                        "models can use incompatible vector spaces. Use the index model or rebuild the "
+                        "index with the query model. Continuing with the explicitly configured model.",
+                        resolved_explicit_model,
+                        resolved_index_model,
+                    )
 
         lancedb_mode = self._resolve_lancedb_query_mode(vdb_call_kwargs)
         for key in _QUERY_ROUTING_VDB_KWARGS:

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -61,6 +61,14 @@ def _install_mock_graph(monkeypatch: pytest.MonkeyPatch, hits: list[list[dict[st
 
 
 class TestQueriesGraphExecution:
+    @pytest.fixture(autouse=True)
+    def _mock_index_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        metadata_reader = MagicMock()
+        metadata_reader.get_index_metadata.return_value = None
+        monkeypatch.setattr(
+            "nemo_retriever.graph.retriever.RetrieveVdbOperator", MagicMock(return_value=metadata_reader)
+        )
+
     def test_empty_queries_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_get = MagicMock()
         monkeypatch.setattr(Retriever, "_get_graph", mock_get)
@@ -87,6 +95,58 @@ class TestQueriesGraphExecution:
         r = _make_retriever(embed_kwargs={"model_name": "base", "embed_model_name": "base"})
         p = r._merge_embed_params({"model_name": "call"})
         assert p.model_name == "call"
+
+    @pytest.mark.parametrize(
+        ("explicit_embed_kwargs", "query_embed_kwargs"),
+        [
+            ({"model_name": "acme/model-b", "embed_model_name": "acme/model-b"}, None),
+            ({}, {"model_name": "acme/model-b", "embed_model_name": "acme/model-b"}),
+        ],
+    )
+    def test_explicit_model_mismatch_warns_and_continues(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        explicit_embed_kwargs: dict[str, str],
+        query_embed_kwargs: dict[str, str] | None,
+    ) -> None:
+        graph = _install_mock_graph(monkeypatch, [[{"text": "retrieved"}]])
+        metadata_reader = MagicMock()
+        metadata_reader.get_index_metadata.side_effect = lambda key, **_kwargs: {
+            "embedding_model_name": "acme/model-a",
+            "embedding_model_revision": "a" * 40,
+        }.get(key)
+        reader_factory = MagicMock(return_value=metadata_reader)
+        monkeypatch.setattr("nemo_retriever.graph.retriever.RetrieveVdbOperator", reader_factory)
+        retriever = _make_retriever(embed_kwargs=explicit_embed_kwargs)
+
+        with caplog.at_level("WARNING", logger="nemo_retriever.graph.retriever"):
+            out = retriever.queries(["q"], embed_kwargs=query_embed_kwargs)
+
+        assert out == [[{"text": "retrieved"}]]
+        assert "query embedding model 'acme/model-b' differs" in caplog.text
+        assert "model 'acme/model-a' recorded on the index" in caplog.text
+        assert "Continuing with the explicitly configured model" in caplog.text
+        reader_factory.assert_called_once()
+        graph.execute_in_place.assert_called_once()
+
+    def test_explicit_model_matching_index_does_not_warn(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _install_mock_graph(monkeypatch, [[{"text": "retrieved"}]])
+        metadata_reader = MagicMock()
+        metadata_reader.get_index_metadata.side_effect = lambda key, **_kwargs: {
+            "embedding_model_name": "acme/model-a",
+        }.get(key)
+        monkeypatch.setattr(
+            "nemo_retriever.graph.retriever.RetrieveVdbOperator", MagicMock(return_value=metadata_reader)
+        )
+        retriever = _make_retriever(embed_kwargs={"model_name": "acme/model-a", "embed_model_name": "acme/model-a"})
+
+        with caplog.at_level("WARNING", logger="nemo_retriever.graph.retriever"):
+            retriever.queries(["q"])
+
+        assert not caplog.records
 
     def test_index_model_keeps_constructor_provider_prefix(self) -> None:
         retriever = _make_retriever(


### PR DESCRIPTION
## Summary
- read persisted embedding metadata even when a query model override is configured
- warn when the explicit query model differs from the model recorded on the index while continuing with the override
- add regression coverage for constructor and per-query overrides, plus matching-model behavior
- document the warning and compatibility risk

## Validation
- 50 passed: tests/test_retriever_queries.py
- 80 passed: query workflow, root query CLI, LanceDB capabilities, and LanceDB write policy tests
- 90 passed: tests/test_root_cli_workflow.py
- git diff --check