### PR TITLE
Add English ViDoRe v3 runset

### DIFF
--- a/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
+++ b/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
@@ -24,6 +24,13 @@ VIDORE_V3_PUBLIC_DATASETS: dict[str, str] = {
     "vidore_v3_pharmaceuticals": "pharmaceuticals",
     "vidore_v3_physics": "physics",
 }
+VIDORE_V3_ENGLISH_DATASETS: tuple[str, ...] = (
+    "vidore_v3_computer_science",
+    "vidore_v3_finance_en",
+    "vidore_v3_hr",
+    "vidore_v3_industrial",
+    "vidore_v3_pharmaceuticals",
+)
 DEFAULT_SUMMARY_KEYS: tuple[str, ...] = (
     "files",
     "pages",
@@ -279,6 +286,12 @@ RUNSETS: dict[str, RunSet] = {
         runs=tuple(f"{dataset_name}_beir" for dataset_name in VIDORE_V3_PUBLIC_DATASETS),
         tags=("vidore", "beir", "all"),
         description="All eight public ViDoRe v3 BEIR retrieval benchmarks.",
+    ),
+    "vidore_v3_english": RunSet(
+        name="vidore_v3_english",
+        runs=tuple(f"{dataset_name}_beir" for dataset_name in VIDORE_V3_ENGLISH_DATASETS),
+        tags=("vidore", "beir", "english"),
+        description="Five English ViDoRe v3 BEIR retrieval benchmarks.",
     ),
 }
 

--- a/nemo_retriever/tests/test_harness_benchmark_registry.py
+++ b/nemo_retriever/tests/test_harness_benchmark_registry.py
@@ -106,3 +106,22 @@ def test_vidore_v3_all_runset_contains_every_public_dataset() -> None:
     runset = get_runset("vidore_v3_all")
 
     assert runset.runs == tuple(f"{name}_beir" for name in VIDORE_V3_PUBLIC_DATASETS)
+
+
+def test_vidore_v3_english_runset_contains_only_requested_datasets() -> None:
+    runset = get_runset("vidore_v3_english")
+
+    assert runset.runs == (
+        "vidore_v3_computer_science_beir",
+        "vidore_v3_finance_en_beir",
+        "vidore_v3_hr_beir",
+        "vidore_v3_industrial_beir",
+        "vidore_v3_pharmaceuticals_beir",
+    )
+    assert set(runset.runs).isdisjoint(
+        {
+            "vidore_v3_energy_beir",
+            "vidore_v3_finance_fr_beir",
+            "vidore_v3_physics_beir",
+        }
+    )


### PR DESCRIPTION
## Summary
- add a `vidore_v3_english` harness runset
- include computer science, English finance, HR, industrial, and pharmaceuticals
- exclude energy, French finance, and physics

## Validation
- `pytest nemo_retriever/tests/test_harness_benchmark_registry.py -q` (20 passed)
- `retriever harness list --runsets` lists the five expected benchmarks