### PR TITLE
fix(ci): align NVSkills workflow caller

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -3,11 +3,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -17,6 +20,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

- invoke the shared NVSkills workflow for pull request events
- grant the status permission required by the nested reusable workflow
- align the caller with the canonical workflow in NVIDIA/skills

## Validation

- `git diff --check`
- `PRE_COMMIT_HOME=/tmp/nemo-retriever-nvskills-pre-commit uvx pre-commit run --files .github/workflows/request-nvskills-ci.yml`
- confirmed that no published documentation update is required