### PR TITLE
fix(executor): partition grouped global batches

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -198,6 +198,18 @@ def _concurrency_target(concurrency: Any) -> int:
     return int(concurrency)
 
 
+def _repartition_global_batch(dataset: Any, group_keys: list[str], concurrency: Any) -> Any:
+    """Repartition a global-batch stage without coalescing independent groups."""
+    if not group_keys:
+        return dataset.repartition(num_blocks=1)
+
+    # Hash partitioning keeps each group together. Retaining at least the
+    # current block count prevents a single-worker actor pool from collapsing
+    # unrelated groups into one potentially oversized Arrow block.
+    num_blocks = max(1, int(dataset.num_blocks()), _concurrency_target(concurrency))
+    return dataset.repartition(num_blocks=num_blocks, keys=group_keys, shuffle=True)
+
+
 def _concurrency_initial(concurrency: Any) -> int:
     """Return the number of actors Ray creates when the pool starts."""
     if isinstance(concurrency, tuple) and len(concurrency) == 3:
@@ -678,11 +690,7 @@ class RayDataExecutor(AbstractExecutor):
                 # concurrency > 1, hash-partition by those keys so rows sharing
                 # the keys stay co-located while blocks distribute across actors.
                 group_keys = list(getattr(node.operator_class, "GLOBAL_BATCH_GROUP_KEYS", None) or ())
-                n_blocks = max(1, int(overrides.get("concurrency") or 1)) if group_keys else 1
-                if n_blocks > 1:
-                    ds = ds.repartition(num_blocks=n_blocks, keys=group_keys, shuffle=True)
-                else:
-                    ds = ds.repartition(num_blocks=1)
+                ds = _repartition_global_batch(ds, group_keys, overrides.get("concurrency", 1))
             elif target_num_rows_per_block is not None and int(target_num_rows_per_block) > 0:
                 ds = ds.repartition(target_num_rows_per_block=int(target_num_rows_per_block))
 

--- a/nemo_retriever/tests/test_global_batch_partitioning.py
+++ b/nemo_retriever/tests/test_global_batch_partitioning.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_retriever.graph.executor import _repartition_global_batch
+
+
+class FakeDataset:
+    def __init__(self, num_blocks: int) -> None:
+        self._num_blocks = num_blocks
+        self.repartition_calls: list[dict] = []
+
+    def num_blocks(self) -> int:
+        return self._num_blocks
+
+    def repartition(self, **kwargs):
+        self.repartition_calls.append(kwargs)
+        return self
+
+
+def test_grouped_global_batch_keeps_existing_partition_count() -> None:
+    dataset = FakeDataset(478)
+    assert _repartition_global_batch(dataset, ["source_path"], 1) is dataset
+    assert dataset.repartition_calls == [
+        {"num_blocks": 478, "keys": ["source_path"], "shuffle": True}
+    ]
+
+
+def test_grouped_global_batch_can_expand_for_actor_concurrency() -> None:
+    dataset = FakeDataset(1)
+    _repartition_global_batch(dataset, ["source_path"], (1, 4, 1))
+    assert dataset.repartition_calls == [
+        {"num_blocks": 4, "keys": ["source_path"], "shuffle": True}
+    ]
+
+
+def test_ungrouped_global_batch_still_coalesces_to_one_block() -> None:
+    dataset = FakeDataset(478)
+    _repartition_global_batch(dataset, [], 8)
+    assert dataset.repartition_calls == [{"num_blocks": 1}]


### PR DESCRIPTION
## Summary

- keep grouped global-batch operators hash-partitioned even when actor concurrency is 1
- retain at least the dataset's existing block count so unrelated source groups are not coalesced into one oversized Arrow block
- preserve single-block behavior for truly ungrouped global-batch operators
- add regression coverage for existing block counts, actor-pool concurrency, and ungrouped stages

Fixes #2643

## Validation

- `python -m compileall -q nemo_retriever/src/nemo_retriever/graph/executor.py nemo_retriever/tests/test_global_batch_partitioning.py`
- `git diff --check`