### PR TITLE
fix: keep VectorDB health probes responsive

### DIFF
--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -22,10 +22,13 @@ Build and run the NeMo Retriever service image with the [Docker service image gu
 3. **Published Library Helm charts (supported):** cluster install and upgrade procedures are covered in [About getting started](getting-started-about.md) — use alongside the NeMo Retriever chart README for your release
 4. [Environment variables](environment-config.md) and [Troubleshoot](troubleshoot.md) as needed
 
-The Helm chart uses `GET /v1/live` for startup and liveness probes and
-`GET /v1/health` for readiness. Both endpoints are unauthenticated. In split
-topology, `/v1/health` returns HTTP `503` when the required realtime or batch
-worker is unavailable, so Kubernetes removes the gateway from Service endpoints.
+The Helm chart uses `GET /v1/live` for startup and liveness probes on the
+retriever and VectorDB services and `GET /v1/health` for readiness. Both
+endpoints are unauthenticated. The VectorDB liveness endpoint performs no
+storage calls, while its readiness endpoint inspects backend and
+collection-catalog health. In split topology, `/v1/health` returns HTTP `503`
+when the required realtime or batch worker is unavailable, so Kubernetes
+removes the gateway from Service endpoints.
 In split topology, the realtime and batch init containers reach `/v1/live`
 through the chart's internal gateway startup Service
 (`<release>-nemo-retriever-gateway-startup`) so a clean install is not blocked

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -613,8 +613,8 @@ The service exposes unauthenticated health endpoints for Kubernetes probes:
 
 | Endpoint | Purpose | Default Helm use |
 | --- | --- | --- |
-| `GET /v1/live` | Shallow process liveness. The endpoint does not check worker backends or wait for service readiness. | Startup and liveness probes. In split mode, the realtime and batch `wait-for-gateway` init containers poll this endpoint on the internal gateway startup Service while waiting for the gateway process to start. |
-| `GET /v1/health` | Deep readiness. In split gateway mode, the endpoint checks the realtime and batch workers. It returns HTTP `503` when either required worker is unreachable or returns a non-2xx health response. | Readiness probe on the externally exposed gateway Service. |
+| `GET /v1/live` | Shallow process liveness. The endpoint does not check worker or storage backends or wait for service readiness. | Startup and liveness probes for the retriever and VectorDB services. In split mode, the realtime and batch `wait-for-gateway` init containers also poll this endpoint on the internal gateway startup Service while waiting for the gateway process to start. |
+| `GET /v1/health` | Deep readiness. In split gateway mode, the endpoint checks the realtime and batch workers. On the VectorDB service, it inspects backend and collection-catalog health. It returns HTTP `503` when a required backend is unavailable. | Readiness probes for the externally exposed gateway and internal VectorDB services. |
 
 In split topology, the gateway readiness probe uses `/v1/health`, which returns
 HTTP `503` until realtime and batch workers are healthy. Worker Pods cannot start
@@ -634,6 +634,10 @@ When a gateway returns HTTP `503` from `/v1/health`, Kubernetes removes it from
 the readiness-gated gateway Service endpoints until its required workers are
 ready. The response includes backend health details to help diagnose the
 unavailable dependency.
+
+The internal VectorDB Deployment follows the same probe separation. Startup and
+liveness use `/v1/live`, which performs no LanceDB access. Readiness uses
+`/v1/health`, which inspects the backend without blocking the HTTP event loop.
 
 ### Service networking
 

--- a/nemo_retriever/helm/templates/deployment-vectordb.yaml
+++ b/nemo_retriever/helm/templates/deployment-vectordb.yaml
@@ -179,7 +179,7 @@ spec:
               mountPath: /tmp
           startupProbe:
             httpGet:
-              path: /v1/health
+              path: /v1/live
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -187,7 +187,7 @@ spec:
             failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /v1/health
+              path: /v1/live
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30

--- a/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/adt_vdb.py
@@ -97,6 +97,10 @@ class VDB(ABC):
     The reference implementation is `LanceDB` (see `lancedb.py`). For an
     overview of how `IngestVdbOperator` and `RetrieveVdbOperator` consume
     this interface, see the package README.
+
+    Service applications may invoke independent backend methods concurrently
+    from worker threads. Implementations must synchronize shared mutable state
+    and any backend operations that cannot safely overlap.
     """
 
     @abstractmethod

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_collections.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_collections.py
@@ -364,7 +364,7 @@ class LanceDBCollectionStore:
             index_columns = (
                 ("scope", "name", "status", "expires_at")
                 if name == _COLLECTIONS_TABLE
-                else ("scope", "collection_name", "document_id", "status")
+                else ("scope", "collection_name", "document_id", "status", "recovery_state")
             )
             for column in index_columns:
                 table.create_scalar_index(column, replace=True)
@@ -1236,7 +1236,11 @@ class LanceDBCollectionStore:
             _COLLECTIONS_TABLE,
             columns=["status", "expires_at", "delete_started_at"],
         )
-        documents = self._rows(_DOCUMENTS_TABLE, columns=["recovery_state", "updated_at"])
+        documents = self._rows(
+            _DOCUMENTS_TABLE,
+            "recovery_state != ''",
+            columns=["updated_at"],
+        )
         active = sum(row.get("status") == "active" for row in collections)
         deleting = sum(row.get("status") == "deleting" for row in collections)
         expired = sum(
@@ -1247,7 +1251,7 @@ class LanceDBCollectionStore:
             if row.get("status") == "deleting" and row.get("delete_started_at"):
                 pending_times.append(datetime.fromisoformat(str(row["delete_started_at"])))
         for row in documents:
-            if row.get("recovery_state") and row.get("updated_at"):
+            if row.get("updated_at"):
                 pending_times.append(datetime.fromisoformat(str(row["updated_at"])))
         oldest_age = max(((now - started).total_seconds() for started in pending_times), default=0.0)
         return {

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -435,7 +435,7 @@ def create_vectordb_app(
 
     @app.middleware("http")
     async def require_internal_credential(request: Request, call_next):
-        if request.url.path == "/v1/health" or not required_internal_token:
+        if request.url.path in {"/v1/health", "/v1/live"} or not required_internal_token:
             return await call_next(request)
         supplied = request.headers.get("X-NRL-Internal-Token", "")
         if not supplied or not hmac.compare_digest(supplied, required_internal_token):
@@ -445,10 +445,15 @@ def create_vectordb_app(
             )
         return await call_next(request)
 
+    @app.get("/v1/live", tags=["system"])
+    async def live() -> dict[str, str]:
+        """Report whether the VectorDB process can answer HTTP requests."""
+        return {"status": "ok"}
+
     @app.get("/v1/health", tags=["system"])
     async def health() -> dict[str, Any]:
         current = state
-        backend_health = _safe_backend_health(current)
+        backend_health = await asyncio.to_thread(_safe_backend_health, current)
         if backend_health is None:
             raise HTTPException(503, "VectorDB backend is unavailable")
         return {
@@ -465,7 +470,7 @@ def create_vectordb_app(
         from prometheus_client import CollectorRegistry, Gauge, generate_latest
 
         registry = CollectorRegistry()
-        backend_health = _safe_backend_health(state) or {}
+        backend_health = await asyncio.to_thread(_safe_backend_health, state) or {}
         collections = backend_health.get("collections") or {}
         cleanup = backend_health.get("cleanup") or {}
         reconciliation = backend_health.get("reconciliation") or {}

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -447,7 +447,7 @@ def create_vectordb_app(
 
     @app.get("/v1/live", tags=["system"])
     async def live() -> dict[str, str]:
-        """Report whether the VectorDB process can answer HTTP requests."""
+        """Return ``{"status": "ok"}`` when the VectorDB process can answer HTTP requests."""
         return {"status": "ok"}
 
     @app.get("/v1/health", tags=["system"])

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -547,7 +547,7 @@ def create_vectordb_app(
         )
         if isinstance(result, CollectionWriteResult):
             return WriteResponse(written=result.written, total_rows=result.total_rows)
-        backend_health = current.vdb.health()
+        backend_health = await asyncio.to_thread(current.vdb.health)
         return WriteResponse(
             written=sum(len(batch) for batch in req.records),
             total_rows=int(backend_health.get("total_rows", 0)),
@@ -716,7 +716,7 @@ def create_vectordb_app(
 
         backend_health: dict[str, Any] = {}
         if req.collection_name is None:
-            backend_health = current.vdb.health()
+            backend_health = await asyncio.to_thread(current.vdb.health)
             if backend_health.get("table_exists") is False:
                 raise VDBInvalidRequest("No data has been ingested yet. Ingest documents first, then query.")
 
@@ -784,7 +784,7 @@ def create_vectordb_app(
             )
         if current.embed_mode != "remote":
             raise HTTPException(501, "Agentic service queries require a remote embedding endpoint.")
-        if not current.table_exists:
+        if not await asyncio.to_thread(lambda: current.table_exists):
             raise VDBInvalidRequest("No data has been ingested yet. Ingest documents first, then query.")
         if req.top_k > agentic_config.backend_top_k:
             raise VDBInvalidRequest(

--- a/nemo_retriever/tests/helm/test_vectordb_index_mode.py
+++ b/nemo_retriever/tests/helm/test_vectordb_index_mode.py
@@ -54,6 +54,20 @@ def test_vectordb_index_mode_rejects_invalid_value() -> None:
     assert "indexMode must be one of" in result.stderr
 
 
+def test_vectordb_probes_separate_liveness_from_readiness() -> None:
+    result = _helm_template()
+    assert result.returncode == 0, result.stderr
+    documents = [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+    deployment = next(
+        doc for doc in documents if doc.get("kind") == "Deployment" and doc["metadata"]["name"].endswith("-vectordb")
+    )
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert container["startupProbe"]["httpGet"]["path"] == "/v1/live"
+    assert container["livenessProbe"]["httpGet"]["path"] == "/v1/live"
+    assert container["readinessProbe"]["httpGet"]["path"] == "/v1/health"
+
+
 def test_service_config_uses_the_same_index_modes_as_helm() -> None:
     assert VectorDbConfig().index_mode == "auto"
     assert [VectorDbConfig(index_mode=mode).index_mode for mode in ("auto", "dense", "hybrid")] == [

--- a/nemo_retriever/tests/test_lancedb_collections.py
+++ b/nemo_retriever/tests/test_lancedb_collections.py
@@ -720,6 +720,72 @@ def test_reconciliation_filters_recoverable_documents_before_scan_limit(tmp_path
     )
 
 
+def test_health_filters_recoverable_documents_before_scan_limit(tmp_path, monkeypatch):
+    backend = _backend_with_collection(tmp_path)
+    backend.write_collection(
+        _records(text="completed", vector=[1.0, 0.0]),
+        context=_context(document_id="document-completed"),
+    )
+    store = backend._get_collection_store()
+    _fail_document_finalize(monkeypatch, store)
+    with pytest.raises(RuntimeError, match="injected catalog finalize failure"):
+        backend.write_collection(
+            _records(text="pending", vector=[0.0, 1.0]),
+            context=_context(document_id="document-pending"),
+        )
+    monkeypatch.setattr(collections_module, "_CATALOG_SCAN_LIMIT", 1)
+    original_rows = store._rows
+
+    def require_recovery_filter(table_name, where=None, columns=None):
+        if table_name == "_nrl_documents":
+            assert where == "recovery_state != ''"
+            assert columns == ["updated_at"]
+        return original_rows(table_name, where, columns)
+
+    monkeypatch.setattr(store, "_rows", require_recovery_filter)
+
+    health = backend.health()
+
+    assert health["cleanup"]["pending"] == 1
+    assert health["cleanup"]["oldest_age_seconds"] >= 0
+
+
+def test_catalog_restart_adds_recovery_index_without_rewriting_documents(tmp_path):
+    backend = _backend_with_collection(tmp_path)
+    backend.write_collection(_records(), context=_context())
+    store = backend._get_collection_store()
+    documents = store._open_table("_nrl_documents")
+
+    def recovery_index(table):
+        return next(
+            (
+                index
+                for index in table.list_indices()
+                if "recovery_state" in {str(column) for column in (index.columns or [])}
+            ),
+            None,
+        )
+
+    documents.checkout_latest()
+    before = documents.search().to_list()
+    index = recovery_index(documents)
+    assert index is not None
+    documents.drop_index(index.name)
+    assert recovery_index(documents) is None
+
+    restarted = LanceDB(
+        uri=str(tmp_path / "lancedb"),
+        table_name="legacy",
+        vector_dim=2,
+        build_index=False,
+    )
+    restarted.get_collection(scope="workspace-a", collection_name="collection-a")
+    restarted_documents = restarted._get_collection_store()._open_table("_nrl_documents")
+
+    assert restarted_documents.search().to_list() == before
+    assert recovery_index(restarted_documents) is not None
+
+
 def test_reconciliation_filters_expired_collections_before_scan_limit(tmp_path, monkeypatch):
     backend = _backend_with_collection(tmp_path)
     backend.create_collection(

--- a/nemo_retriever/tests/test_service_vectordb_app.py
+++ b/nemo_retriever/tests/test_service_vectordb_app.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -265,6 +267,19 @@ class ValueFailureVDB(FakeVDB):
 class HealthFailureVDB(FakeVDB):
     def health(self) -> dict[str, Any]:
         raise RuntimeError("backend unavailable")
+
+
+class BlockingHealthVDB(FakeVDB):
+    def __init__(self) -> None:
+        super().__init__()
+        self.health_entered = threading.Event()
+        self.release_health = threading.Event()
+
+    def health(self) -> dict[str, Any]:
+        self.health_entered.set()
+        if not self.release_health.wait(timeout=5):
+            raise RuntimeError("timed out waiting to release health inspection")
+        return super().health()
 
 
 class DefaultHealthVDB(FakeVDB):
@@ -650,8 +665,11 @@ def test_query_without_embed_backend_returns_501() -> None:
 
 
 def test_internal_auth_is_optional_and_can_be_enabled() -> None:
-    app = _app(FakeVDB(), internal_api_token="internal-secret")
+    backend = FakeVDB()
+    app = _app(backend, internal_api_token="internal-secret")
     with TestClient(app) as client:
+        assert client.get("/v1/live").json() == {"status": "ok"}
+        assert backend.health_calls == 0
         assert client.get("/v1/health").status_code == 200
         assert client.get("/v1/collections").status_code == 401
         assert (
@@ -661,6 +679,32 @@ def test_internal_auth_is_optional_and_can_be_enabled() -> None:
             ).status_code
             == 200
         )
+
+
+def test_blocked_health_does_not_block_liveness_or_ordinary_requests() -> None:
+    backend = BlockingHealthVDB()
+    app = _app(backend, internal_api_token="internal-secret")
+
+    with TestClient(app) as client, ThreadPoolExecutor(max_workers=3) as executor:
+        health_future = executor.submit(client.get, "/v1/health")
+        assert backend.health_entered.wait(timeout=2)
+        live_future = executor.submit(client.get, "/v1/live")
+        collections_future = executor.submit(
+            client.get,
+            "/v1/collections",
+            headers={"X-NRL-Internal-Token": "internal-secret"},
+        )
+        try:
+            live = live_future.result(timeout=2)
+            collections = collections_future.result(timeout=2)
+        finally:
+            backend.release_health.set()
+        health = health_future.result(timeout=5)
+
+    assert live.status_code == 200
+    assert live.json() == {"status": "ok"}
+    assert collections.status_code == 200
+    assert health.status_code == 200
 
 
 def test_health_and_metrics_use_backend_neutral_health() -> None:

--- a/nemo_retriever/tests/test_service_vectordb_app.py
+++ b/nemo_retriever/tests/test_service_vectordb_app.py
@@ -36,6 +36,7 @@ from nemo_retriever.common.vdb.adt_vdb import (
 from nemo_retriever.common.vdb.hybrid_fusion import DEFAULT_HYBRID_FUSION_POLICY
 from nemo_retriever.common.vdb.lancedb import LanceDB
 from nemo_retriever.common.vdb.records import RetrievalContractError
+from nemo_retriever.service.config import AgenticConfig
 from nemo_retriever.service.vectordb_app import (
     VectorDBState,
     _embed_queries_remote,
@@ -681,30 +682,57 @@ def test_internal_auth_is_optional_and_can_be_enabled() -> None:
         )
 
 
-def test_blocked_health_does_not_block_liveness_or_ordinary_requests() -> None:
+@pytest.mark.parametrize(
+    ("method", "path", "payload", "expected_status", "agentic_enabled"),
+    [
+        ("GET", "/v1/health", None, 200, False),
+        (
+            "POST",
+            "/internal/vectordb/write",
+            {
+                "records": [[{"document_type": "text", "metadata": {}}]],
+                "filename": "legacy.pdf",
+                "document_version": "1",
+            },
+            200,
+            False,
+        ),
+        ("POST", "/v1/query", {"query": "legacy"}, 422, False),
+        ("POST", "/v1/query", {"query": "legacy", "agentic": True}, 422, True),
+    ],
+)
+def test_blocked_health_inspection_does_not_block_other_requests(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None,
+    expected_status: int,
+    agentic_enabled: bool,
+) -> None:
     backend = BlockingHealthVDB()
-    app = _app(backend, internal_api_token="internal-secret")
+    agentic_config = (
+        AgenticConfig(enabled=True, llm_model="model", invoke_url="https://llm.example/v1/chat/completions")
+        if agentic_enabled
+        else None
+    )
+    app = _app(backend, internal_api_token="internal-secret", agentic_config=agentic_config)
+    headers = {"X-NRL-Internal-Token": "internal-secret"}
 
     with TestClient(app) as client, ThreadPoolExecutor(max_workers=3) as executor:
-        health_future = executor.submit(client.get, "/v1/health")
+        blocked_future = executor.submit(client.request, method, path, headers=headers, json=payload)
         assert backend.health_entered.wait(timeout=2)
         live_future = executor.submit(client.get, "/v1/live")
-        collections_future = executor.submit(
-            client.get,
-            "/v1/collections",
-            headers={"X-NRL-Internal-Token": "internal-secret"},
-        )
+        collections_future = executor.submit(client.get, "/v1/collections", headers=headers)
         try:
             live = live_future.result(timeout=2)
             collections = collections_future.result(timeout=2)
         finally:
             backend.release_health.set()
-        health = health_future.result(timeout=5)
+        blocked = blocked_future.result(timeout=5)
 
     assert live.status_code == 200
     assert live.json() == {"status": "ok"}
     assert collections.status_code == 200
-    assert health.status_code == 200
+    assert blocked.status_code == expected_status
 
 
 def test_health_and_metrics_use_backend_neutral_health() -> None:


### PR DESCRIPTION
## Description

Keep the VectorDB service responsive when LanceDB health inspection is slow or the document catalog is large.

This change:

- Adds an unauthenticated `GET /v1/live` endpoint that performs no backend or storage operations.
- Runs backend health and metrics inspection outside the asyncio event loop.
- Changes LanceDB health inspection to query only pending recovery records using `recovery_state != ''`.
- Adds an additive scalar index on `recovery_state` for existing and new catalogs.
- Uses `/v1/live` for VectorDB startup and liveness probes while retaining `/v1/health` for readiness.
- Documents the distinction between process liveness and storage-aware readiness.

The existing `/v1/health` response contract and status codes remain unchanged. This does not change ingestion, retrieval, ranking, identifiers, collection behavior, or stored document data, and it requires no data migration.

### Validation

- 118 focused and adjacent tests passed.
- Repository pre-commit checks passed.
- Helm lint and rendering passed.
- Kubernetes server-side dry-run validation passed.
- Direct HTTP smoke tests confirmed successful responses from `/v1/live`, `/v1/health`, and `/v1/collections`.
- A local container build was not run because the Docker daemon was unavailable; container validation remains covered by CI.

## Checklist

- [x] I am familiar with the [[Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.