### PR TITLE
docs(readme): omit --embed-model-name in agentic examples (NVBug 6622437)

### DIFF
--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -355,6 +355,8 @@ Cat is the animal whose activity (jumping onto a laptop) matches the location of
 Agentic retrieval runs an LLM-driven ReAct loop over an existing LanceDB index.
 It does not ingest documents. Build the index with one of the ingestion flows
 above, then query the same `lancedb_uri`, `table_name`, and embedding model.
+When you omit `--embed-model-name`, agentic retrieval uses the selected
+table's model.
 
 By default, the agent LLM runs in process with local vLLM and `nemotron-8b`
 (`nvidia/Llama-3.1-Nemotron-Nano-8B-v1`). This requires a CUDA GPU host and the
@@ -373,8 +375,7 @@ GPUs (for example `CUDA_VISIBLE_DEVICES=0,1`).
 CUDA_VISIBLE_DEVICES=0 retriever query "Given their activities, which animal is responsible for the typos in my documents?" \
   --agentic \
   --lancedb-uri lancedb \
-  --table-name nemo-retriever \
-  --embed-model-name nvidia/llama-nemotron-embed-1b-v2
+  --table-name nemo-retriever
 ```
 
 ```bash
@@ -383,8 +384,7 @@ CUDA_VISIBLE_DEVICES=0,1 retriever query "Given their activities, which animal i
   --agentic-llm-model super-49b \
   --agentic-local-tensor-parallel-size 2 \
   --lancedb-uri lancedb \
-  --table-name nemo-retriever \
-  --embed-model-name nvidia/llama-nemotron-embed-vl-1b-v2
+  --table-name nemo-retriever
 ```
 
 When the first ``tensor_parallel_size`` CUDA-visible GPUs are not
@@ -406,8 +406,7 @@ retriever query "What is RAG?" \
   --agentic-llm-model nvidia/llama-3.3-nemotron-super-49b-v1.5 \
   --agentic-invoke-url http://localhost:9000/v1/chat/completions \
   --lancedb-uri lancedb \
-  --table-name nemo-retriever \
-  --embed-model-name nvidia/llama-nemotron-embed-1b-v2
+  --table-name nemo-retriever
 ```
 
 The Helm `answer_llm` Super-49B NIM is not tool-call ready by default.
@@ -430,20 +429,19 @@ CUDA_VISIBLE_DEVICES=0 retriever query "What is RAG?" \
   --agentic \
   --lancedb-uri lancedb \
   --table-name nemo-retriever \
-  --embed-model-name nvidia/llama-nemotron-embed-1b-v2 \
   --top-k 1 \
   --agentic-react-max-steps 1
 ```
 
 You can run the same flow from Python. Omit `invoke_url` for the default local
 in-process vLLM backend, or pass `invoke_url` on `QueryAgenticOptions` for a
-separate OpenAI-compatible chat-completions endpoint.
+separate OpenAI-compatible chat-completions endpoint. Omit `embed_model_name`
+so the query reuses the table's recorded model.
 
 ```python
 from nemo_retriever.cli.query_workflow import agentic_query_documents
 from nemo_retriever.query.options import (
     QueryAgenticOptions,
-    QueryEmbedOptions,
     QueryRequest,
     QueryRetrievalOptions,
     QueryStorageOptions,
@@ -458,9 +456,6 @@ results = agentic_query_documents(
         storage=QueryStorageOptions(
             lancedb_uri="lancedb",
             table_name="nemo-retriever",
-        ),
-        embed=QueryEmbedOptions(
-            embed_model_name="nvidia/llama-nemotron-embed-1b-v2",
         ),
         agentic=QueryAgenticOptions(
             enabled=True,


### PR DESCRIPTION
## Summary
- Remove `--embed-model-name` from all five agentic README samples so they demonstrate the documented LanceDB model-reuse contract.
- State that omitting the flag (and omitting `embed_model_name` in Python) reuses the table's recorded model. This matches the CLI help and `docs/cli/README.md` agentic examples.
- Leave hosted ingest and remote `Retriever` recipes on `nvidia/llama-nemotron-embed-1b-v2`. Those examples already pass the matching `--embed-invoke-url` / `embedding_endpoint`.

Fixes NVBug 6622437.

This supersedes draft https://github.com/NVIDIA/NeMo-Retriever/pull/2597, which pinned the VL model instead of omitting the override.

## Test plan
- [x] `git diff --name-only upstream/main..HEAD` is only `nemo_retriever/README.md`
- [x] Agentic CLI samples omit `--embed-model-name`
- [x] Python sample omits `QueryEmbedOptions` / `embed_model_name`
- [x] Hosted ingest and remote query recipes still pin the remote-lane model with its invoke URL
- [ ] Copy-paste: default local ingest, then an agentic example from this README (no embed-model flag)

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** `nemo_retriever/README.md`

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — no `see [` CTAs; `installFfmpeg` on README is pre-existing Helm guidance |
| Allowed paths | PASS — 1 documentation file |
| mkdocs --strict | PASS for this change — exit 1 is from untracked leftover pages (`custom-metadata.md`, `user-defined-stages.md`) that are not in this diff |
| ::a audit | PASS — omit flag uses table metadata then default (`Retriever._resolve_embed_kwargs`; `build_agentic_config` only sets `query_embedder` when `embed_model_name` is set; CLI help documents reuse). 15 code blocks checked, 0 issues. |
| ::p polish | Applied — second-person wording for omit-reuse; no structural rewrite of the README |
| ::r style | 95% — no blocking issues on the changed sentences. Pre-existing `smoke test` in the same section is unchanged. |

**Code drift (not in this docs PR):** none for this claim. The recommended e2e README-example assertion belongs in a separate eng PR.

**PR:** this draft