### PR TITLE
fix(parse): reject unsupported local models

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -52,7 +52,7 @@ silently select another extraction path.
 For local `nemotron_parse` extraction in NeMo Retriever Library 26.08, omit
 `nemotron_parse_model` to use the default model, or set it to
 `nvidia/NVIDIA-Nemotron-Parse-v1.2`. Other local model values, including
-`nvidia/NVIDIA-Nemotron-Parse-2.0`, raise `ValueError` before pipeline
+`nvidia/NVIDIA-Nemotron-Parse-2.0`, raise a Pydantic `ValidationError` before pipeline
 execution. To use a remote Nemotron Parse endpoint, configure
 `nemotron_parse_invoke_url` or `invoke_url` and select the model that matches
 the endpoint contract.

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -49,6 +49,14 @@ Any other value raises a Pydantic `ValidationError` before pipeline setup. The
 error lists the supported values, so spelling and configuration errors do not
 silently select another extraction path.
 
+For local `nemotron_parse` extraction in NeMo Retriever Library 26.08, omit
+`nemotron_parse_model` to use the default model, or set it to
+`nvidia/NVIDIA-Nemotron-Parse-v1.2`. Other local model values, including
+`nvidia/NVIDIA-Nemotron-Parse-2.0`, raise `ValueError` before pipeline
+execution. To use a remote Nemotron Parse endpoint, configure
+`nemotron_parse_invoke_url` or `invoke_url` and select the model that matches
+the endpoint contract.
+
 ### Choose raise or collect behavior
 
 For graph run modes, `error_policy="raise"` raises `GraphIngestionError` when

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -25,7 +25,10 @@ from pydantic import (
 )
 
 from nemo_retriever.common.modality.caption.model_profiles import DEFAULT_LOCAL_CAPTION_MODEL_ID
-from nemo_retriever.common.params.utils import validate_nemotron_parse_endpoint_list
+from nemo_retriever.common.params.utils import (
+    NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL,
+    validate_nemotron_parse_endpoint_list,
+)
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 
 IngestorRunMode = Literal["inprocess", "batch", "service"]
@@ -583,7 +586,17 @@ class ExtractParams(_ParamsModel):
                 "`method='nemotron_parse'`; Parse-specific configuration is otherwise ignored."
             )
         if self.method == "nemotron_parse":
-            validate_nemotron_parse_endpoint_list(self.nemotron_parse_invoke_url or self.invoke_url)
+            parse_endpoints = validate_nemotron_parse_endpoint_list(self.nemotron_parse_invoke_url or self.invoke_url)
+            if (
+                not parse_endpoints
+                and self.nemotron_parse_model is not None
+                and self.nemotron_parse_model != NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL
+            ):
+                raise ValueError(
+                    f"Local Nemotron Parse supports only `{NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL}` in this release; "
+                    f"received `{self.nemotron_parse_model}`. Configure `nemotron_parse_invoke_url` or `invoke_url` "
+                    "to use a compatible remote model."
+                )
         if not self.use_page_elements:
             consumers = [("use_table_structure", self.use_table_structure and self.extract_tables)]
             enabled = [name for name, on in consumers if on]

--- a/nemo_retriever/src/nemo_retriever/common/params/utils.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/utils.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from nemo_retriever.common.params.models import BatchTuningParams
 
 
+NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL = "nvidia/NVIDIA-Nemotron-Parse-v1.2"
+
+
 def validate_nemotron_parse_endpoint_list(invoke_url: str | None) -> tuple[str, ...]:
     """Normalize Parse endpoints and reject mixed NVIDIA Build/self-hosted lists."""
     invoke_urls = tuple(part.strip() for part in str(invoke_url or "").split(",") if part.strip())

--- a/nemo_retriever/tests/test_params_models.py
+++ b/nemo_retriever/tests/test_params_models.py
@@ -54,6 +54,28 @@ class TestExtractParams:
         )
         assert params.method == "nemotron_parse"
 
+    @pytest.mark.parametrize("endpoint_field", ["nemotron_parse_invoke_url", "invoke_url"])
+    def test_remote_parse_model_is_accepted(self, endpoint_field: str) -> None:
+        params = ExtractParams(
+            method="nemotron_parse",
+            nemotron_parse_model="nvidia/NVIDIA-Nemotron-Parse-2.0",
+            **{endpoint_field: "http://parse:8000/v1/chat/completions"},
+        )
+
+        assert params.nemotron_parse_model == "nvidia/NVIDIA-Nemotron-Parse-2.0"
+
+    def test_unsupported_local_parse_model_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Local Nemotron Parse supports only") as exc_info:
+            ExtractParams(
+                method="nemotron_parse",
+                nemotron_parse_model="nvidia/NVIDIA-Nemotron-Parse-2.0",
+            )
+
+        error = str(exc_info.value)
+        assert "nvidia/NVIDIA-Nemotron-Parse-v1.2" in error
+        assert "nvidia/NVIDIA-Nemotron-Parse-2.0" in error
+        assert "nemotron_parse_invoke_url" in error
+
     @pytest.mark.parametrize(
         "model",
         [None, "nvidia/nemotron-parse", "nvidia/nemotron-parse-v1.2"],


### PR DESCRIPTION
## Summary

- reject unsupported local Nemotron Parse model IDs during ExtractParams validation
- keep explicitly configured remote Parse model contracts available
- document that NeMo Retriever 26.08 supports NVIDIA-Nemotron-Parse-v1.2 for local extraction

This prevents a Parse 2.0 request from being silently ignored while the local actor loads Parse v1.2.

## Validation

- pre-commit run --all-files
- 27 focused parameter and local Parse tests passed
- git diff --check