### PR TITLE
feat(helm): add measured four-B200 BO767 profile

### DIFF
--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -344,6 +344,9 @@ hardware. They are not general performance guarantees.
 
 The target node must advertise two time-sliced `nvidia.com/gpu` resources per
 physical GPU and use the NVIDIA device plugin's `packed` allocation policy.
+Set `TARGET_NODE` to that node's `kubernetes.io/hostname` label. The commands
+below pass the target as a node selector for all four NIMs, which prevents
+Kubernetes from scheduling any replica on another eligible GPU node.
 The final placement must contain the following physical GPU pairs:
 
 | Physical GPU | NIM workloads |
@@ -364,10 +367,21 @@ structure are disabled:
 REL=retriever
 NS=nemo-retriever
 PROFILE=./nemo_retriever/helm/examples/values-b200-4gpu-bo767.yaml
+TARGET_NODE=b200-node-name
+NODE_SELECTOR_ARGS=(
+  "--set-string=nimOperator.page_elements.nodeSelector.kubernetes\\.io/hostname=${TARGET_NODE}"
+  "--set-string=nimOperator.table_structure.nodeSelector.kubernetes\\.io/hostname=${TARGET_NODE}"
+  "--set-string=nimOperator.ocr.nodeSelector.kubernetes\\.io/hostname=${TARGET_NODE}"
+  "--set-string=nimOperator.vlm_embed.nodeSelector.kubernetes\\.io/hostname=${TARGET_NODE}"
+)
+
+kubectl get node "${TARGET_NODE}" \
+  -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\\.com/gpu
 
 helm upgrade --install "${REL}" ./nemo_retriever/helm \
   -n "${NS}" --create-namespace \
   -f "${PROFILE}" \
+  "${NODE_SELECTOR_ARGS[@]}" \
   --set nimOperator.page_elements.enabled=false \
   --set nimOperator.table_structure.enabled=false \
   --set nimOperator.ocr.replicas=1 \
@@ -382,16 +396,35 @@ Add each subsequent embed replica before its matching OCR replica. Wait for
 each Deployment so the packed allocator fills the next physical GPU pair:
 
 ```bash
+set -euo pipefail
+
+wait_for_deployment_replicas() {
+  local deployment="$1"
+  local replicas="$2"
+  local generation
+
+  kubectl wait deployment/"${deployment}" -n "${NS}" \
+    --for=jsonpath='{.spec.replicas}'="${replicas}" --timeout=10m || return 1
+  generation="$(kubectl get deployment/"${deployment}" -n "${NS}" \
+    -o jsonpath='{.metadata.generation}')" || return 1
+  kubectl wait deployment/"${deployment}" -n "${NS}" \
+    --for=jsonpath='{.status.observedGeneration}'="${generation}" --timeout=10m || return 1
+  kubectl wait deployment/"${deployment}" -n "${NS}" \
+    --for=jsonpath='{.status.updatedReplicas}'="${replicas}" --timeout=10m || return 1
+  kubectl wait deployment/"${deployment}" -n "${NS}" \
+    --for=jsonpath='{.status.readyReplicas}'="${replicas}" --timeout=10m
+}
+
 for REPLICAS in 2 3; do
   kubectl patch nimservice llama-nemotron-embed-vl-1b-v2 -n "${NS}" \
     --type merge -p "{\"spec\":{\"replicas\":${REPLICAS}}}"
-  kubectl rollout status deployment/llama-nemotron-embed-vl-1b-v2 \
-    -n "${NS}" --timeout=10m
+  wait_for_deployment_replicas llama-nemotron-embed-vl-1b-v2 "${REPLICAS}" \
+    || exit 1
 
   kubectl patch nimservice nemotron-ocr-v2 -n "${NS}" \
     --type merge -p "{\"spec\":{\"replicas\":${REPLICAS}}}"
-  kubectl rollout status deployment/nemotron-ocr-v2 \
-    -n "${NS}" --timeout=10m
+  wait_for_deployment_replicas nemotron-ocr-v2 "${REPLICAS}" \
+    || exit 1
 done
 ```
 
@@ -399,7 +432,8 @@ Apply the final profile to enable page elements and table structure. Wait for
 the four NIMServices and the retriever service before sending traffic:
 
 ```bash
-helm upgrade "${REL}" ./nemo_retriever/helm -n "${NS}" -f "${PROFILE}"
+helm upgrade "${REL}" ./nemo_retriever/helm -n "${NS}" -f "${PROFILE}" \
+  "${NODE_SELECTOR_ARGS[@]}"
 
 kubectl wait -n "${NS}" --for=jsonpath='{.status.state}'=Ready \
   nimservice/llama-nemotron-embed-vl-1b-v2 \
@@ -423,6 +457,51 @@ for POD in $(kubectl get pods -n "${NS}" -o name | grep -E \
     nvidia-smi --query-gpu=uuid --format=csv,noheader
 done | sort -k2,2 -k1,1
 ```
+
+#### Reproduce the measured BO767 run
+
+The measured run used
+[`harness/runfiles/bo767_vl_text_hybrid_beir_service.json`](../harness/runfiles/bo767_vl_text_hybrid_beir_service.json).
+The runfile selects text embedding at element granularity and automatic
+retrieval. The resolved benchmark disables captioning, deduplication,
+chunking, page deduplication, and reranking. It queries the top 10 results and
+sets `overwrite=true`, which replaces the target table before ingestion.
+
+Create a dataset-paths file that points to the SSD copy of the corpus. The
+measured machine used the following file:
+
+```yaml
+schema_version: 1
+datasets:
+  bo767:
+    path: /raid/jperez/data/bo767
+    query_file: /raid/jperez/nemo_retriever/data/bo767_query_gt.csv
+```
+
+In one terminal, forward the deployed service port:
+
+```bash
+kubectl port-forward -n "${NS}" \
+  service/"${REL}"-nemo-retriever 17671:7670
+```
+
+From the repository root in another terminal, run the same harness command
+used for the measurement:
+
+```bash
+uv run --project nemo_retriever retriever-harness run-files \
+  --output-dir /raid/jperez/nemo_retriever_runs/bo767_scale_260801_embed3_ocr3_4gpu_balanced_batch8/results \
+  --session-name bo767_scale_260801_embed3_ocr3_4gpu_balanced_batch8 \
+  --mode service \
+  --service-endpoint http://localhost:17671 \
+  --dataset-paths /raid/jperez/nemo_retriever_runs/bo767_scale_260801_embed3_ocr3_4gpu_balanced_batch8/dataset_paths.yaml \
+  nemo_retriever/harness/runfiles/bo767_vl_text_hybrid_beir_service.json
+```
+
+The timed run started after the service and all four NIMServices were ready.
+The NIM containers and model caches were warm, but the corpus did not receive
+an untimed ingestion warmup pass. Use a new output directory and update the
+machine-local paths when you reproduce the run elsewhere.
 
 This profile targets BO767 PDF ingestion. `service.installFfmpeg` remains
 `false`. Enable FFmpeg separately for audio or video workflows.

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -54,6 +54,8 @@ nemo_retriever/helm/
 ├── README.md            <-- this file
 ├── openshift.md         <-- OpenShift restricted-v2 install guide
 ├── .helmignore
+├── examples/
+│   └── values-b200-4gpu-bo767.yaml       # measured four-B200 BO767 profile
 └── templates/
     ├── _helpers.tpl
     ├── NOTES.txt
@@ -325,6 +327,105 @@ if you manage ResourceClaims outside the chart.
 If `helm install` already succeeded and NIM pods stay `Pending` on
 `nvidia.com/gpu`, refer to
 [Core NIM pods stay Pending for GPU](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/troubleshoot.md#helm-pending-gpus).
+
+### Measured four-B200 BO767 profile { #measured-four-b200-bo767-profile }
+
+Use [`examples/values-b200-4gpu-bo767.yaml`](./examples/values-b200-4gpu-bo767.yaml)
+to reproduce the best four-physical-GPU BO767 configuration measured with the
+26.08.1 chart. The profile pins the tested service and NIM images. It deploys
+three embed replicas, three OCR replicas, one page-elements replica, and one
+table-structure replica. OCR and object-detection NIMs use a maximum pipeline
+batch size of `8`. The embed NIM uses FP16 precision.
+
+On four NVIDIA B200 GPUs, this configuration processed 54,730 BO767 pages at
+92.790 pages per second. Recall@5 was 0.860747, Recall@10 was 0.907164, and
+nDCG@10 was 0.755657. These measurements describe the tested workload and
+hardware. They are not general performance guarantees.
+
+The target node must advertise two time-sliced `nvidia.com/gpu` resources per
+physical GPU and use the NVIDIA device plugin's `packed` allocation policy.
+The final placement must contain the following physical GPU pairs:
+
+| Physical GPU | NIM workloads |
+| --- | --- |
+| 1 | Embed and OCR |
+| 2 | Embed and OCR |
+| 3 | Embed and OCR |
+| 4 | Page elements and table structure |
+
+The final values file cannot select a physical GPU UUID. A single Helm install
+can therefore produce a slower `embed+embed`, `embed+OCR`, and `OCR+OCR`
+placement. Stage the replicas to fill one packed GPU at a time.
+
+Start with one embed and one OCR replica while page elements and table
+structure are disabled:
+
+```bash
+REL=retriever
+NS=nemo-retriever
+PROFILE=./nemo_retriever/helm/examples/values-b200-4gpu-bo767.yaml
+
+helm upgrade --install "${REL}" ./nemo_retriever/helm \
+  -n "${NS}" --create-namespace \
+  -f "${PROFILE}" \
+  --set nimOperator.page_elements.enabled=false \
+  --set nimOperator.table_structure.enabled=false \
+  --set nimOperator.ocr.replicas=1 \
+  --set nimOperator.vlm_embed.replicas=1
+
+kubectl wait -n "${NS}" --for=jsonpath='{.status.state}'=Ready \
+  nimservice/llama-nemotron-embed-vl-1b-v2 nimservice/nemotron-ocr-v2 \
+  --timeout=30m
+```
+
+Add each subsequent embed replica before its matching OCR replica. Wait for
+each Deployment so the packed allocator fills the next physical GPU pair:
+
+```bash
+for REPLICAS in 2 3; do
+  kubectl patch nimservice llama-nemotron-embed-vl-1b-v2 -n "${NS}" \
+    --type merge -p "{\"spec\":{\"replicas\":${REPLICAS}}}"
+  kubectl rollout status deployment/llama-nemotron-embed-vl-1b-v2 \
+    -n "${NS}" --timeout=10m
+
+  kubectl patch nimservice nemotron-ocr-v2 -n "${NS}" \
+    --type merge -p "{\"spec\":{\"replicas\":${REPLICAS}}}"
+  kubectl rollout status deployment/nemotron-ocr-v2 \
+    -n "${NS}" --timeout=10m
+done
+```
+
+Apply the final profile to enable page elements and table structure. Wait for
+the four NIMServices and the retriever service before sending traffic:
+
+```bash
+helm upgrade "${REL}" ./nemo_retriever/helm -n "${NS}" -f "${PROFILE}"
+
+kubectl wait -n "${NS}" --for=jsonpath='{.status.state}'=Ready \
+  nimservice/llama-nemotron-embed-vl-1b-v2 \
+  nimservice/nemotron-ocr-v2 \
+  nimservice/nemotron-page-elements-v3 \
+  nimservice/nemotron-table-structure-v1 \
+  --timeout=30m
+kubectl rollout status deployment/"${REL}"-nemo-retriever \
+  -n "${NS}" --timeout=10m
+```
+
+Verify placement by grouping the visible UUID reported by each runtime NIM
+pod. Continue only when each physical UUID has the expected pair:
+
+```bash
+for POD in $(kubectl get pods -n "${NS}" -o name | grep -E \
+  'llama-nemotron-embed-vl|nemotron-ocr-v2-|nemotron-page-elements-v3-|nemotron-table-structure-v1-' \
+  | grep -v -- '-job-'); do
+  printf '%s ' "${POD}"
+  kubectl exec -n "${NS}" "${POD}" -- \
+    nvidia-smi --query-gpu=uuid --format=csv,noheader
+done | sort -k2,2 -k1,1
+```
+
+This profile targets BO767 PDF ingestion. `service.installFfmpeg` remains
+`false`. Enable FFmpeg separately for audio or video workflows.
 
 ### 1. Service image { #1-service-image }
 

--- a/nemo_retriever/helm/examples/values-b200-4gpu-bo767.yaml
+++ b/nemo_retriever/helm/examples/values-b200-4gpu-bo767.yaml
@@ -1,0 +1,145 @@
+# Measured BO767 throughput profile for four physical NVIDIA B200 GPUs.
+#
+# This profile reproduces the NIM versions and settings tested with the
+# NeMo Retriever 26.08.1 chart. The target node must expose two time-sliced
+# nvidia.com/gpu resources per physical GPU with the device plugin's packed
+# allocation policy. Apply the staged rollout in the chart README to obtain
+# three embed+OCR pairs and one page-elements+table-structure pair.
+
+service:
+  image:
+    repository: nvcr.io/nvidia/nemo-microservices/nrl-service
+    tag: "26.08.1"
+  # BO767 is a PDF workload. Audio and video require FFmpeg.
+  installFfmpeg: false
+
+topology:
+  mode: standalone
+  otel:
+    enabled: false
+
+serviceConfig:
+  vectordb:
+    enabled: true
+    embedModel: nvidia/llama-nemotron-embed-vl-1b-v2
+    indexMode: hybrid
+
+nims:
+  enabled: true
+
+nimOperator:
+  page_elements:
+    enabled: true
+    replicas: 1
+    image:
+      repository: nvcr.io/nim/nvidia/nemotron-object-detection
+      tag: "2.0.1"
+      pullPolicy: IfNotPresent
+      pullSecrets: []
+    env:
+      - name: NIM_SERVER_BIND_ADDR
+        value: "0.0.0.0:8000"
+      - name: NIM_PERFORMANCE_MODE
+        value: "1"
+      - name: NIM_SERVER_MODE
+        value: latency
+      - name: NIM_SERVER_MAX_WAIT_MS
+        value: "0"
+      - name: NIM_ENGINE_COUNT
+        value: "1"
+      - name: NIM_PIPELINE_MAX_BATCH_SIZE
+        value: "8"
+      - name: NIM_ENGINE_MODEL_DOWNLOAD_PROVIDER
+        value: ngc
+      - name: NIM_ENGINE_MODEL_NAME
+        value: nvidia/nemotron-page-elements-v3
+      - name: NIM_ENGINE_MODEL_PATH
+        value: /model-store/page-elements
+
+  table_structure:
+    enabled: true
+    replicas: 1
+    image:
+      repository: nvcr.io/nim/nvidia/nemotron-object-detection
+      tag: "2.0.1"
+      pullPolicy: IfNotPresent
+      pullSecrets: []
+    env:
+      - name: NIM_SERVER_BIND_ADDR
+        value: "0.0.0.0:8000"
+      - name: NIM_PERFORMANCE_MODE
+        value: "1"
+      - name: NIM_SERVER_MODE
+        value: latency
+      - name: NIM_SERVER_MAX_WAIT_MS
+        value: "0"
+      - name: NIM_ENGINE_COUNT
+        value: "1"
+      - name: NIM_PIPELINE_MAX_BATCH_SIZE
+        value: "8"
+      - name: NIM_ENGINE_MODEL_DOWNLOAD_PROVIDER
+        value: ngc
+      - name: NIM_ENGINE_MODEL_NAME
+        value: nvidia/nemotron-table-structure-v1
+      - name: NIM_ENGINE_MODEL_PATH
+        value: /model-store/table-structure
+
+  ocr:
+    enabled: true
+    replicas: 3
+    image:
+      repository: nvcr.io/nim/nvidia/nemotron-ocr-v2
+      tag: "2.0.1"
+      pullPolicy: IfNotPresent
+      pullSecrets: []
+    env:
+      - name: NIM_SERVER_BIND_ADDR
+        value: "0.0.0.0:8000"
+      - name: NIM_PERFORMANCE_MODE
+        value: "1"
+      - name: NIM_SERVER_MODE
+        value: latency
+      - name: NIM_SERVER_MAX_WAIT_MS
+        value: "0"
+      - name: NIM_ENGINE_COUNT
+        value: "1"
+      - name: NIM_PIPELINE_MAX_BATCH_SIZE
+        value: "8"
+      - name: NIM_ENGINE_MODEL_DOWNLOAD_PROVIDER
+        value: ngc
+      - name: NIM_ENGINE_MODEL_NAME
+        value: nvidia/nemotron-ocr-v2
+      - name: NIM_ENGINE_MODEL_PATH
+        value: /model-store/ocr
+      - name: NIM_ENGINE_MODEL_VARIANT
+        value: multilingual
+
+  vlm_embed:
+    enabled: true
+    nimServiceName: llama-nemotron-embed-vl-1b-v2
+    replicas: 3
+    image:
+      repository: nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2
+      tag: "2.3.0"
+      pullPolicy: IfNotPresent
+      pullSecrets: []
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: OMP_NUM_THREADS
+        value: "1"
+      - name: NIM_ENGINE_PRECISION
+        value: fp16
+
+  rerankqa:
+    enabled: false
+  nemotron_parse:
+    enabled: false
+  nemotron_3_nano_omni_30b_a3b_reasoning:
+    enabled: false
+  answer_llm:
+    enabled: false
+  audio:
+    enabled: false

--- a/nemo_retriever/helm/examples/values-b200-4gpu-bo767.yaml
+++ b/nemo_retriever/helm/examples/values-b200-4gpu-bo767.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Measured BO767 throughput profile for four physical NVIDIA B200 GPUs.
 #
 # This profile reproduces the NIM versions and settings tested with the


### PR DESCRIPTION
## Summary

Adds a reproducible Helm values profile for the best-performing four-GPU BO767 configuration measured with NeMo Retriever 26.08.1.

The profile deploys eight NIM replicas across four physical NVIDIA B200 GPUs:

- 3 embedding replicas
- 3 OCR replicas
- 1 page-elements replica
- 1 table-structure replica
- FP16 embedding precision
- Maximum OCR and object-detection pipeline batch size of 8

## Measured results

The configuration processed the complete 54,730-page BO767 workload with:

| Metric | Result |
| --- | ---: |
| Throughput | 92.790 pages/second |
| Recall@5 | 0.860747 |
| Recall@10 | 0.907164 |
| nDCG@10 | 0.755657 |

These measurements are specific to the tested BO767 workload and four-B200 environment and are not intended as general performance guarantees.

## Changes

- Adds `helm/examples/values-b200-4gpu-bo767.yaml`
  - Pins the tested service and NIM image versions.
  - Configures three embed and three OCR replicas.
  - Configures one page-elements and one table-structure replica.
  - Sets `NIM_PIPELINE_MAX_BATCH_SIZE=8` for OCR and object detection.
  - Sets embedding precision to FP16.
  - Disables unused NIMs and OpenTelemetry for the benchmark profile.
- Documents the required staged rollout in the Helm README.
- Documents the expected physical GPU placement and a command for verifying placement by GPU UUID.

## GPU topology

The target Kubernetes node must expose two time-sliced `nvidia.com/gpu` resources per physical GPU and use the NVIDIA device plugin’s `packed` allocation policy.

The expected physical placement is:

| Physical GPU | Workloads |
| --- | --- |
| GPU 1 | Embed + OCR |
| GPU 2 | Embed + OCR |
| GPU 3 | Embed + OCR |
| GPU 4 | Page elements + table structure |

Because Helm values cannot select individual physical GPU UUIDs, the README uses a staged rollout to produce this placement consistently.

## Validation

- `helm lint` passes.
- The chart renders successfully when the NIM Operator API is declared:


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
