### PR TITLE
docs(extraction): complete LanceDB.run and retrieval example (NVBug 662232)

### DIFF
--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -7,6 +7,7 @@ Use this documentation to learn how [NeMo Retriever Library](overview.md) stores
 - [Overview](#overview)
 - [LanceDB Overview](#why-lancedb)
 - [Upload to LanceDB](#upload-to-lancedb)
+    - [Direct LanceDB ingest and retrieval](#direct-lancedb-ingest-and-retrieval)
 - [Semantic retrieval](#semantic-retrieval)
 - [Metadata and filtering](#metadata-and-filtering)
 - [LanceDB deployment characteristics](#lancedb-deployment-characteristics)
@@ -89,22 +90,69 @@ Use `--lancedb-uri` and `--table-name` on the local and batch commands when you 
 
 For URI, table name, and other parameters, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
-You can also construct a `LanceDB` instance and call `run` and `retrieval` directly:
+### Direct LanceDB ingest and retrieval { #direct-lancedb-ingest-and-retrieval }
+
+You can also construct a `LanceDB` instance and call `run` and `retrieval` directly. This is the optional low-level path. Prefer `.vdb_upload()` for typical ingest.
+
+Graph ingest returns a pandas `DataFrame` of flat rows. Use the following input shapes:
+
+- `LanceDB.run()` expects nested client record batches: a `list` of batches, and each batch is a `list` of record dictionaries. Convert graph or `DataFrame` rows with `to_client_vdb_records()` before you call `run()`.
+- `LanceDB.run()` does not accept the graph `DataFrame` or a flat `list` of dictionaries from `DataFrame.to_dict("records")`.
+- `LanceDB.retrieval()` takes precomputed query vectors. Pass a `list` of embedding vectors whose length matches `vector_dim`. For query strings, use [`Retriever.query`](nemo-retriever-api-reference.md).
+- `IngestVdbOperator` accepts the same flat `DataFrame` or graph rows. It converts them with `to_client_vdb_records()` and then calls `run()`.
+
+The following example uses a two-dimensional fixture so you can copy it without a GPU or embedding NIM:
+
+- Replace `graph_rows` with your `.ingest()` `DataFrame` when you already have embeddings.
+- Set `vector_dim` to your embedding length. The `LanceDB` default `vector_dim` is 2048.
+- The fixture sets `create_index=False` so the one-row table is written without building the default `IVF_HNSW_SQ` index. Default ingest builds that index.
+
+For the ingestion contract, refer to the [Vector DB operators and LanceDB README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.08.1/nemo_retriever/src/nemo_retriever/common/vdb/README.md#ingestvdboperator-ingestion).
+
+Copy this example to write one row and retrieve at least one hit.
 
 ```python
-from nemo_retriever.common.vdb.lancedb import LanceDB
+import pandas as pd
 
-vdb = LanceDB(
-    uri="./lancedb_data",    # Path to LanceDB database directory
-    table_name="nemo-retriever",  # Table name
-    index_type="IVF_HNSW_SQ",  # Index type (default)
+from nemo_retriever.common.vdb.lancedb import LanceDB
+from nemo_retriever.common.vdb.records import to_client_vdb_records
+from nemo_retriever.operators.vdb import IngestVdbOperator
+
+# Graph ingest rows after extract and embed. Substitute your .ingest() DataFrame.
+graph_rows = pd.DataFrame(
+    [
+        {
+            "text": "hello from graph",
+            "text_embeddings_1b_v2": {"embedding": [1.0, 0.0]},
+            "path": "graph.pdf",
+            "page_number": 2,
+            "metadata": {},
+        }
+    ]
 )
 
-# Ingest
-vdb.run(results)
+vdb = LanceDB(
+    uri="./lancedb_data",
+    table_name="nemo-retriever",
+    vector_dim=2,
+    create_index=False,
+)
 
-# Retrieve with precomputed query vectors
+records = to_client_vdb_records(graph_rows)
+vdb.run(records)
+
+queries = [[1.0, 0.0]]
 docs = vdb.retrieval(queries, top_k=10)
+
+operator = IngestVdbOperator(
+    vdb=LanceDB(
+        uri="./lancedb_data_operator",
+        table_name="nemo-retriever",
+        vector_dim=2,
+        create_index=False,
+    )
+)
+operator(graph_rows)
 ```
 
 Query ingested tables with `LanceDB.retrieval()` (precomputed vectors) or with [`Retriever.query`](nemo-retriever-api-reference.md) (embeds the query string for you). Optional `where` predicates and client-side filters are documented under [Metadata and filtering](#metadata-and-filtering).


### PR DESCRIPTION
## Summary
- Fixes NVBug 662232: the Vector Databases page advertised `LanceDB.run(results)` and `LanceDB.retrieval(queries)` without defining either input or the DataFrame-to-client-record adapter.
- The direct path now documents the nested `list[list[dict]]` ingest contract, converts graph/DataFrame rows with `to_client_vdb_records()`, defines precomputed query vectors, and shows `IngestVdbOperator` as the graph-row alternative.

## Test plan
- [x] Copied the documented example against `nemo_retriever/.venv`: `to_client_vdb_records` produced `list`/`list` shape 1x1; `LanceDB.run` wrote 1 row; `retrieval([[1.0, 0.0]], top_k=10)` returned 1 hit (`hello from graph`); `IngestVdbOperator` wrote 1 row.
- [x] `inspect.signature` confirms `LanceDB`, `to_client_vdb_records`, and `IngestVdbOperator` imports and `vector_dim` default 2048.
- [ ] `python -m mkdocs build --strict` on a clean tree (local strict failed on untracked leftover pages that are not in this PR).

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** docs/docs/extraction/vdbs.md

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS — `vdbs.md` has no `see [` CTAs. The leakage script vs `origin/main` also scanned stale/untracked leftovers (`custom-metadata.md`); those files are not in this PR. |
| Allowed paths | PASS — 1 documentation file (`docs/docs/extraction/vdbs.md`) |
| mkdocs --strict | PASS for this change — strict failed on untracked leftover pages (`custom-metadata.md`, `user-defined-stages.md`) that are not in this diff. |
| ::a audit | PASS — `LanceDB.run` expects nested client batches; `to_client_vdb_records` converts DataFrames; `IngestVdbOperator.process` adapts then calls `run()` (high confidence). Executed example: 1 row and 1 hit. |
| ::p polish | Applied — input shapes and fixture notes as lists; one copy-paste example that ingest+retrieves. |
| ::r style | 95% on the changed prose — no blocking issues. Surrounding page still has pre-existing em dashes that were left untouched. |

**Code drift (not in this docs PR):** `LanceDB.run()` still evaluates `records or []`, so a pandas DataFrame raises `ValueError` before conversion. Native DataFrame acceptance (or a contract error) would be an optional eng follow-up. No docs smoke test was added.

**PR:** this draft