### PR TITLE
test(docs): support relocated vector database page

### DIFF
--- a/nemo_retriever/tests/test_src_documentation_snippets.py
+++ b/nemo_retriever/tests/test_src_documentation_snippets.py
@@ -52,7 +52,7 @@ def _iter_markdown_python_blocks() -> list[tuple[str, str]]:
 _MD_BLOCKS = _iter_markdown_python_blocks()
 _PUBLIC_RETRIEVER_DOCS = (
     "README.md",
-    "docs/docs/extraction/vdbs.md",
+    "docs/docs/extraction/collections/vdbs.md",
     "examples/building_vdb_operator.ipynb",
     "examples/nemo_retriever_retriever_query_metadata_filter.ipynb",
     "nemo_retriever/README.md",
@@ -61,6 +61,9 @@ _PUBLIC_RETRIEVER_DOCS = (
     "nemo_retriever/src/nemo_retriever/tools/evaluation/README.md",
     "nemo_retriever/src/nemo_retriever/common/vdb/README.md",
 )
+_PUBLIC_DOC_LEGACY_PATHS = {
+    "docs/docs/extraction/collections/vdbs.md": "docs/docs/extraction/vdbs.md",
+}
 _UNSUPPORTED_DIRECT_RETRIEVER_KWARGS = frozenset(
     {
         "vdb",
@@ -78,6 +81,9 @@ def _public_doc_path(root: Path, rel_path: str) -> Path | None:
     path = root / rel_path
     if path.exists():
         return path
+    legacy_path = _PUBLIC_DOC_LEGACY_PATHS.get(rel_path)
+    if legacy_path is not None and (root / legacy_path).exists():
+        return root / legacy_path
     repo_only_doc = rel_path == "README.md" or rel_path.startswith(("docs/", "examples/"))
     package_only_image = not (root / "README.md").exists() and not (root / "docs").exists()
     if repo_only_doc and package_only_image:


### PR DESCRIPTION
## Summary

- Track the template-aligned vector database documentation path introduced by #2629.
- Fall back to the current path so this test fix can merge before the documentation move.

## Validation

- `uv run --project nemo_retriever --no-default-groups --extra dev pytest nemo_retriever/tests/test_src_documentation_snippets.py::test_public_retriever_examples_do_not_use_unsupported_constructor_kwargs -q`: 1 passed.
- Commit hooks passed.

## Relationship

This independently mergeable test fix unblocks #2629 without adding test changes to that docs-only PR.