### PR TITLE
Expose cache-read token usage for agentic queries

### DIFF
--- a/docs/docs/extraction/workflow-agentic-retrieval.md
+++ b/docs/docs/extraction/workflow-agentic-retrieval.md
@@ -261,6 +261,7 @@ retriever query "find documents about parser behavior" \
   ],
   "usage": {
     "input_tokens": 1250,
+    "cache_tokens": 400,
     "output_tokens": 184,
     "total_tokens": 1434
   }
@@ -268,11 +269,14 @@ retriever query "find documents about parser behavior" \
 ```
 
 The `usage` object reports the exact token counts returned by the LLM provider.
-It contains `input_tokens`, `output_tokens`, and `total_tokens`. When available,
-`stages` preserves the provider-reported breakdown for the ReAct and
-final-selection calls. When a provider reports uncached, cache-creation, and
-cache-read input separately, `input_tokens` includes all three counters. If the
-provider does not report usage, the response sets `usage` to `null`.
+It contains `input_tokens`, observed cache-read `cache_tokens`, `output_tokens`,
+and `total_tokens`. `cache_tokens` is `null` when no stage reports cache usage.
+When available, `stages` preserves the provider-reported breakdown for the
+ReAct and final-selection calls, including cache-creation counters. When a
+provider reports uncached, cache-creation, and cache-read input separately,
+`input_tokens` includes all three counters. Cache tokens are therefore not
+added again when calculating `total_tokens`. If the provider does not report
+usage, the response sets `usage` to `null`.
 `--include-usage` applies only to agentic queries. Classic `retriever query`
 output is unchanged.
 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -303,18 +303,21 @@ retriever query "how does the ingestion pipeline handle tables?" \
   ],
   "usage": {
     "input_tokens": 1250,
+    "cache_tokens": 400,
     "output_tokens": 184,
     "total_tokens": 1434
   }
 }
 ```
 
-The `usage` object can also include `stages`, which preserves the
-provider-reported breakdown for the ReAct and final-selection calls. When a
-provider reports uncached, cache-creation, and cache-read input separately,
-`input_tokens` includes all three counters. The output sets `usage` to `null`
-when the LLM provider does not report it. This flag applies only with
-`--agentic`; classic query behavior and output are unchanged.
+The `usage` object reports observed cache reads as `cache_tokens` and can also
+include `stages`, which preserves the provider-reported breakdown for the ReAct
+and final-selection calls, including cache creation. When a provider reports
+uncached, cache-creation, and cache-read input separately, `input_tokens`
+includes all three counters; cache is not added again to `total_tokens`.
+`cache_tokens` is `null` when no stage reports cache usage. The output sets
+`usage` to `null` when the LLM provider does not report it. This flag applies
+only with `--agentic`; classic query behavior and output are unchanged.
 
 **How it works.** Each agentic query runs `Query -> ReActAgentOperator -> (RRF
 fusion) -> SelectionAgentOperator -> ranked results`:

--- a/nemo_retriever/src/nemo_retriever/_agentic/nemo_agent/atif.py
+++ b/nemo_retriever/src/nemo_retriever/_agentic/nemo_agent/atif.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
+from .llm.usage import cache_read_tokens, usage_integer
 from nemo_retriever.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -232,23 +233,19 @@ def _atif_metrics(raw_usage: Any) -> Dict[str, Any]:
     if not isinstance(raw_usage, Mapping) or not raw_usage:
         return {}
 
-    prompt = _integer(raw_usage, "prompt_tokens")
+    prompt = usage_integer(raw_usage, "prompt_tokens")
     if prompt is None:
-        prompt = _integer(raw_usage, "input_tokens")
+        prompt = usage_integer(raw_usage, "input_tokens")
         if prompt is not None:
             prompt += sum(
                 value or 0
                 for value in (
-                    _integer(raw_usage, "cache_creation_input_tokens"),
-                    _integer(raw_usage, "cache_read_input_tokens"),
+                    usage_integer(raw_usage, "cache_creation_input_tokens"),
+                    usage_integer(raw_usage, "cache_read_input_tokens"),
                 )
             )
-    completion = _integer(raw_usage, "completion_tokens", "output_tokens")
-    cached = _integer(raw_usage, "cached_tokens", "cached_input_tokens", "cache_read_input_tokens")
-    if cached is None:
-        prompt_details = raw_usage.get("prompt_tokens_details")
-        if isinstance(prompt_details, Mapping):
-            cached = _integer(prompt_details, "cached_tokens")
+    completion = usage_integer(raw_usage, "completion_tokens", "output_tokens")
+    cached = cache_read_tokens(raw_usage)
     metrics: Dict[str, Any] = {}
     if prompt is not None:
         metrics["prompt_tokens"] = prompt
@@ -258,14 +255,6 @@ def _atif_metrics(raw_usage: Any) -> Dict[str, Any]:
         metrics["cached_tokens"] = cached
     metrics["extra"] = {"provider_usage": dict(raw_usage)}
     return metrics
-
-
-def _integer(values: Mapping[str, Any], *keys: str) -> Optional[int]:
-    for key in keys:
-        value = values.get(key)
-        if isinstance(value, int) and not isinstance(value, bool):
-            return int(value)
-    return None
 
 
 def _insert_bootstrap_retrieval(
@@ -331,15 +320,15 @@ def _final_metrics(steps: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
     for step in steps:
         metrics = step.get("metrics")
         if isinstance(metrics, Mapping):
-            value = _integer(metrics, "prompt_tokens")
+            value = usage_integer(metrics, "prompt_tokens")
             if value is not None:
                 prompt += value
                 has_prompt = True
-            value = _integer(metrics, "completion_tokens")
+            value = usage_integer(metrics, "completion_tokens")
             if value is not None:
                 completion += value
                 has_completion = True
-            value = _integer(metrics, "cached_tokens")
+            value = usage_integer(metrics, "cached_tokens")
             if value is not None:
                 cached += value
                 has_cached = True

--- a/nemo_retriever/src/nemo_retriever/_agentic/nemo_agent/llm/usage.py
+++ b/nemo_retriever/src/nemo_retriever/_agentic/nemo_agent/llm/usage.py
@@ -218,6 +218,34 @@ def sum_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Dict[str
     return total
 
 
+def usage_integer(usage: Mapping[str, Any], *keys: str) -> Optional[int]:
+    """Return the first integer usage value found under ``keys``."""
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return int(value)
+    return None
+
+
+def cache_read_tokens(usage: Mapping[str, Any]) -> Optional[int]:
+    """Return provider-reported cache-read input tokens, when available."""
+    cached = usage_integer(
+        usage,
+        "cached_tokens",
+        "cached_input_tokens",
+        "cache_read_input_tokens",
+    )
+    if cached is not None:
+        return cached
+    for details_key in ("prompt_tokens_details", "input_tokens_details"):
+        details = usage.get(details_key)
+        if isinstance(details, Mapping):
+            cached = usage_integer(details, "cached_tokens")
+            if cached is not None:
+                return cached
+    return None
+
+
 def normalize_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
     """Return stable token totals plus the exact provider stage breakdown.
 
@@ -234,21 +262,14 @@ def normalize_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Di
 
     stages = deepcopy(dict(usage_by_stage))
 
-    def _integer(usage: Mapping[str, Any], *keys: str) -> Optional[int]:
-        for key in keys:
-            value = usage.get(key)
-            if isinstance(value, int) and not isinstance(value, bool):
-                return int(value)
-        return None
-
     def _token_count(
         usage: Mapping[str, Any],
         aliases: tuple[str, ...],
         *,
         additive_keys: tuple[str, ...] = (),
     ) -> Optional[int]:
-        value = _integer(usage, *aliases)
-        additions = [_integer(usage, key) for key in additive_keys]
+        value = usage_integer(usage, *aliases)
+        additions = [usage_integer(usage, key) for key in additive_keys]
         if not any(addition is not None for addition in additions):
             return value
         if value is None:
@@ -267,21 +288,9 @@ def normalize_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Di
             ("input_tokens", "prompt_tokens"),
             additive_keys=("cache_creation_input_tokens", "cache_read_input_tokens"),
         )
-        stage_cache = _integer(
-            usage,
-            "cached_tokens",
-            "cached_input_tokens",
-            "cache_read_input_tokens",
-        )
-        if stage_cache is None:
-            for details_key in ("prompt_tokens_details", "input_tokens_details"):
-                details = usage.get(details_key)
-                if isinstance(details, Mapping):
-                    stage_cache = _integer(details, "cached_tokens")
-                    if stage_cache is not None:
-                        break
+        stage_cache = cache_read_tokens(usage)
         stage_output = _token_count(usage, ("output_tokens", "completion_tokens"))
-        stage_total = _integer(usage, "total_tokens")
+        stage_total = usage_integer(usage, "total_tokens")
         if stage_total is None and stage_input is not None and stage_output is not None:
             stage_total = stage_input + stage_output
         input_by_stage.append(stage_input)

--- a/nemo_retriever/src/nemo_retriever/_agentic/nemo_agent/llm/usage.py
+++ b/nemo_retriever/src/nemo_retriever/_agentic/nemo_agent/llm/usage.py
@@ -224,8 +224,10 @@ def normalize_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Di
     Usage schemas use both ``prompt_tokens`` / ``completion_tokens`` and
     ``input_tokens`` / ``output_tokens`` names. Values are copied from the
     provider aggregate. Separately reported cache-write and cache-read input
-    counters are included in the input total. ``total_tokens`` is only filled
-    by exact addition when both component totals are present.
+    counters are included in the input total. ``cache_tokens`` sums observed
+    provider-reported cache reads; cache creation remains available only in the
+    stage breakdown because it has different pricing semantics. ``total_tokens``
+    is only filled by exact addition when both component totals are present.
     """
     if not usage_by_stage:
         return {}
@@ -254,6 +256,7 @@ def normalize_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Di
         return value + sum(addition or 0 for addition in additions)
 
     input_by_stage: list[int | None] = []
+    cache_by_stage: list[int | None] = []
     output_by_stage: list[int | None] = []
     total_by_stage: list[int | None] = []
     for usage in usage_by_stage.values():
@@ -264,11 +267,25 @@ def normalize_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Di
             ("input_tokens", "prompt_tokens"),
             additive_keys=("cache_creation_input_tokens", "cache_read_input_tokens"),
         )
+        stage_cache = _integer(
+            usage,
+            "cached_tokens",
+            "cached_input_tokens",
+            "cache_read_input_tokens",
+        )
+        if stage_cache is None:
+            for details_key in ("prompt_tokens_details", "input_tokens_details"):
+                details = usage.get(details_key)
+                if isinstance(details, Mapping):
+                    stage_cache = _integer(details, "cached_tokens")
+                    if stage_cache is not None:
+                        break
         stage_output = _token_count(usage, ("output_tokens", "completion_tokens"))
         stage_total = _integer(usage, "total_tokens")
         if stage_total is None and stage_input is not None and stage_output is not None:
             stage_total = stage_input + stage_output
         input_by_stage.append(stage_input)
+        cache_by_stage.append(stage_cache)
         output_by_stage.append(stage_output)
         total_by_stage.append(stage_total)
 
@@ -279,8 +296,13 @@ def normalize_usage_breakdown(usage_by_stage: Optional[Mapping[str, Any]]) -> Di
             else None
         )
 
+    def _observed_sum(values: list[int | None]) -> Optional[int]:
+        observed = [value for value in values if value is not None]
+        return sum(observed) if observed else None
+
     return {
         "input_tokens": _complete_sum(input_by_stage),
+        "cache_tokens": _observed_sum(cache_by_stage),
         "output_tokens": _complete_sum(output_by_stage),
         "total_tokens": _complete_sum(total_by_stage),
         "stages": stages,

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -36,11 +36,11 @@ class AgenticQueryDocumentsResult:
     hits:
         Ranked agentic document hits in the root query output shape.
     usage:
-        Normalized usage with ``input_tokens``, ``output_tokens``,
-        ``total_tokens``, and the original provider breakdown under ``stages``.
-        Token totals are integers or ``None`` when the provider did not report
-        enough information for an exact total. The mapping is empty when no
-        provider usage was reported.
+        Normalized usage with ``input_tokens``, observed cache-read
+        ``cache_tokens``, ``output_tokens``, ``total_tokens``, and the original
+        provider breakdown under ``stages``. Token totals are integers or
+        ``None`` when the provider did not report enough information for an
+        exact total. The mapping is empty when no provider usage was reported.
     """
 
     hits: list[dict[str, Any]]

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -109,6 +109,11 @@ class AgenticTokenUsage(BaseModel):
     """Provider-reported LLM usage for one agentic retrieval query."""
 
     input_tokens: int | None = Field(default=None, ge=0)
+    cache_tokens: int | None = Field(
+        default=None,
+        ge=0,
+        description="Observed provider-reported cache-read input tokens.",
+    )
     output_tokens: int | None = Field(default=None, ge=0)
     total_tokens: int | None = Field(default=None, ge=0)
     stages: dict[str, dict[str, Any]] = Field(default_factory=dict)

--- a/nemo_retriever/tests/test_agentic_eval.py
+++ b/nemo_retriever/tests/test_agentic_eval.py
@@ -365,7 +365,12 @@ def test_agentic_query_documents_with_metadata_normalizes_usage():
         ),
         usage={
             "0": {
-                "main_agent": {"prompt_tokens": 11, "completion_tokens": 4, "total_tokens": 15},
+                "main_agent": {
+                    "prompt_tokens": 11,
+                    "completion_tokens": 4,
+                    "total_tokens": 15,
+                    "prompt_tokens_details": {"cached_tokens": 5},
+                },
                 "top1_agent": {"input_tokens": 3, "output_tokens": 2},
             }
         },
@@ -380,6 +385,7 @@ def test_agentic_query_documents_with_metadata_normalizes_usage():
         result = agentic_query_documents_with_metadata(request)
 
     assert result.usage["input_tokens"] == 14
+    assert result.usage["cache_tokens"] == 5
     assert result.usage["output_tokens"] == 6
     assert result.usage["total_tokens"] == 20
     assert set(result.usage["stages"]) == {"main_agent", "top1_agent"}
@@ -406,10 +412,42 @@ def test_normalize_usage_breakdown_includes_split_cache_input_tokens():
 
     assert result == {
         "input_tokens": 550,
+        "cache_tokens": 400,
         "output_tokens": 25,
         "total_tokens": 575,
         "stages": {"main_agent": split_input_usage},
     }
+
+
+def test_normalize_usage_breakdown_sums_observed_nested_cache_reads():
+    from nemo_retriever._agentic.nemo_agent.llm.usage import normalize_usage_breakdown
+
+    usage = {
+        "main_agent": {
+            "prompt_tokens": 120,
+            "completion_tokens": 25,
+            "total_tokens": 145,
+            "prompt_tokens_details": {"cached_tokens": 40},
+        },
+        "selection_agent": {
+            "input_tokens": 30,
+            "output_tokens": 5,
+            "input_tokens_details": {"cached_tokens": 10},
+        },
+        "provider_without_cache_details": {
+            "prompt_tokens": 20,
+            "completion_tokens": 3,
+            "total_tokens": 23,
+        },
+    }
+
+    result = normalize_usage_breakdown(usage)
+
+    assert result["input_tokens"] == 170
+    assert result["cache_tokens"] == 50
+    assert result["output_tokens"] == 33
+    assert result["total_tokens"] == 203
+    assert result["stages"] == usage
 
 
 @patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)

--- a/nemo_retriever/tests/test_nemo_agent_atif.py
+++ b/nemo_retriever/tests/test_nemo_agent_atif.py
@@ -49,7 +49,7 @@ def test_agent_run_builds_atif_steps_and_token_metrics():
                 "prompt_tokens": 11,
                 "completion_tokens": 7,
                 "total_tokens": 18,
-                "prompt_tokens_details": {"cached_tokens": 4},
+                "input_tokens_details": {"cached_tokens": 4},
             },
         }
 

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -460,6 +460,7 @@ def test_root_query_agentic_include_usage_emits_envelope(monkeypatch) -> None:
 
     usage = {
         "input_tokens": 12,
+        "cache_tokens": 4,
         "output_tokens": 5,
         "total_tokens": 17,
         "stages": {"main_agent": {"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17}},

--- a/nemo_retriever/tests/test_service_agentic_query.py
+++ b/nemo_retriever/tests/test_service_agentic_query.py
@@ -93,6 +93,7 @@ def test_run_agentic_query_includes_provider_usage() -> None:
 
     usage = {
         "input_tokens": 12,
+        "cache_tokens": 4,
         "output_tokens": 5,
         "total_tokens": 17,
         "stages": {"main_agent": {"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17}},
@@ -247,6 +248,7 @@ def test_agentic_true_runs_react_workflow_on_v1_query(tmp_path) -> None:
         query_mode="agentic",
         usage={
             "input_tokens": 120,
+            "cache_tokens": 40,
             "output_tokens": 30,
             "total_tokens": 150,
             "stages": {},
@@ -283,6 +285,7 @@ def test_agentic_true_runs_react_workflow_on_v1_query(tmp_path) -> None:
         "query_mode": "agentic",
         "usage": {
             "input_tokens": 120,
+            "cache_tokens": 40,
             "output_tokens": 30,
             "total_tokens": 150,
             "stages": {},

--- a/nemo_retriever/tests/test_service_mcp.py
+++ b/nemo_retriever/tests/test_service_mcp.py
@@ -135,6 +135,7 @@ def test_agentic_query_client_posts_agentic_flag_on_v1_query() -> None:
                 ],
                 "usage": {
                     "input_tokens": 120,
+                    "cache_tokens": 40,
                     "output_tokens": 30,
                     "total_tokens": 150,
                     "stages": {},
@@ -164,6 +165,7 @@ def test_agentic_query_client_posts_agentic_flag_on_v1_query() -> None:
         },
     }
     assert result["results"][0]["hits"][0]["source"] == "report.pdf"
+    assert result["usage"]["cache_tokens"] == 40
     assert result["usage"]["total_tokens"] == 150
 
 


### PR DESCRIPTION
## Description
- Normalize provider-reported cache-read tokens as `usage.cache_tokens`.
- Expose cache-read usage through Python, CLI, service, and MCP responses.
- Preserve the original provider breakdown under `usage.stages`.
- Keep cache tokens as a subset of input tokens so they are not added again to totals.
- Update API schemas, CLI documentation, workflow documentation, and tests.
## Semantics
`input_tokens` represents total input processed, including cached input.
`cache_tokens` is the observed cache-read portion of that input.
`total_tokens` remains `input_tokens + output_tokens`.
Cache creation details remain available in the provider-specific stage breakdown.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
