### PR TITLE
docs(extraction): state Helm OCR v2 as the 26.08.1 default (NVBug 6620878)

### DIFF
--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -12,7 +12,7 @@ The following sections summarize user-visible changes included in 26.08.1 and fo
 
 ### Upgrade notes { #upgrade-notes }
 
-- Nemotron OCR v2 is now the default OCR engine for local Hugging Face, hosted CPU actors, and Helm NIM deployments. The previous release kept Helm on OCR v1. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`.
+- Nemotron OCR v2 is now the default OCR engine for local Hugging Face and hosted CPU actors. For Helm NIM deployments, Nemotron OCR v2 is the default. The previous release kept Helm on OCR v1. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) for the chart image repository and tag.
 - Helm replaces separate page-elements and table-structure NIMs with the combined `nemotron-object-detection:2.0.1` image. Development Compose uses the same combined object-detection image and OCR v2, but still defaults to `2.0.0` tags unless you override `NIM_*_TAG`.
 - Helm default VL embed and VL rerank NIM images bump to `2.3.0`. The previous release used `1.12.0` and `1.11.0`. Development Compose still defaults to `1.12.0` and `1.11.0` unless you override `NIM_EMBED_TAG` and `NIM_RERANK_TAG`.
 - Default VLM image captioning is Nemotron 3 Nano Omni for local and hosted paths. Chart-classified PDF regions remain on the layout and OCR path.
@@ -45,10 +45,11 @@ The following sections summarize user-visible changes included in 26.08.1 and fo
 
 ### Models, OCR, and NIM artifacts { #models-ocr-and-captioning }
 
-- Nemotron OCR v2 is unified across library, hosted, and Helm defaults. The Helm default image is `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration).
+- Nemotron OCR v2 is unified across library, hosted, and Helm defaults. Hosted OCR uses its own language behavior. Refer to [Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims) and [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration) for the chart image.
 - Local OCR crop batching runs across page rows for throughput. Helm extraction NIMs (OCR and object detection) enable performance mode by default. The VL embed NIM does not.
 - 26.08.1 Helm default and optional NIM images that affect mirroring, allowlisting, and troubleshooting include the following:
     - Combined object detection for page elements and table structure: `nvcr.io/nim/nvidia/nemotron-object-detection:2.0.1`
+    - Image OCR: `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`
     - VL embedding: `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:2.3.0`
     - VL reranking (optional): `nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0`
     - Optional Omni caption and configurable answer VLM: `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:2.0.4-variant`


### PR DESCRIPTION
## Summary
- Makes the 26.08.1 release notes Helm clause match the chart: **For Helm NIM deployments, Nemotron OCR v2 is the default.**
- Adds the default OCR image `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1` to the mirroring and allowlisting list. Exact repository and tag remain owned by the support matrix and `nemo_retriever/helm/values.yaml`.
- Related: NVBug 6628502 / PR #2548 already replaced the RC4 `OCR v1` sentence. This PR keeps that generation claim explicit for Helm and restores the OCR pin in the artifact list. Inverse historical mismatch: NVBug 6198662 (26.05 chart v1 vs docs v2).

## Test plan
- [ ] Search the Release Notes page for `For Helm NIM deployments, Nemotron OCR v2 is the default`.
- [ ] Confirm the mirroring list includes `nvcr.io/nim/nvidia/nemotron-ocr-v2:2.0.1`.
- [ ] Confirm [Default Helm NIMs](docs/docs/extraction/prerequisites-support-matrix.md#default-helm-nims) still lists that same image as enabled by default.
- [ ] Confirm `nimOperator.ocr` in `nemo_retriever/helm/values.yaml` is `enabled: true` with repository `nvcr.io/nim/nvidia/nemotron-ocr-v2` and tag `2.0.1`.

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** `docs/docs/extraction/releasenotes.md`

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — no `see [` CTAs on releasenotes.md; faq/overview/multimodal-extraction were not in this diff |
| Allowed paths | PASS — 1 documentation file |
| mkdocs --strict | PASS for this diff — no new warnings from releasenotes.md; exit 1 on untracked leftover pages `custom-metadata.md` and `user-defined-stages.md` that are not in this diff |
| ::a audit | PASS — Helm OCR default `nemotron-ocr-v2:2.0.1` matches `values.yaml` (`nimOperator.ocr.enabled: true`) and the support matrix; packaged DORI runtime missing, used canonical `validate_code_blocks` / `verify_docs` / `detect_drift` (pass, fresh) |
| ::p polish | Applied — Helm generation clause is explicit; exact image pin lives in the mirroring list and support matrix |
| ::r style | 95% — no blocking issues on the changed bullets |

**Code drift (not in this docs PR):** No runtime mismatch. A release-note vs chart default-generation contract check is still missing; that belongs in a separate eng/test PR, not this docs PR.

**PR:** this draft

Fixes NVBug 6620878.