### PR TITLE
Add BO767 text-only run config for Helm chart 26.08.2

### DIFF
--- a/nemo_retriever/harness/examples/managed-helm-bo767-vl-text-26.08.2.yaml
+++ b/nemo_retriever/harness/examples/managed-helm-bo767-vl-text-26.08.2.yaml
@@ -1,0 +1,38 @@
+# Managed Helm target for the BO767 VL text-only hybrid qualification run.
+# Before running, add the authenticated staging Helm repository:
+#   sudo microk8s helm repo add nvstaging https://helm.ngc.nvidia.com/nvstaging/nim \
+#     --username '$oauthtoken' --password "$NGC_API_KEY"
+# The target namespace must already contain `ngc-secret` (nvcr.io pull secret)
+# and `ngc-api` (opaque NGC API-key secret). Keep credentials out of this file.
+helm_chart: nvstaging/nemo-retriever
+helm_chart_version: "26.08.2"
+service_image_repository: nvcr.io/nvidia/nemo-microservices/nrl-service
+service_image_tag: "26.08.1"
+helm_release: nemo-retriever-bo767-vl-text-2608
+helm_namespace: nemo-retriever-bo767-vl-text-2608
+helm_values_file: ../helm-profiles/core.yaml
+helm_timeout: 1800
+readiness_timeout: 1800
+helm_service_local_port: 17670
+helm_bin: microk8s helm
+kubectl_bin: microk8s kubectl
+helm_sudo: true
+kubectl_sudo: true
+helm_set:
+  ngcImagePullSecret.create: false
+  ngcImagePullSecret.name: ngc-secret
+  ngcApiSecret.create: false
+  ngcApiSecret.name: ngc-api
+  serviceConfig.vectordb.embedModel: nvidia/llama-nemotron-embed-vl-1b-v2
+  serviceConfig.vectordb.indexMode: hybrid
+  serviceConfig.vectordb.tableName: bo767_vl_text_hybrid_2608
+  nimOperator.vlm_embed.image.repository: nvcr.io/nvstaging/nim/retriever-photon-embed
+  nimOperator.vlm_embed.image.tag: 2.4.0-rc.20260904025509-66b9cd5b57d8e207
+  # Replaces the chart default list, deliberately omitting NIM_ENGINE_PRECISION.
+  nimOperator.vlm_embed.env:
+    - name: NIM_HTTP_API_PORT
+      value: "8000"
+    - name: NIM_TRITON_LOG_VERBOSE
+      value: "1"
+    - name: OMP_NUM_THREADS
+      value: "1"

--- a/nemo_retriever/harness/runfiles/bo767_vl_text_hybrid_beir_service.json
+++ b/nemo_retriever/harness/runfiles/bo767_vl_text_hybrid_beir_service.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "name": "bo767_vl_text_hybrid_beir_service",
+  "benchmark": "bo767_beir",
+  "mode": "service",
+  "require": [
+    "files==767",
+    "pages==54730",
+    "query_count==991"
+  ],
+  "set": {
+    "ingest.embed.embed_modality": "text",
+    "ingest.embed.embed_granularity": "element",
+    "query.retrieval_mode": "auto"
+  }
+}


### PR DESCRIPTION
## Description

Adds a managed Helm target and service-mode runfile for the BO767 qualification run using Helm chart `26.08.2` and text-only modality for VL embedding inference.

The managed target pins NRL service image `26.08.1` and the staged Photon VL embed image, configures hybrid retrieval, and replaces the chart default VL embed environment list without `NIM_ENGINE_PRECISION`. The runfile sets `ingest.embed.embed_modality: text` and validates the expected BO767 file, page, and query counts.

The environment-specific dataset-path mapping is intentionally excluded.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

Validation: `uv run --project nemo_retriever pytest nemo_retriever/tests/test_harness_benchmark_registry.py nemo_retriever/tests/test_harness_helm_cli.py -q` — 27 passed.