### PR TITLE
docs(readme): call judge before score in Batch RAG examples (NVBug 6622193)

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -362,7 +362,7 @@ Service-only methods include `split()`, `pdf_split_config()`, `save_to_disk()`, 
 
 `Retriever.answer()` requires an `LLMClient` and returns `AnswerResult`. Pass an `AnswerJudge` only when you also pass `reference`. Those types are documented in [LLM clients, tasks, and results](#llm-clients-tasks-and-results).
 
-`Retriever.pipeline()` returns `RetrieverPipelineBuilder`. `generate()` accepts a `LiteLLMClient` instance or `model=` keyword arguments. `judge()` accepts an `LLMJudge` instance or `model=` keyword arguments.
+`Retriever.pipeline()` returns `RetrieverPipelineBuilder`. `generate()` accepts a `LiteLLMClient` instance or `model=` keyword arguments. `judge()` accepts an `LLMJudge` instance or `model=` keyword arguments. When you include both `.judge()` and `.score()`, call `.judge()` first. `.score()` derives `failure_mode` from the `judge_score` present at that step. A later `.judge()` does not recompute `failure_mode`.
 
 The package exports `nemo_retriever.retriever` as a default `Retriever()` instance. Construct `Retriever` directly when you need a configured object.
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -481,7 +481,7 @@ The pattern above -- retrieve hits, build a prompt, call an LLM -- is baked into
 | --- | --- | --- | --- |
 | `Retriever.retrieve(query, top_k=...)` | one query | `RetrievalResult` (`chunks`, `metadata`) | Structured retrieval without an LLM. |
 | `Retriever.answer(query, llm=..., judge=None, reference=None, ...)` | one query | `AnswerResult` (answer + chunks + optional scores) | One-shot RAG -- production/live. |
-| `Retriever.pipeline().generate(...).score().judge(...).run(queries)` | many queries | `pandas.DataFrame` | Batch RAG over the operator graph, each step optional. |
+| `Retriever.pipeline().generate(...).judge(...).score().run(queries)` | many queries | `pandas.DataFrame` | Batch RAG over the operator graph, each step optional. |
 
 Install the LLM client extra:
 ```bash
@@ -553,8 +553,8 @@ Batch RAG over the operator graph -- each builder step is optional:
 df = (
     retriever.pipeline()
     .generate(llm)
-    .score()
     .judge(judge)
+    .score()
     .run(
         queries=["What is RAG?", "What is reranking?"],
         reference=["RAG combines retrieval with generation.", "Reranking re-scores retrieved passages."],
@@ -563,12 +563,14 @@ df = (
 print(df[["query", "answer", "token_f1", "judge_score", "failure_mode"]])
 ```
 
+The pipeline builder runs steps in call order. `.score()` writes `failure_mode` from the `judge_score` present at that step. Call `.judge()` before `.score()` when you want `failure_mode` to reflect the judge result. If `.score()` runs first, a missing `judge_score` is classified as `judge_error`, and a later `.judge()` does not recompute `failure_mode`.
+
 Scoring tiers on `AnswerResult`:
 
 - **Tier 1** (`answer_in_context`) -- whether retrieval surfaced the evidence; requires `reference`.
 - **Tier 2** (`token_f1`, `exact_match`) -- token-level overlap; requires `reference`.
 - **Tier 3** (`judge_score`) -- dual-judge `AnswerAccuracy` LLM-as-judge score (0.0-1.0), ported from ragas onto `litellm`; requires `reference` and `judge`. `judge_reasoning` is always empty (the metric emits only a rating).
-- `failure_mode` -- derived classification (`correct`, `partial`, `retrieval_miss`, `generation_miss`, `refused_*`, `thinking_truncated`).
+- `failure_mode` -- derived classification (`correct`, `partial`, `retrieval_miss`, `generation_miss`, `refused_*`, `thinking_truncated`, `judge_error`).
 
 If only `reference` is supplied, Tier 1 + 2 run. If only `judge` is supplied (without `reference`), a `ValueError` is raised. On generation error, scoring and judge are skipped and `AnswerResult.error` is populated.
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -570,7 +570,7 @@ Scoring tiers on `AnswerResult`:
 - **Tier 1** (`answer_in_context`) -- whether retrieval surfaced the evidence; requires `reference`.
 - **Tier 2** (`token_f1`, `exact_match`) -- token-level overlap; requires `reference`.
 - **Tier 3** (`judge_score`) -- dual-judge `AnswerAccuracy` LLM-as-judge score (0.0-1.0), ported from ragas onto `litellm`; requires `reference` and `judge`. `judge_reasoning` is always empty (the metric emits only a rating).
-- `failure_mode` -- derived classification (`correct`, `partial`, `retrieval_miss`, `generation_miss`, `refused_*`, `thinking_truncated`, `judge_error`).
+- `failure_mode` -- derived classification (`correct`, `partial`, `retrieval_miss`, `generation_miss`, `generation_error`, `refused_*`, `thinking_truncated`, `judge_error`).
 
 If only `reference` is supplied, Tier 1 + 2 run. If only `judge` is supplied (without `reference`), a `ValueError` is raised. On generation error, scoring and judge are skipped and `AnswerResult.error` is populated.
 


### PR DESCRIPTION
## Summary

- NVBug 6622193: the Batch RAG README example called `.score()` before `.judge()`. The pipeline builder runs steps in call order, so scoring classified a missing `judge_score` as `failure_mode='judge_error'`. A later successful judge does not recompute that field.
- Reorder the README table and Batch RAG example to `.generate(llm).judge(judge).score()`. Document the call-order dependency on the README and on the API reference Retrieve section.
- Docs-only. Live RAG `Retriever.answer()` is unchanged: it classifies `failure_mode` after both scoring and judging complete.

## Test plan

- [x] Confirm `ScoringOperator` / `score_dataframe()` persist `failure_mode` from the `judge_score` present at that step (`scoring.py`).
- [x] Confirm `JudgingOperator.process()` adds judge fields and does not update `failure_mode` (`judging.py`).
- [x] Confirm `RetrieverPipelineBuilder` appends and executes steps in call order (`retriever.py`).
- [x] Confirm no remaining `.score().judge()` occurrences in `nemo_retriever/README.md`.
- [ ] Optional SDK follow-up (not in this PR): reorder or recompute `failure_mode` after `.judge()`, and add a regression test that a successful `judge_score` cannot coexist with `failure_mode='judge_error'`.

## pre-draft: leakage, mkdocs --strict, ::a, ::p, ::r on the diff vs main

**Base:** upstream/main
**Files:** `nemo_retriever/README.md`, `docs/docs/extraction/nemo-retriever-api-reference.md`

| Check | Result |
|-------|--------|
| Leakage (page roles + `see [` CTAs) | PASS for this diff — no `see [` CTAs; no `nimOperator` on faq/overview/multimodal. The leakage script vs `origin/main` also flagged untracked leftover `custom-metadata.md`, which is not in this PR. |
| Allowed paths | PASS — 2 documentation files |
| mkdocs --strict | PASS for this diff — exit 1 from untracked leftover pages (`custom-metadata.md`, `user-defined-stages.md`) that are not in this change |
| ::a audit | PASS — 4 claims vs `retriever.py`, `scoring.py`, `judging.py` (95%). Code-block validator pass on both files. |
| ::p polish | Applied — shortened the call-order note; listed `judge_error` among `failure_mode` values |
| ::r style | 95% — no blocking issues in the added sentences |

**Code drift (not in this docs PR):** `nemo_retriever/src/nemo_retriever/graph/retriever.py:632` docstring still shows `.generate(llm).score().judge(judge)`. `nemo_retriever/tests/test_live_rag.py:533` still uses that order (mocked operators; does not assert `failure_mode`). `JudgingOperator` still does not recompute `failure_mode`.

**PR:** this draft