### PR TITLE
fix(helm): defer extraction NIM batch defaults

### DIFF
--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -1119,13 +1119,7 @@ nimOperator:
         value: "0.0.0.0:8000"
       - name: NIM_PERFORMANCE_MODE
         value: "1"
-      - name: NIM_SERVER_MODE
-        value: latency
-      - name: NIM_SERVER_MAX_WAIT_MS
-        value: "0"
       - name: NIM_ENGINE_COUNT
-        value: "1"
-      - name: NIM_PIPELINE_MAX_BATCH_SIZE
         value: "1"
       - name: NIM_ENGINE_MODEL_DOWNLOAD_PROVIDER
         value: ngc
@@ -1178,13 +1172,7 @@ nimOperator:
         value: "0.0.0.0:8000"
       - name: NIM_PERFORMANCE_MODE
         value: "1"
-      - name: NIM_SERVER_MODE
-        value: latency
-      - name: NIM_SERVER_MAX_WAIT_MS
-        value: "0"
       - name: NIM_ENGINE_COUNT
-        value: "1"
-      - name: NIM_PIPELINE_MAX_BATCH_SIZE
         value: "1"
       - name: NIM_ENGINE_MODEL_DOWNLOAD_PROVIDER
         value: ngc
@@ -1238,13 +1226,7 @@ nimOperator:
         value: "0.0.0.0:8000"
       - name: NIM_PERFORMANCE_MODE
         value: "1"
-      - name: NIM_SERVER_MODE
-        value: latency
-      - name: NIM_SERVER_MAX_WAIT_MS
-        value: "0"
       - name: NIM_ENGINE_COUNT
-        value: "1"
-      - name: NIM_PIPELINE_MAX_BATCH_SIZE
         value: "1"
       - name: NIM_ENGINE_MODEL_DOWNLOAD_PROVIDER
         value: ngc

--- a/nemo_retriever/tests/test_helm_nim_2_contracts.py
+++ b/nemo_retriever/tests/test_helm_nim_2_contracts.py
@@ -66,7 +66,7 @@ def test_extraction_nims_select_distinct_native_models() -> None:
         assert env["NIM_ENGINE_MODEL_PATH"] == model_path
         assert env["NIM_PERFORMANCE_MODE"] == "1"
         assert env["NIM_ENGINE_COUNT"] == "1"
-        assert env["NIM_PIPELINE_MAX_BATCH_SIZE"] == "1"
+        assert "NIM_PIPELINE_MAX_BATCH_SIZE" not in env
         assert "NIM_TRITON_MAX_BATCH_SIZE" not in env
 
     ocr_env = {

--- a/nemo_retriever/tests/test_helm_tracing_zipkin.py
+++ b/nemo_retriever/tests/test_helm_tracing_zipkin.py
@@ -775,7 +775,7 @@ def test_chart_wide_nim_otel_disable_omits_managed_env() -> None:
         assert chart_managed_names.isdisjoint(values)
 
     page_elements_values = _env_values(_nim_env(_find(docs, "NIMService", "nemotron-page-elements-v3")))
-    assert page_elements_values["NIM_PIPELINE_MAX_BATCH_SIZE"] == "1"
+    assert "NIM_PIPELINE_MAX_BATCH_SIZE" not in page_elements_values
 
 
 def test_per_nim_otel_endpoint_overrides_chart_endpoint() -> None:


### PR DESCRIPTION
## Description

Removes the explicit latency and single-item batch defaults from the page-elements, table-structure, and OCR NIM Helm environments. This lets the NIM images select their own batch defaults, matching patch tag 26.08.2.

Validation: helm lint nemo_retriever/helm; helm template nemo-retriever nemo_retriever/helm --api-versions apps.nvidia.com/v1alpha1 --set serviceConfig.vectordb.enabled=false.

Documentation is tracked separately in #2634.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. Documentation is addressed in #2634.