### PR TITLE
fix(service): return complete result payloads

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -346,6 +346,38 @@ service = create_ingestor(run_mode="service", base_url="http://localhost:7670")
 
 Service-only methods include `split()`, `pdf_split_config()`, `save_to_disk()`, `ingest_stream()`, `aingest_stream()`, and `cancel()`. `cancel()` is part of the public class. It currently raises `NotImplementedError` because the service does not expose a cancel endpoint.
 
+#### Choose a service result schema { #service-result-schema }
+
+`ServiceIngestor.ingest()` returns result rows in the `legacy` schema by
+default. You can pass `result_schema="compact"` to use the compact schema.
+The schemas return text and embeddings as follows.
+
+| Schema | Text | Embeddings |
+| --- | --- | --- |
+| `legacy` | The `text` and `content` columns preserve their complete strings. Other values continue to use transport sanitization. | Pass `return_embeddings=True` to preserve embedding payloads in their legacy columns and nested fields. |
+| `compact` | The top-level `text` field preserves the complete extracted text. | Pass `return_embeddings=True` to add a top-level `embedding` field when the source row contains an embedding. |
+
+The default `return_embeddings=False` omits the top-level `embedding` field
+from compact rows. This default keeps the compact response shape and payload
+size unchanged. Raw image payloads remain available only in legacy rows when
+you pass `return_images=True`.
+
+The following example requests compact rows with their embeddings.
+
+```python
+from nemo_retriever import create_ingestor
+
+result = (
+    create_ingestor(run_mode="service", base_url="http://localhost:7670")
+    .texts(["Text to embed and return."])
+    .embed()
+    .ingest(result_schema="compact", return_embeddings=True)
+)
+
+for row in result.dataframe.to_dict(orient="records"):
+    print(row["text"], row.get("embedding"))
+```
+
 ::: nemo_retriever.service.service_ingestor.ServiceIngestor
     options:
       heading_level: 4

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -359,8 +359,10 @@ The schemas return text and embeddings as follows.
 
 The default `return_embeddings=False` omits the top-level `embedding` field
 from compact rows. This default keeps the compact response shape and payload
-size unchanged. Raw image payloads remain available only in legacy rows when
-you pass `return_images=True`.
+size unchanged. When you configure `EmbedParams.output_column`, compact rows
+read the embedding from that column and normalize it to the top-level
+`embedding` field. Raw image payloads remain available only in legacy rows
+when you pass `return_images=True`.
 
 The following example requests compact rows with their embeddings.
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -354,8 +354,13 @@ The schemas return text and embeddings as follows.
 
 | Schema | Text | Embeddings |
 | --- | --- | --- |
-| `legacy` | The `text` and `content` columns preserve their complete strings. Other values continue to use transport sanitization. | Pass `return_embeddings=True` to preserve embedding payloads in their legacy columns and nested fields. |
+| `legacy` | Ordinary string values are not truncated. | Pass `return_embeddings=True` to preserve embedding payloads in their legacy columns and nested fields. |
 | `compact` | The top-level `text` field preserves the complete extracted text. | Pass `return_embeddings=True` to add a top-level `embedding` field when the source row contains an embedding. |
+
+For legacy rows, the service preserves extracted text and string-valued
+metadata in full, including returned strings nested in table, chart,
+infographic, and image results. Raw images and embeddings remain opt-in.
+Arrays, binary values, and oversized non-text collections remain summarized.
 
 The default `return_embeddings=False` omits the top-level `embedding` field
 from compact rows. This default keeps the compact response shape and payload

--- a/nemo_retriever/src/nemo_retriever/common/schemas/pipeline_spec.py
+++ b/nemo_retriever/src/nemo_retriever/common/schemas/pipeline_spec.py
@@ -92,7 +92,7 @@ class PipelineSpec(RichModel):
     )
     return_embeddings: bool = Field(
         default=False,
-        description="Include embedding payload values in legacy transport rows.",
+        description="Include embedding payload values in transport rows.",
     )
     return_images: bool = Field(
         default=False,

--- a/nemo_retriever/src/nemo_retriever/ingestor/results.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/results.py
@@ -336,6 +336,11 @@ def _extract_embedding(row: dict[str, Any], metadata: dict[str, Any]) -> Any:
     if embedding is None:
         payload = row.get("text_embeddings_1b_v2")
         embedding = payload.get("embedding") if isinstance(payload, dict) else payload
+    if embedding is None:
+        for payload in row.values():
+            if isinstance(payload, dict) and payload.get("embedding") is not None:
+                embedding = payload["embedding"]
+                break
     if _is_missing(embedding):
         return None
     return _sanitize_returned_payload(embedding)
@@ -355,7 +360,20 @@ def _compact_error(value: Any) -> Any:
 
 
 def compact_result_record(row: dict[str, Any], *, return_embeddings: bool = False) -> dict[str, Any]:
-    """Project a full pipeline row into the compact public result shape."""
+    """Project a full pipeline row into the compact public result shape.
+
+    Parameters
+    ----------
+    row
+        Full pipeline result row to project.
+    return_embeddings
+        Include a normalized top-level embedding when the row contains one.
+
+    Returns
+    -------
+    dict[str, Any]
+        Compact public result record.
+    """
     metadata = _mapping(row.get("metadata"))
     element_type = _extract_element_type(row, metadata)
     start, end = _extract_time_bounds(row, metadata)

--- a/nemo_retriever/src/nemo_retriever/ingestor/results.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/results.py
@@ -20,6 +20,7 @@ import numpy as np
 
 ResultSchema = Literal["legacy", "compact"]
 
+_DEFAULT_EMBEDDING_COLUMN = "text_embeddings_1b_v2"
 _MAX_STR_LEN = 500
 _TEXT_FIELD_NAMES = frozenset({"text", "content"})
 _RAW_IMAGE_FIELD_NAMES = frozenset({"image_b64", "_image_b64"})
@@ -331,16 +332,11 @@ def _extract_stored_image_uri(row: dict[str, Any]) -> str | None:
     return _first_str(row.get("_stored_image_uri"), row.get("stored_image_uri"), page_uri)
 
 
-def _extract_embedding(row: dict[str, Any], metadata: dict[str, Any]) -> Any:
-    embedding = metadata.get("embedding")
+def _extract_embedding(row: dict[str, Any], metadata: dict[str, Any], *, embedding_column: str) -> Any:
+    payload = row.get(embedding_column)
+    embedding = payload.get("embedding") if isinstance(payload, dict) else payload
     if embedding is None:
-        payload = row.get("text_embeddings_1b_v2")
-        embedding = payload.get("embedding") if isinstance(payload, dict) else payload
-    if embedding is None:
-        for payload in row.values():
-            if isinstance(payload, dict) and payload.get("embedding") is not None:
-                embedding = payload["embedding"]
-                break
+        embedding = metadata.get("embedding")
     if _is_missing(embedding):
         return None
     return _sanitize_returned_payload(embedding)
@@ -359,7 +355,12 @@ def _compact_error(value: Any) -> Any:
     return sanitize_cell_value(value)
 
 
-def compact_result_record(row: dict[str, Any], *, return_embeddings: bool = False) -> dict[str, Any]:
+def compact_result_record(
+    row: dict[str, Any],
+    *,
+    return_embeddings: bool = False,
+    embedding_column: str = _DEFAULT_EMBEDDING_COLUMN,
+) -> dict[str, Any]:
     """Project a full pipeline row into the compact public result shape.
 
     Parameters
@@ -368,6 +369,8 @@ def compact_result_record(row: dict[str, Any], *, return_embeddings: bool = Fals
         Full pipeline result row to project.
     return_embeddings
         Include a normalized top-level embedding when the row contains one.
+    embedding_column
+        Pipeline result column containing the embedding payload.
 
     Returns
     -------
@@ -403,7 +406,7 @@ def compact_result_record(row: dict[str, Any], *, return_embeddings: bool = Fals
         record["stored_image_uri"] = stored_image_uri
 
     if return_embeddings:
-        embedding = _extract_embedding(row, metadata)
+        embedding = _extract_embedding(row, metadata, embedding_column=embedding_column)
         if embedding is not None:
             record["embedding"] = embedding
 
@@ -420,6 +423,7 @@ def dataframe_to_transport_records(
     result_schema: ResultSchema = "legacy",
     return_embeddings: bool = False,
     return_images: bool = False,
+    embedding_column: str | None = None,
 ) -> list[dict[str, Any]]:
     """Serialize a pipeline DataFrame to JSON-safe row dicts.
 
@@ -440,7 +444,14 @@ def dataframe_to_transport_records(
         raise TypeError(f"expected pandas.DataFrame, got {type(df).__name__}")
     records = df.to_dict(orient="records")
     if result_schema == "compact":
-        return [compact_result_record(row, return_embeddings=return_embeddings) for row in records]
+        return [
+            compact_result_record(
+                row,
+                return_embeddings=return_embeddings,
+                embedding_column=embedding_column or _DEFAULT_EMBEDDING_COLUMN,
+            )
+            for row in records
+        ]
     return [
         {
             k: _sanitize_result_value(

--- a/nemo_retriever/src/nemo_retriever/ingestor/results.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/results.py
@@ -21,6 +21,7 @@ import numpy as np
 ResultSchema = Literal["legacy", "compact"]
 
 _MAX_STR_LEN = 500
+_TEXT_FIELD_NAMES = frozenset({"text", "content"})
 _RAW_IMAGE_FIELD_NAMES = frozenset({"image_b64", "_image_b64"})
 _EMBEDDING_FIELD_NAMES = frozenset({"embedding", "embeddings"})
 _EMBEDDING_PAYLOAD_COLUMNS = frozenset({"text_embeddings_1b_v2"})
@@ -127,6 +128,8 @@ def _sanitize_result_value(
     them in service results dominates memory use. Keep the surrounding
     keys/columns stable and null only the bulky payload values.
     """
+    if key in _TEXT_FIELD_NAMES and isinstance(val, str):
+        return val
     if key in _RAW_IMAGE_FIELD_NAMES:
         return _sanitize_returned_payload(val) if return_images else None
     if key in _EMBEDDING_FIELD_NAMES:
@@ -328,6 +331,16 @@ def _extract_stored_image_uri(row: dict[str, Any]) -> str | None:
     return _first_str(row.get("_stored_image_uri"), row.get("stored_image_uri"), page_uri)
 
 
+def _extract_embedding(row: dict[str, Any], metadata: dict[str, Any]) -> Any:
+    embedding = metadata.get("embedding")
+    if embedding is None:
+        payload = row.get("text_embeddings_1b_v2")
+        embedding = payload.get("embedding") if isinstance(payload, dict) else payload
+    if _is_missing(embedding):
+        return None
+    return _sanitize_returned_payload(embedding)
+
+
 def _compact_error(value: Any) -> Any:
     if _is_missing(value):
         return None
@@ -341,7 +354,7 @@ def _compact_error(value: Any) -> Any:
     return sanitize_cell_value(value)
 
 
-def compact_result_record(row: dict[str, Any]) -> dict[str, Any]:
+def compact_result_record(row: dict[str, Any], *, return_embeddings: bool = False) -> dict[str, Any]:
     """Project a full pipeline row into the compact public result shape."""
     metadata = _mapping(row.get("metadata"))
     element_type = _extract_element_type(row, metadata)
@@ -371,6 +384,11 @@ def compact_result_record(row: dict[str, Any]) -> dict[str, Any]:
     if stored_image_uri is not None:
         record["stored_image_uri"] = stored_image_uri
 
+    if return_embeddings:
+        embedding = _extract_embedding(row, metadata)
+        if embedding is not None:
+            record["embedding"] = embedding
+
     error = _compact_error(row.get("error") if "error" in row else metadata.get("error"))
     if error is not None:
         record["error"] = error
@@ -393,7 +411,8 @@ def dataframe_to_transport_records(
 
     ``result_schema="compact"`` returns the future compact public schema:
     extracted text, source provenance, element type, page number or media
-    timings, optional stored-image URIs, and optional errors.
+    timings, optional stored-image URIs, optional embeddings, and optional
+    errors.
     """
     import pandas as pd
 
@@ -403,7 +422,7 @@ def dataframe_to_transport_records(
         raise TypeError(f"expected pandas.DataFrame, got {type(df).__name__}")
     records = df.to_dict(orient="records")
     if result_schema == "compact":
-        return [compact_result_record(row) for row in records]
+        return [compact_result_record(row, return_embeddings=return_embeddings) for row in records]
     return [
         {
             k: _sanitize_result_value(

--- a/nemo_retriever/src/nemo_retriever/ingestor/results.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/results.py
@@ -22,7 +22,7 @@ ResultSchema = Literal["legacy", "compact"]
 
 _DEFAULT_EMBEDDING_COLUMN = "text_embeddings_1b_v2"
 _MAX_STR_LEN = 500
-_TEXT_FIELD_NAMES = frozenset({"text", "content"})
+_TEXT_FIELD_NAMES = frozenset({"caption", "content", "text"})
 _RAW_IMAGE_FIELD_NAMES = frozenset({"image_b64", "_image_b64"})
 _EMBEDDING_FIELD_NAMES = frozenset({"embedding", "embeddings"})
 _EMBEDDING_PAYLOAD_COLUMNS = frozenset({"text_embeddings_1b_v2"})
@@ -115,6 +115,17 @@ def _contains_requested_payload(val: Any, *, return_embeddings: bool, return_ima
     return False
 
 
+def _contains_full_text(val: Any) -> bool:
+    if isinstance(val, dict):
+        return any(
+            (str(key) in _TEXT_FIELD_NAMES and isinstance(nested, str)) or _contains_full_text(nested)
+            for key, nested in val.items()
+        )
+    if isinstance(val, (list, tuple)):
+        return any(_contains_full_text(item) for item in val)
+    return False
+
+
 def _sanitize_result_value(
     key: str,
     val: Any,
@@ -129,8 +140,6 @@ def _sanitize_result_value(
     them in service results dominates memory use. Keep the surrounding
     keys/columns stable and null only the bulky payload values.
     """
-    if key in _TEXT_FIELD_NAMES and isinstance(val, str):
-        return val
     if key in _RAW_IMAGE_FIELD_NAMES:
         return _sanitize_returned_payload(val) if return_images else None
     if key in _EMBEDDING_FIELD_NAMES:
@@ -139,6 +148,8 @@ def _sanitize_result_value(
         return None
     if key in _EMBEDDING_PAYLOAD_COLUMNS and not isinstance(val, dict):
         return _sanitize_returned_payload(val)
+    if isinstance(val, str):
+        return val
     if isinstance(val, dict):
         return {
             str(k): _sanitize_result_value(
@@ -159,7 +170,9 @@ def _sanitize_result_value(
             )
             for item in val
         ]
-        if _contains_requested_payload(val, return_embeddings=return_embeddings, return_images=return_images):
+        if _contains_full_text(val) or _contains_requested_payload(
+            val, return_embeddings=return_embeddings, return_images=return_images
+        ):
             return sanitized
         return sanitize_cell_value(sanitized)
     if isinstance(val, tuple):
@@ -172,7 +185,9 @@ def _sanitize_result_value(
             )
             for item in val
         ]
-        if _contains_requested_payload(val, return_embeddings=return_embeddings, return_images=return_images):
+        if _contains_full_text(val) or _contains_requested_payload(
+            val, return_embeddings=return_embeddings, return_images=return_images
+        ):
             return sanitized
         return sanitize_cell_value(sanitized)
     return sanitize_cell_value(val)
@@ -427,9 +442,10 @@ def dataframe_to_transport_records(
 ) -> list[dict[str, Any]]:
     """Serialize a pipeline DataFrame to JSON-safe row dicts.
 
-    ``result_schema="legacy"`` retains all columns so the reconstructed
-    frame matches ``GraphIngestor.ingest()`` output; by default raw image
-    and embedding payload values are nulled before transport.
+    ``result_schema="legacy"`` retains all columns and complete string
+    values so the reconstructed frame matches ``GraphIngestor.ingest()``
+    output; by default raw image and embedding payload values are nulled
+    before transport.
 
     ``result_schema="compact"`` returns the future compact public schema:
     extracted text, source provenance, element type, page number or media

--- a/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
@@ -160,8 +160,8 @@ class ServiceIngestResult(list):
         ``GET /v1/ingest/status/{document_id}``, concatenated in upload
         order. The current default ``result_schema="legacy"`` preserves
         the same column layout as ``GraphIngestor.ingest()`` in
-        ``inprocess`` / ``batch`` run modes, with bulky raw image and
-        embedding values stripped from cells before transport. Pass
+        ``inprocess`` / ``batch`` run modes. It preserves full text and strips
+        bulky raw image and embedding values from cells before transport. Pass
         ``result_schema="compact"`` to opt into the future compact schema.
         ``None`` when ``return_results=False``.
     """
@@ -1166,10 +1166,13 @@ class ServiceIngestor(ingestor):
             DataFrame column layout with bulky values stripped and emits
             a deprecation warning when result rows are retained.
             ``"compact"`` opts into the future compact row schema.
-        return_embeddings, return_images
-            When using legacy result rows, include embedding vectors and
-            raw image payloads instead of stripping them from transport
-            cells. Defaults remain ``False`` to avoid large responses.
+        return_embeddings
+            Include embedding vectors in legacy or compact result rows.
+            Defaults to ``False`` to avoid large responses.
+        return_images
+            When using legacy result rows, include raw image payloads instead
+            of stripping them from transport cells. Defaults to ``False`` to
+            avoid large responses.
 
         Returns
         -------

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -96,6 +96,7 @@ def _sanitize_result_data(
     result_schema: str = "legacy",
     return_embeddings: bool = False,
     return_images: bool = False,
+    embedding_column: str | None = None,
 ) -> list[dict[str, Any]]:
     """Convert a pipeline DataFrame to JSON-safe dicts for the status API.
 
@@ -109,6 +110,7 @@ def _sanitize_result_data(
         df,
         result_schema=result_schema,
         return_embeddings=return_embeddings,
+        embedding_column=embedding_column,
         return_images=return_images,
     )
 
@@ -786,6 +788,8 @@ def _run_pipeline_in_process(
                 caption_params_dict,
                 asr_params_dict,
             )
+            effective_embed_params = getattr(ingestor, "_embed_params", None)
+            embedding_column = getattr(effective_embed_params, "output_column", None)
 
             result_df = ingestor.ingest()
             _merge_document_metadata(
@@ -833,6 +837,7 @@ def _run_pipeline_in_process(
         result_df,
         result_schema=result_schema,
         return_embeddings=bool(result_options.get("return_embeddings", False)),
+        embedding_column=embedding_column,
         return_images=bool(result_options.get("return_images", False)),
     )
     return row_count, result_data, elapsed

--- a/nemo_retriever/tests/test_ingest_results.py
+++ b/nemo_retriever/tests/test_ingest_results.py
@@ -69,6 +69,24 @@ def test_transport_can_return_legacy_bulk_payloads_when_requested() -> None:
     assert record["metadata"] == {"embedding": embedding}
 
 
+def test_transport_preserves_full_legacy_text_and_content() -> None:
+    long_text = "text " * 200
+    long_content = "content " * 100
+    long_incidental_value = "x" * 600
+    df = pd.DataFrame(
+        {
+            "text": [long_text],
+            "metadata": [{"content": long_content, "note": long_incidental_value}],
+        }
+    )
+
+    record = dataframe_to_transport_records(df)[0]
+
+    assert record["text"] == long_text
+    assert record["metadata"]["content"] == long_content
+    assert record["metadata"]["note"] == long_incidental_value[:500] + "…[600 chars total]"
+
+
 def test_transport_summarizes_long_lists_after_nested_sanitization() -> None:
     rows = [{"image_b64": f"raw-{idx}", "label": "image"} for idx in range(21)]
     df = pd.DataFrame({"path": ["/a.pdf"], "images": [rows]})
@@ -146,6 +164,40 @@ def test_transport_compact_media_rows_return_timings() -> None:
     ]
 
 
+def test_transport_compact_rows_return_metadata_embedding_when_requested() -> None:
+    embedding = __import__("numpy").array([0.1, 0.2])
+    df = pd.DataFrame(
+        {
+            "path": ["/a.pdf"],
+            "text": ["hello"],
+            "metadata": [{"embedding": embedding}],
+        }
+    )
+
+    assert dataframe_to_transport_records(df, result_schema="compact", return_embeddings=True) == [
+        {
+            "text": "hello",
+            "source_id": "/a.pdf",
+            "element_type": "text",
+            "embedding": [0.1, 0.2],
+        }
+    ]
+
+
+def test_transport_compact_rows_return_payload_embedding_when_requested() -> None:
+    df = pd.DataFrame(
+        {
+            "path": ["/a.pdf"],
+            "text": ["hello"],
+            "text_embeddings_1b_v2": [{"embedding": (0.3, 0.4)}],
+        }
+    )
+
+    record = dataframe_to_transport_records(df, result_schema="compact", return_embeddings=True)[0]
+
+    assert record["embedding"] == [0.3, 0.4]
+
+
 def test_round_trip_matches_inprocess_column_layout() -> None:
     df = pd.DataFrame(
         {
@@ -171,6 +223,16 @@ def test_sanitize_result_data_accepts_compact_schema() -> None:
     assert _sanitize_result_data(df, result_schema="compact") == dataframe_to_transport_records(
         df,
         result_schema="compact",
+    )
+
+
+def test_sanitize_result_data_forwards_compact_embedding_flag() -> None:
+    df = pd.DataFrame({"text": ["x"], "metadata": [{"embedding": [0.1]}]})
+
+    assert _sanitize_result_data(df, result_schema="compact", return_embeddings=True) == dataframe_to_transport_records(
+        df,
+        result_schema="compact",
+        return_embeddings=True,
     )
 
 

--- a/nemo_retriever/tests/test_ingest_results.py
+++ b/nemo_retriever/tests/test_ingest_results.py
@@ -203,11 +203,14 @@ def test_transport_compact_rows_return_configured_column_embedding_when_requeste
         {
             "path": ["/a.pdf"],
             "text": ["hello"],
+            "earlier_payload": [{"embedding": [9.0, 9.0]}],
             "custom_embeddings": [{"embedding": [0.5, 0.6]}],
         }
     )
 
-    record = dataframe_to_transport_records(df, result_schema="compact", return_embeddings=True)[0]
+    record = dataframe_to_transport_records(
+        df, result_schema="compact", return_embeddings=True, embedding_column="custom_embeddings"
+    )[0]
 
     assert record["embedding"] == [0.5, 0.6]
 
@@ -241,12 +244,18 @@ def test_sanitize_result_data_accepts_compact_schema() -> None:
 
 
 def test_sanitize_result_data_forwards_compact_embedding_flag() -> None:
-    df = pd.DataFrame({"text": ["x"], "metadata": [{"embedding": [0.1]}]})
+    df = pd.DataFrame(
+        {
+            "text": ["x"],
+            "earlier_payload": [{"embedding": [9.0]}],
+            "custom_embeddings": [{"embedding": [0.1]}],
+        }
+    )
 
-    assert _sanitize_result_data(df, result_schema="compact", return_embeddings=True) == dataframe_to_transport_records(
-        df,
-        result_schema="compact",
-        return_embeddings=True,
+    assert _sanitize_result_data(
+        df, result_schema="compact", return_embeddings=True, embedding_column="custom_embeddings"
+    ) == dataframe_to_transport_records(
+        df, result_schema="compact", return_embeddings=True, embedding_column="custom_embeddings"
     )
 
 

--- a/nemo_retriever/tests/test_ingest_results.py
+++ b/nemo_retriever/tests/test_ingest_results.py
@@ -69,7 +69,7 @@ def test_transport_can_return_legacy_bulk_payloads_when_requested() -> None:
     assert record["metadata"] == {"embedding": embedding}
 
 
-def test_transport_preserves_full_legacy_text_and_content() -> None:
+def test_transport_preserves_all_legacy_string_values() -> None:
     long_text = "text " * 200
     long_content = "content " * 100
     long_incidental_value = "x" * 600
@@ -84,7 +84,68 @@ def test_transport_preserves_full_legacy_text_and_content() -> None:
 
     assert record["text"] == long_text
     assert record["metadata"]["content"] == long_content
-    assert record["metadata"]["note"] == long_incidental_value[:500] + "…[600 chars total]"
+    assert record["metadata"]["note"] == long_incidental_value
+
+
+def test_transport_preserves_text_across_element_types() -> None:
+    long_text = "element text " * 100
+    element_types = (
+        "text",
+        "table",
+        "table_caption",
+        "chart",
+        "chart_caption",
+        "infographic",
+        "infographic_caption",
+        "images",
+        "image_caption",
+        "audio",
+        "video",
+        "video_frame",
+    )
+    df = pd.DataFrame(
+        {
+            "text": [long_text] * len(element_types),
+            "_content_type": list(element_types),
+            "custom_embeddings": [{"embedding": [float(index)]} for index in range(len(element_types))],
+        }
+    )
+
+    legacy_records = dataframe_to_transport_records(df)
+    compact_records = dataframe_to_transport_records(
+        df,
+        result_schema="compact",
+        return_embeddings=True,
+        embedding_column="custom_embeddings",
+    )
+
+    assert all(record["text"] == long_text for record in legacy_records)
+    assert all(record["text"] == long_text for record in compact_records)
+    assert [record["embedding"] for record in compact_records] == [
+        [float(index)] for index in range(len(element_types))
+    ]
+
+
+def test_transport_preserves_long_nested_structured_text_collections() -> None:
+    long_text = "nested text " * 100
+    content_columns = ("table", "chart", "infographic", "images")
+    items = [
+        {
+            "text": long_text,
+            "caption": long_text,
+            "image_b64": "raw-image",
+        }
+        for _ in range(21)
+    ]
+    df = pd.DataFrame({column: [items] for column in content_columns})
+
+    record = dataframe_to_transport_records(df)[0]
+
+    for column in content_columns:
+        assert len(record[column]) == 21
+        assert record[column][0]["text"] == long_text
+        assert record[column][0]["caption"] == long_text
+        assert record[column][0]["image_b64"] is None
 
 
 def test_transport_summarizes_long_lists_after_nested_sanitization() -> None:

--- a/nemo_retriever/tests/test_ingest_results.py
+++ b/nemo_retriever/tests/test_ingest_results.py
@@ -198,6 +198,20 @@ def test_transport_compact_rows_return_payload_embedding_when_requested() -> Non
     assert record["embedding"] == [0.3, 0.4]
 
 
+def test_transport_compact_rows_return_configured_column_embedding_when_requested() -> None:
+    df = pd.DataFrame(
+        {
+            "path": ["/a.pdf"],
+            "text": ["hello"],
+            "custom_embeddings": [{"embedding": [0.5, 0.6]}],
+        }
+    )
+
+    record = dataframe_to_transport_records(df, result_schema="compact", return_embeddings=True)[0]
+
+    assert record["embedding"] == [0.5, 0.6]
+
+
 def test_round_trip_matches_inprocess_column_layout() -> None:
     df = pd.DataFrame(
         {

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -831,6 +831,40 @@ def test_run_pipeline_in_process_preserves_service_inline_identity(monkeypatch: 
     assert rows[0]["metadata"]["source_path"] == "inline://00000003"
 
 
+def test_run_pipeline_in_process_uses_effective_embedding_output_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pandas as pd
+
+    class _Ingestor:
+        _embed_params = EmbedParams(model_name="embed-model", output_column="custom_embeddings")
+
+        def ingest(self):
+            return pd.DataFrame(
+                {
+                    "text": ["hello"],
+                    "earlier_payload": [{"embedding": [9.0]}],
+                    "custom_embeddings": [{"embedding": [0.1]}],
+                }
+            )
+
+    monkeypatch.setattr(
+        "nemo_retriever.service.services.pipeline_executor._build_graph_ingestor_from_spec",
+        lambda *_args, **_kwargs: (_Ingestor(), "pdf", False),
+    )
+
+    row_count, rows, _ = _run_pipeline_in_process(
+        "document.pdf",
+        b"%PDF-1.4 stub",
+        {},
+        None,
+        pipeline_spec={"result_schema": "compact", "return_embeddings": True},
+    )
+
+    assert row_count == 1
+    assert rows[0]["embedding"] == [0.1]
+
+
 def test_build_graph_ingestor_omits_asr_params_when_worker_unconfigured() -> None:
     """When the worker has no ASR endpoint, nothing should be attached
     regardless of filename or extraction mode.


### PR DESCRIPTION
## Description

- Preserve complete `text` and `content` strings in legacy service result rows while retaining transport sanitization for incidental values.
- Honor `return_embeddings=True` for compact result rows by returning a normalized top-level `embedding` field.
- Document the service result schema behavior and add regression coverage for both embedding storage shapes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation
- `pre-commit run --all-files`
- `pytest nemo_retriever/tests/test_ingest_results.py nemo_retriever/tests/test_service_pipeline_spec.py nemo_retriever/tests/test_service_ingest_async.py -q` (136 passed)