### PR TITLE
feat(ci): publish multi-arch nrl-service images on release

### DIFF
--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build Docker image
         run: |
           docker buildx create --use
-          docker buildx build -f Dockerfile --platform linux/amd64 --push --target service --build-arg GIT_COMMIT=${GITHUB_SHA} --build-arg DOWNLOAD_DEFAULT_TOKENIZER=True --secret id=hf_token,src=./scripts/private_local/hf_token.txt -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ env.SHORT_BRANCH_NAME }} .
+          docker buildx build -f Dockerfile --platform linux/amd64,linux/arm64 --push --target service --build-arg GIT_COMMIT=${GITHUB_SHA} --build-arg DOWNLOAD_DEFAULT_TOKENIZER=True --secret id=hf_token,src=./scripts/private_local/hf_token.txt -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ env.SHORT_BRANCH_NAME }} .
 
       - name: Cleanup HF token file
         if: always()

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -278,7 +278,6 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           tags: ${{ needs.nvingest-docker-build.outputs.image }}
           secret-files: hf_token=./scripts/private_local/hf_token.txt
-          cache-to: type=gha,scope=nvingest-release,mode=max
           cache-from: type=gha,scope=nvingest-release
 
       - name: Inspect published image

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -123,6 +123,9 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: ./.github/actions/setup-docker-buildx
+        with:
+          use-qemu: 'true'
+          platforms: 'linux/amd64,linux/arm64'
 
       - name: Set image metadata
         id: meta
@@ -144,34 +147,27 @@ jobs:
             printf '%s' "${HF_ACCESS_TOKEN}" > ./scripts/private_local/hf_token.txt
           fi
 
-      - name: Build image (validate)
+      # Multi-platform images cannot be docker-saved/loaded. Build both
+      # architectures into GHA cache here; the publish job rebuilds from that
+      # cache and pushes a manifest list only after every artifact validates.
+      - name: Build image (validate, do not push)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: false
-          load: true
           target: service
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
           build-args: |
             DOWNLOAD_DEFAULT_TOKENIZER=True
             GIT_COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.image }}
           secret-files: hf_token=./scripts/private_local/hf_token.txt
-          cache-to: type=gha,scope=nvingest,mode=max
-          cache-from: type=gha,scope=nvingest
-
-      - name: Export Docker image
-        run: |
-          docker save "${{ steps.meta.outputs.image }}" | gzip -1 > nrl-service-docker-image.tar.gz
-          ls -lh nrl-service-docker-image.tar.gz
-
-      - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v5
-        with:
-          name: nrl-service-docker-image
-          path: nrl-service-docker-image.tar.gz
-          if-no-files-found: error
+          cache-to: type=gha,scope=nvingest-release,mode=max
+          cache-from: type=gha,scope=nvingest-release
+          outputs: type=cacheonly
 
   helm-build:
     name: Build Helm Chart
@@ -247,30 +243,50 @@ jobs:
         with:
           ref: ${{ needs.determine-version.outputs.source-ref }}
 
+      - name: Setup Docker Buildx
+        uses: ./.github/actions/setup-docker-buildx
+        with:
+          use-qemu: 'true'
+          platforms: 'linux/amd64,linux/arm64'
+
       - name: Login to NGC
         uses: ./.github/actions/docker-login-ngc
         with:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Download Docker image artifact
-        uses: actions/download-artifact@v5
-        with:
-          name: nrl-service-docker-image
+      - name: Create HF token file
+        env:
+          HF_ACCESS_TOKEN: ${{ secrets.HF_ACCESS_TOKEN }}
+        run: |
+          mkdir -p ./scripts/private_local
+          if [ -n "${HF_ACCESS_TOKEN}" ]; then
+            printf '%s' "${HF_ACCESS_TOKEN}" > ./scripts/private_local/hf_token.txt
+          fi
 
-      - name: Load and push image
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          target: service
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
+          build-args: |
+            DOWNLOAD_DEFAULT_TOKENIZER=True
+            GIT_COMMIT=${{ github.sha }}
+          tags: ${{ needs.nvingest-docker-build.outputs.image }}
+          secret-files: hf_token=./scripts/private_local/hf_token.txt
+          cache-to: type=gha,scope=nvingest-release,mode=max
+          cache-from: type=gha,scope=nvingest-release
+
+      - name: Inspect published image
         id: push
         run: |
-          echo "Loading image from tarball..."
-          LOAD_OUTPUT=$(gunzip -c nrl-service-docker-image.tar.gz | docker load)
-          echo "$LOAD_OUTPUT"
-          IMAGE=$(echo "$LOAD_OUTPUT" | sed -n 's/^Loaded image: //p')
-          if [ -z "$IMAGE" ]; then
-            echo "::error::Failed to parse image name from docker load output"
-            exit 1
-          fi
-          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "Pushing ${IMAGE}..."
-          docker push "${IMAGE}"
+          IMAGE="${{ needs.nvingest-docker-build.outputs.image }}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          docker buildx imagetools inspect "$IMAGE"
 
   helm-publish:
     name: Publish Helm Chart
@@ -459,7 +475,7 @@ jobs:
           elif [ "$DRY_RUN" = "true" ]; then
             MSG+="\n$(status_emoji "$NVINGEST_BUILD_RESULT") *nv-ingest Docker* — Built and validated (not pushed)"
           elif [ "$NVINGEST_PUBLISH_RESULT" = "success" ]; then
-            MSG+="\n:white_check_mark: *nv-ingest Docker* — \`${NVINGEST_IMAGE}\`"
+            MSG+="\n:white_check_mark: *nv-ingest Docker* — \`${NVINGEST_IMAGE}\` (linux/amd64, linux/arm64)"
             MSG+="\n    \`\`\`docker pull ${NVINGEST_IMAGE}\`\`\`"
           elif [ "$NVINGEST_BUILD_RESULT" != "success" ]; then
             MSG+="\n$(status_emoji "$NVINGEST_BUILD_RESULT") *nv-ingest Docker* — Build: ${NVINGEST_BUILD_RESULT}"

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -11,6 +11,7 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 ## Software Requirements { #software-requirements }
 
 - Linux operating systems (Ubuntu 22.04 or later recommended) for supported local GPU inference. For remote NIM inference, the base package can also be installed on Windows x64 and macOS Apple Silicon (arm64); local GPU inference is not supported on those platforms. macOS Intel (x86_64) is not supported: package installation fails because Ray `>=2.56.1` has no Intel Mac wheels (including in-process library mode).
+- Release builds of the `nrl-service` container image are a multi-architecture manifest for `linux/amd64` and `linux/arm64`. `docker pull` selects the architecture that matches the host. Local GPU inference in that image still requires Linux with a supported NVIDIA GPU and driver.
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (local GPU inference only; NVIDIA Driver >= `580`, CUDA >= `13.0`)
 - [Python](https://www.python.org/downloads/) `3.12` — required to install and run the NeMo Retriever Library Python API, CLI, and related packages from PyPI (for example `pip` or `uv`). Older Python versions will fail dependency resolution without a clear error.
 - [UV Python package and environment manager](https://docs.astral.sh/uv/getting-started/installation/) (optional; recommended for creating isolated environments)

--- a/nemo_retriever/docker.md
+++ b/nemo_retriever/docker.md
@@ -2,6 +2,8 @@
 
 This page covers the standalone Docker image for the NeMo Retriever service. For production-scale service and NIM deployment, use the Helm chart in [`helm/README.md`](helm/README.md) and the published NeMo Retriever Library install procedures.
 
+Release-published `nrl-service` tags are multi-architecture images for `linux/amd64` and `linux/arm64`. `docker pull` selects the variant that matches the host. A local `docker build` without `--platform` produces the architecture of the machine that runs the build.
+
 ## Build The Service Image
 
 Run from the repository root:

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -327,6 +327,8 @@ The chart defaults to the image published to NGC:
 nvcr.io/nvidia/nemo-microservices/nrl-service:26.5.0
 ```
 
+Release-published tags of that image are multi-architecture (`linux/amd64` and `linux/arm64`). Kubernetes pulls the variant that matches the node.
+
 Pulling from `nvcr.io` requires an NGC pull secret — either set
 `ngcImagePullSecret.create=true` (see below) or pre-create one in the
 namespace named `ngc-secret`.


### PR DESCRIPTION
Perform Release saved a single-arch tarball, so versioned NGC tags shipped linux/amd64 only. Build and push linux/amd64 and linux/arm64 as a manifest list after all artifacts validate.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
