### PR TITLE
docs(extraction): report Recall@5 and NDCG@10 on Evaluate on your data

### DIFF
--- a/docs/docs/extraction/evaluate-on-your-data.md
+++ b/docs/docs/extraction/evaluate-on-your-data.md
@@ -4,7 +4,17 @@ Retrieval and ingestion performance **depend on your documents**, hardware, and 
 
 ## Benchmarking and baselines { #benchmarking-and-baselines }
 
-Use this page as the baseline for methodology and expectations. Use [Operational tuning](#operational-tuning) below to observe production-like runs.
+Use this page as the baseline for methodology and expectations. Use [Accuracy metrics](#accuracy-metrics) when you compare retrieval quality. Use [Operational tuning](#operational-tuning) below to observe production-like runs.
+
+## Accuracy metrics { #accuracy-metrics }
+
+When you measure retrieval accuracy, report both `Recall@5` and `NDCG@10` (normalized discounted cumulative gain at 10). NeMo Retriever Library end-to-end retrieval benchmarks report both metrics.
+
+`Recall@5` remains the primary accuracy metric. It is the fraction of relevant items that appear in the top five retrieved results.
+
+`NDCG@10` accounts for the rank of relevant results, not only whether those results appear in the list. Most popular public retrieval benchmarks use `NDCG@10` as their comparison metric. `Recall@5` can vary more across queries than `NDCG@10`.
+
+Use both metrics when you compare published NeMo Retriever Library numbers to public leaderboards. Use both metrics when you evaluate retrieval on your own labeled queries. Do not treat a single cutoff as the full accuracy picture.
 
 ## Throughput and dataset effects { #throughput-and-dataset-effects }
 


### PR DESCRIPTION
## Summary

- Adds an **Accuracy metrics** section to Evaluate on your data so readers know NRL end-to-end retrieval benchmarks report both `Recall@5` and `NDCG@10`.
- Keeps `Recall@5` as the primary accuracy metric and explains why `NDCG@10` is reported as well (public-benchmark comparison; `Recall@5` varies more across queries).
- Scoped to this PIC 2026-09-01 decision only. No CLI, eval-harness, or default-pipeline changes.

## Why this PR exists

PIC 2026-09-01: Research and NRL E2E will report both metrics going forward. This is not a switch away from Recall. Nave and Even keep Recall as the accuracy north star. Janisha/Sean/Bo asked to include NDCG@10 because popular public benchmarks use it and Recall@5 is noisy.

The BEIR helpers already compute recall and NDCG at cutoffs 1, 3, 5, and 10 (`DEFAULT_BEIR_KS`). Tests already assert `ndcg@10` and `recall@5`. This PR documents that reporting policy. It does not add a customer eval CLI.

## Out of scope (same PIC; separate follow-ups)

- Build endpoint deprecation coordination
- GTC Berlin / AIQ-Retriever GTM after Nave's scope
- LLM NIM SKU split-hosting (Nemotron Ultra / RTX Pro 6000) after Janisha's follow-up
- Nemotron 3 Embed 1B migration / reindex guide
- `nemo-memory-datasets` partner share
- NIM patch timing for Berlin

## Test plan

- [x] `python -m mkdocs build --strict --config-file mkdocs.yml` from `docs/` (local untracked pages moved aside so they did not fail strict)
- [x] `git diff --name-only upstream/main...HEAD` is only `docs/docs/extraction/evaluate-on-your-data.md`
- [ ] SME glance: Nave/Even okay with "primary accuracy metric" plus dual report in customer docs

## Feedback requested

Please focus on the dual-report wording. Confirm we should not name experimental `retriever eval` / `benchmark` / `skill-eval` commands on this page.
