### PR TITLE
fix(packaging): align PyPI OS classifiers with supported platforms (NVBug 6670718)

### DIFF
--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -7,8 +7,9 @@ managed = true
 package = true
 no-build-package = ["nemotron-ocr"]
 # The complete dependency graph, including `local`, must resolve on both Linux
-# architectures. Windows x64 and macOS x64/ARM64 support only the base install
-# and are validated separately by CI.
+# architectures. Windows x64 and macOS Apple Silicon (arm64) support only the
+# base install and are validated separately by CI. macOS Intel (x86_64) is not
+# supported.
 required-environments = [
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
   "sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -50,7 +51,11 @@ license-files = ["LICENSE"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
-  "Operating System :: OS Independent",
+  # Not OS Independent: macOS Intel (x86_64) is unsupported because Ray >=2.56.1
+  # has no Intel Mac wheels. Supported: Linux, Windows x64, macOS Apple Silicon.
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: MacOS",
 ]
 dependencies = [
   # Core orchestration and framework

--- a/nemo_retriever/tests/test_service_packaging.py
+++ b/nemo_retriever/tests/test_service_packaging.py
@@ -35,3 +35,13 @@ def test_core_dependencies_include_tokenizer_stack() -> None:
 
     assert "tokenizers" in names
     assert "huggingface-hub" in names
+
+
+def test_os_classifiers_match_supported_platforms() -> None:
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    classifiers = pyproject["project"]["classifiers"]
+
+    assert "Operating System :: OS Independent" not in classifiers
+    assert "Operating System :: POSIX :: Linux" in classifiers
+    assert "Operating System :: Microsoft :: Windows" in classifiers
+    assert "Operating System :: MacOS" in classifiers


### PR DESCRIPTION
## Summary
- NVBug 6670718 is a packaging metadata issue, not a docs change. Published `nemo-retriever` 26.8.1 declares `Operating System :: OS Independent` on PyPI.
- That classifier is too broad: the package does not support macOS Intel (x86_64), because `ray[data,serve]>=2.56.1` has no macOS x86_64 wheel.
- Replace `OS Independent` with Linux, Windows, and macOS classifiers so the next package publish matches the supported-platform policy. Trove classifiers cannot distinguish Apple Silicon from Intel Mac.
- Add a packaging regression test so `OS Independent` cannot return unnoticed.
- The already-published 26.8.1 artifacts on PyPI stay unchanged until the next version is uploaded.

## Test plan
- [x] `uv run --no-project --with pytest --with packaging pytest tests/test_service_packaging.py` (3 passed)
- [ ] After the next PyPI publish, confirm https://pypi.org/pypi/nemo-retriever/json classifiers no longer include `Operating System :: OS Independent`

## PR scope check
- **Base:** upstream/main
- **Commits:** 1 — `fix(packaging): align PyPI OS classifiers with supported platforms`
- **Files changed:** `nemo_retriever/pyproject.toml`, `nemo_retriever/tests/test_service_packaging.py`
- **Red flags:** none